### PR TITLE
builder: Store alpha and use it to derive rsk for signing spends

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -613,12 +613,12 @@ mod tests {
         builder
             .add_recipient(None, recipient, NoteValue::from_raw(5000), None)
             .unwrap();
-        let bundle: Bundle<Authorized, i64> = dbg!(builder
+        let bundle: Bundle<Authorized, i64> = builder
             .build(&mut rng, &pk)
             .unwrap()
-            .prepare(&mut rng, [0; 32]))
-        .finalize()
-        .unwrap();
+            .prepare(&mut rng, [0; 32])
+            .finalize()
+            .unwrap();
         assert_eq!(bundle.value_balance(), &(-5000))
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -8,7 +8,7 @@ use fpe::ff1::{BinaryNumeralString, FF1};
 use group::GroupEncoding;
 use halo2::arithmetic::FieldExt;
 use pasta_curves::pallas;
-use rand::{CryptoRng, RngCore};
+use rand::RngCore;
 use subtle::CtOption;
 
 use crate::{
@@ -76,13 +76,11 @@ impl SpendAuthorizingKey {
         to_scalar(PrfExpand::OrchardAsk.expand(&sk.0))
     }
 
-    /// Creates a spend authorization signature over the given message.
-    pub fn sign<R: RngCore + CryptoRng>(
-        &self,
-        rng: R,
-        msg: &[u8],
-    ) -> redpallas::Signature<SpendAuth> {
-        self.0.sign(rng, msg)
+    /// Randomizes this spend authorizing key with the given `randomizer`.
+    ///
+    /// The resulting key can be used to actually sign a spend.
+    pub fn randomize(&self, randomizer: &pallas::Scalar) -> redpallas::SigningKey<SpendAuth> {
+        self.0.randomize(randomizer)
     }
 }
 

--- a/src/primitives/redpallas.rs
+++ b/src/primitives/redpallas.rs
@@ -40,6 +40,15 @@ impl<T: SigType> TryFrom<[u8; 32]> for SigningKey<T> {
     }
 }
 
+impl SigningKey<SpendAuth> {
+    /// Randomizes this signing key with the given `randomizer`.
+    ///
+    /// Randomization is only supported for `SpendAuth` keys.
+    pub fn randomize(&self, randomizer: &pallas::Scalar) -> Self {
+        SigningKey(self.0.randomize(randomizer))
+    }
+}
+
 impl<T: SigType> SigningKey<T> {
     /// Creates a signature of type `T` on `msg` using this `SigningKey`.
     pub fn sign<R: RngCore + CryptoRng>(&self, rng: R, msg: &[u8]) -> Signature<T> {


### PR DESCRIPTION
This was missed from zcash/orchard#49, but could not have caused a consensus failure, loss-of-funds, or privacy violation because `alpha` _was_ being sampled and used to derive `rk`, meaning that the signatures would fail to validate.

Closes zcash/orchard#102.