### PR TITLE
Remove rand 0.7 usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ fpe = "0.4"
 group = "0.9"
 proptest = { version = "1.0.0", optional = true }
 rand = "0.8"
-rand_7 = { package = "rand", version = "0.7" }
 nonempty = "0.6"
 subtle = "2.3"
 
@@ -41,7 +40,7 @@ rev = "b55a6960dfafd7f767e2820ddf1adaa499322f98"
 
 [dependencies.reddsa]
 git = "https://github.com/str4d/redjubjub.git"
-rev = "f1e76dbc9abf2b68cc609e874fe39f2a15b75b12"
+rev = "daab5355bf8e85289aa37804656bf85182df9eea"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -355,7 +355,7 @@ pub struct BundleAuthorizingCommitment;
 #[cfg(any(test, feature = "test-dependencies"))]
 pub mod testing {
     use nonempty::NonEmpty;
-    use rand_7::{rngs::StdRng, SeedableRng};
+    use rand::{rngs::StdRng, SeedableRng};
     use reddsa::orchard::SpendAuth;
 
     use proptest::collection::vec;

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -8,7 +8,7 @@ use fpe::ff1::{BinaryNumeralString, FF1};
 use group::GroupEncoding;
 use halo2::arithmetic::FieldExt;
 use pasta_curves::pallas;
-use rand::RngCore;
+use rand::{CryptoRng, RngCore};
 use subtle::CtOption;
 
 use crate::{
@@ -77,7 +77,7 @@ impl SpendAuthorizingKey {
     }
 
     /// Creates a spend authorization signature over the given message.
-    pub fn sign<R: rand_7::RngCore + rand_7::CryptoRng>(
+    pub fn sign<R: RngCore + CryptoRng>(
         &self,
         rng: R,
         msg: &[u8],

--- a/src/primitives/redpallas.rs
+++ b/src/primitives/redpallas.rs
@@ -3,7 +3,7 @@
 use std::convert::{TryFrom, TryInto};
 
 use pasta_curves::pallas;
-use rand_7::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 
 /// A RedPallas signature type.
 pub trait SigType: reddsa::SigType + private::Sealed {}


### PR DESCRIPTION
Upstream `redjubjub` (on which our `reddsa` dependency is based) has migrated to `rand 0.8`.