### PR TITLE
CI: Reduce noise of clippy lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,44 +55,6 @@ jobs:
       - name: Test Orchard book
         run: mdbook test book/
 
-  clippy:
-    name: Clippy (1.51.0)
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.51.0
-          components: clippy
-          override: true
-      - name: Run clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          name: Clippy (1.51.0)
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets -- -D warnings
-
-  clippy-nightly:
-    name: Clippy (nightly)
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          components: clippy
-          override: true
-      - name: Run Clippy (nightly)
-        uses: actions-rs/clippy-check@v1
-        continue-on-error: true
-        with:
-          name: Clippy (nightly)
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets
-
   codecov:
     name: Code coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/lints-nightly.yml
+++ b/.github/workflows/lints-nightly.yml
@@ -1,0 +1,27 @@
+name: Nightly lints
+
+# These lints are only informative, so we only run them directly on branches
+# and not trial-merges of PRs, to reduce noise.
+on: push
+
+jobs:
+  clippy-nightly:
+    name: Clippy (nightly)
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: clippy
+          override: true
+      - name: Run Clippy (nightly)
+        uses: actions-rs/clippy-check@v1
+        continue-on-error: true
+        with:
+          name: Clippy (nightly)
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features --all-targets
+

--- a/.github/workflows/lints-stable.yml
+++ b/.github/workflows/lints-stable.yml
@@ -1,0 +1,23 @@
+name: Stable lints
+
+# We only run these lints on trial-merges of PRs to reduce noise.
+on: pull_request
+
+jobs:
+  clippy:
+    name: Clippy (1.51.0)
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.51.0
+          components: clippy
+          override: true
+      - name: Run Clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          name: Clippy (1.51.0)
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features --all-targets -- -D warnings


### PR DESCRIPTION
We move Clippy lints into separate workflows that only run either directly on branches, or on trial-merges of PRs, to deduplicate the lint annotations. We will still see stable lints duplicated in nightly, but that's fine.