### PR TITLE
Update implementation to match protocol spec version 2021.2.0

### DIFF
--- a/book/src/design/commitments.md
+++ b/book/src/design/commitments.md
@@ -23,6 +23,15 @@ $$\mathsf{cm} = \mathit{Commit}^{\mathsf{cm}}_{\mathsf{rcm}}(\text{rest of note}
 This is the same split (and rationale) as in Sapling, but using the more PLONK-efficient
 Sinsemilla instead of Bowe--Hopwood Pedersen hashes.
 
-Note that we also deviate from Sapling by using $\mathit{ShortCommit}$ to deriving $\mathsf{ivk}$
-instead of a full PRF. This removes an unnecessary (large) PRF primitive from the circuit,
-at the cost of requiring $\mathsf{rivk}$ to be part of the full viewing key.
+Note that for $\mathsf{ivk}$, we also deviate from Sapling in two ways:
+
+- We use $\mathit{ShortCommit}$ to derive $\mathsf{ivk}$ instead of a full PRF. This removes an
+  unnecessary (large) PRF primitive from the circuit, at the cost of requiring $\mathsf{rivk}$ to be
+  part of the full viewing key.
+- We define $\mathsf{ivk}$ as an integer in $[1, q_P)$; that is, we exclude $\mathsf{ivk} = 0$. For
+  Sapling, we relied on BLAKE2s to make $\mathsf{ivk} = 0$ infeasible to produce, but it was still
+  technically possible. For Orchard, we get this by construction:
+  - $0$ is not a valid x-coordinate for any Pallas point.
+  - $\mathit{ShortCommit}$ internally maps points to field elements by replacing the identity (which
+    has no affine coordinates) with $0$. But Sinsemilla is defined using incomplete addition, and
+    thus will never produce the identity.

--- a/book/src/design/commitments.md
+++ b/book/src/design/commitments.md
@@ -32,6 +32,6 @@ Note that for $\mathsf{ivk}$, we also deviate from Sapling in two ways:
   Sapling, we relied on BLAKE2s to make $\mathsf{ivk} = 0$ infeasible to produce, but it was still
   technically possible. For Orchard, we get this by construction:
   - $0$ is not a valid x-coordinate for any Pallas point.
-  - $\mathit{ShortCommit}$ internally maps points to field elements by replacing the identity (which
-    has no affine coordinates) with $0$. But Sinsemilla is defined using incomplete addition, and
+  - $\mathsf{SinsemillaShortCommit}$ internally maps points to field elements by replacing the identity (which
+    has no affine coordinates) with $0$. But $\mathsf{SinsemillaCommit}$ is defined using incomplete addition, and
     thus will never produce the identity.

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,8 +1,6 @@
-use pasta_curves::pallas;
-
 use crate::{
     keys::{DiversifiedTransmissionKey, Diversifier},
-    spec::diversify_hash,
+    spec::{diversify_hash, NonIdentityPallasPoint},
 };
 
 /// A shielded payment address.
@@ -30,7 +28,7 @@ impl Address {
         Address { d, pk_d }
     }
 
-    pub(crate) fn g_d(&self) -> pallas::Point {
+    pub(crate) fn g_d(&self) -> NonIdentityPallasPoint {
         diversify_hash(self.d.as_array())
     }
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -13,7 +13,7 @@ use crate::{
 /// let sk = SpendingKey::from_bytes([7; 32]).unwrap();
 /// let address = FullViewingKey::from(&sk).default_address();
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Address {
     d: Diversifier,
     pk_d: DiversifiedTransmissionKey,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -328,7 +328,7 @@ impl From<&FullViewingKey> for KeyAgreementPrivateKey {
 }
 
 impl KeyAgreementPrivateKey {
-    /// Derives ask from sk. Internal use only, does not enforce all constraints.
+    /// Derives ivk from fvk. Internal use only, does not enforce all constraints.
     fn derive_inner(fvk: &FullViewingKey) -> CtOption<NonZeroPallasBase> {
         let ak = extract_p(&pallas::Point::from_bytes(&(&fvk.ak.0).into()).unwrap());
         commit_ivk(&ak, &fvk.nk.0, &fvk.rivk.0)

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -288,7 +288,7 @@ impl DiversifierKey {
 /// Defined in [Zcash Protocol Spec § 4.2.3: Orchard Key Components][orchardkeycomponents].
 ///
 /// [orchardkeycomponents]: https://zips.z.cash/protocol/nu5.pdf#orchardkeycomponents
-#[derive(Debug, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Diversifier([u8; 11]);
 
 impl Diversifier {
@@ -408,7 +408,7 @@ impl From<&FullViewingKey> for OutgoingViewingKey {
 /// Defined in [Zcash Protocol Spec § 4.2.3: Orchard Key Components][orchardkeycomponents].
 ///
 /// [orchardkeycomponents]: https://zips.z.cash/protocol/nu5.pdf#orchardkeycomponents
-#[derive(Debug, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub(crate) struct DiversifiedTransmissionKey(NonIdentityPallasPoint);
 
 impl DiversifiedTransmissionKey {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -16,7 +16,7 @@ use crate::{
     primitives::redpallas::{self, SpendAuth},
     spec::{
         commit_ivk, diversify_hash, extract_p, ka_orchard, prf_expand, prf_expand_vec, prf_nf,
-        to_base, to_scalar, NonZeroPallasBase, NonZeroPallasScalar,
+        to_base, to_scalar, NonIdentityPallasPoint, NonZeroPallasBase, NonZeroPallasScalar,
     },
 };
 
@@ -363,7 +363,7 @@ impl From<&FullViewingKey> for OutgoingViewingKey {
 ///
 /// [orchardkeycomponents]: https://zips.z.cash/protocol/nu5.pdf#orchardkeycomponents
 #[derive(Debug, Clone)]
-pub(crate) struct DiversifiedTransmissionKey(pallas::Point);
+pub(crate) struct DiversifiedTransmissionKey(NonIdentityPallasPoint);
 
 impl DiversifiedTransmissionKey {
     /// Defined in [Zcash Protocol Spec § 4.2.3: Orchard Key Components][orchardkeycomponents].

--- a/src/note/commitment.rs
+++ b/src/note/commitment.rs
@@ -5,22 +5,9 @@ use ff::PrimeField;
 use pasta_curves::{arithmetic::FieldExt, pallas};
 use subtle::CtOption;
 
-use crate::{
-    constants::L_ORCHARD_BASE,
-    primitives::sinsemilla,
-    spec::{extract_p, prf_expand, to_scalar},
-    value::NoteValue,
-};
+use crate::{constants::L_ORCHARD_BASE, primitives::sinsemilla, spec::extract_p, value::NoteValue};
 
-use super::RandomSeed;
-
-pub(super) struct NoteCommitTrapdoor(pallas::Scalar);
-
-impl From<&RandomSeed> for NoteCommitTrapdoor {
-    fn from(rseed: &RandomSeed) -> Self {
-        NoteCommitTrapdoor(to_scalar(prf_expand(&rseed.0, &[0x05])))
-    }
-}
+pub(super) struct NoteCommitTrapdoor(pub(super) pallas::Scalar);
 
 /// A commitment to a note.
 #[derive(Debug)]

--- a/src/note/nullifier.rs
+++ b/src/note/nullifier.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// A unique nullifier for a note.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Nullifier(pub(crate) pallas::Base);
 
 impl Nullifier {

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -134,6 +134,7 @@ pub(crate) fn diversify_hash(d: &[u8; 11]) -> NonIdentityPallasPoint {
     let hasher = pallas::Point::hash_to_curve("z.cash:Orchard-gd");
     let pk_d = hasher(d);
     // If the identity occurs, we replace it with a different fixed point.
+    // TODO: Replace the unwrap_or_else with a cached fixed point.
     NonIdentityPallasPoint(CtOption::new(pk_d, !pk_d.is_identity()).unwrap_or_else(|| hasher(&[])))
 }
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -18,7 +18,7 @@ use crate::{
 const PRF_EXPAND_PERSONALIZATION: &[u8; 16] = b"Zcash_ExpandSeed";
 
 /// A Pallas point that is guaranteed to not be the identity.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub(crate) struct NonIdentityPallasPoint(pallas::Point);
 
 impl Deref for NonIdentityPallasPoint {

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1,9 +1,10 @@
 //! Helper functions defined in the Zcash Protocol Specification.
 
 use std::iter;
+use std::ops::Deref;
 
 use blake2b_simd::Params;
-use ff::PrimeField;
+use ff::{Field, PrimeField};
 use group::{Curve, Group};
 use halo2::arithmetic::{CurveAffine, CurveExt, FieldExt};
 use pasta_curves::pallas;
@@ -15,6 +16,51 @@ use crate::{
 };
 
 const PRF_EXPAND_PERSONALIZATION: &[u8; 16] = b"Zcash_ExpandSeed";
+
+/// An integer in [1..q_P].
+pub(crate) struct NonZeroPallasBase(pallas::Base);
+
+impl NonZeroPallasBase {
+    /// Constructs a wrapper for a base field element that is guaranteed to be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `s.is_zero()`.
+    fn guaranteed(s: pallas::Base) -> Self {
+        assert!(!s.is_zero());
+        NonZeroPallasBase(s)
+    }
+}
+
+/// An integer in [1..r_P].
+#[derive(Debug)]
+pub(crate) struct NonZeroPallasScalar(pallas::Scalar);
+
+impl From<NonZeroPallasBase> for NonZeroPallasScalar {
+    fn from(s: NonZeroPallasBase) -> Self {
+        NonZeroPallasScalar::guaranteed(mod_r_p(s.0))
+    }
+}
+
+impl NonZeroPallasScalar {
+    /// Constructs a wrapper for a scalar field element that is guaranteed to be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `s.is_zero()`.
+    fn guaranteed(s: pallas::Scalar) -> Self {
+        assert!(!s.is_zero());
+        NonZeroPallasScalar(s)
+    }
+}
+
+impl Deref for NonZeroPallasScalar {
+    type Target = pallas::Scalar;
+
+    fn deref(&self) -> &pallas::Scalar {
+        &self.0
+    }
+}
 
 /// $\mathsf{ToBase}^\mathsf{Orchard}(x) := LEOS2IP_{\ell_\mathsf{PRFexpand}}(x) (mod q_P)$
 ///
@@ -49,7 +95,7 @@ pub(crate) fn commit_ivk(
     ak: &pallas::Base,
     nk: &pallas::Base,
     rivk: &pallas::Scalar,
-) -> CtOption<pallas::Scalar> {
+) -> CtOption<NonZeroPallasBase> {
     // We rely on the API contract that to_le_bits() returns at least PrimeField::NUM_BITS
     // bits, which is equal to L_ORCHARD_BASE.
     let domain = sinsemilla::CommitDomain::new(&"z.cash:Orchard-CommitIvk");
@@ -60,7 +106,13 @@ pub(crate) fn commit_ivk(
                 .chain(nk.to_le_bits().iter().by_val().take(L_ORCHARD_BASE)),
             rivk,
         )
-        .map(mod_r_p)
+        // Commit^ivk.Output is specified as [1..q_P] ∪ {⊥}. We get this from
+        // sinsemilla::CommitDomain::short_commit by construction:
+        // - 0 is not a valid x-coordinate for any Pallas point.
+        // - sinsemilla::CommitDomain::short_commit calls extract_p_bottom, which replaces
+        //   the identity (which has no affine coordinates) with 0. but Sinsemilla is
+        //   defined using incomplete addition, and thus will never produce the identity.
+        .map(NonZeroPallasBase::guaranteed)
 }
 
 /// Defined in [Zcash Protocol Spec § 5.4.1.6: DiversifyHash^Sapling and DiversifyHash^Orchard Hash Functions][concretediversifyhash].


### PR DESCRIPTION
The implementation was previously (supposed to be) implementing version 2021.1.20 of the protocol spec.

Closes #79.