### PR TITLE
`constants::load.rs`: Use concrete `pallas::Affine` type for generators

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,9 +2,10 @@
 use arrayvec::ArrayVec;
 use ff::{Field, PrimeField};
 use group::Curve;
-use halo2::{
-    arithmetic::{lagrange_interpolate, CurveAffine, FieldExt},
-    pasta::pallas,
+use halo2::arithmetic::lagrange_interpolate;
+use pasta_curves::{
+    arithmetic::{CurveAffine, FieldExt},
+    pallas,
 };
 
 pub mod commit_ivk_r;

--- a/src/constants/commit_ivk_r.rs
+++ b/src/constants/commit_ivk_r.rs
@@ -1,4 +1,7 @@
-use halo2::arithmetic::{CurveAffine, FieldExt};
+use pasta_curves::{
+    arithmetic::{CurveAffine, FieldExt},
+    pallas,
+};
 
 /// Generator used in SinsemillaCommit randomness for IVK commitment
 pub const GENERATOR: ([u8; 32], [u8; 32]) = (
@@ -2917,10 +2920,10 @@ pub const U: [[[u8; 32]; super::H]; super::NUM_WINDOWS] = [
     ],
 ];
 
-pub fn generator<C: CurveAffine>() -> C {
-    C::from_xy(
-        C::Base::from_bytes(&GENERATOR.0).unwrap(),
-        C::Base::from_bytes(&GENERATOR.1).unwrap(),
+pub fn generator() -> pallas::Affine {
+    pallas::Affine::from_xy(
+        pallas::Base::from_bytes(&GENERATOR.0).unwrap(),
+        pallas::Base::from_bytes(&GENERATOR.1).unwrap(),
     )
     .unwrap()
 }
@@ -2933,9 +2936,9 @@ mod tests {
     use super::*;
     use crate::primitives::sinsemilla::CommitDomain;
     use group::Curve;
-    use halo2::{
+    use pasta_curves::{
         arithmetic::{CurveAffine, FieldExt},
-        pasta::pallas,
+        pallas,
     };
 
     #[test]
@@ -2950,13 +2953,13 @@ mod tests {
 
     #[test]
     fn lagrange_coeffs() {
-        let base = super::generator::<pallas::Affine>();
+        let base = super::generator();
         test_lagrange_coeffs(base, NUM_WINDOWS);
     }
 
     #[test]
     fn z() {
-        let base = super::generator::<pallas::Affine>();
+        let base = super::generator();
         test_zs_and_us(base, &Z, &U, NUM_WINDOWS);
     }
 }

--- a/src/constants/note_commit_r.rs
+++ b/src/constants/note_commit_r.rs
@@ -1,4 +1,7 @@
-use halo2::arithmetic::{CurveAffine, FieldExt};
+use pasta_curves::{
+    arithmetic::{CurveAffine, FieldExt},
+    pallas,
+};
 
 /// Generator used in SinsemillaCommit randomness for note commitment
 pub const GENERATOR: ([u8; 32], [u8; 32]) = (
@@ -2917,10 +2920,10 @@ pub const U: [[[u8; 32]; super::H]; super::NUM_WINDOWS] = [
     ],
 ];
 
-pub fn generator<C: CurveAffine>() -> C {
-    C::from_xy(
-        C::Base::from_bytes(&GENERATOR.0).unwrap(),
-        C::Base::from_bytes(&GENERATOR.1).unwrap(),
+pub fn generator() -> pallas::Affine {
+    pallas::Affine::from_xy(
+        pallas::Base::from_bytes(&GENERATOR.0).unwrap(),
+        pallas::Base::from_bytes(&GENERATOR.1).unwrap(),
     )
     .unwrap()
 }
@@ -2933,9 +2936,9 @@ mod tests {
     use super::*;
     use crate::primitives::sinsemilla::CommitDomain;
     use group::Curve;
-    use halo2::{
+    use pasta_curves::{
         arithmetic::{CurveAffine, FieldExt},
-        pasta::pallas,
+        pallas,
     };
 
     #[test]
@@ -2950,13 +2953,13 @@ mod tests {
 
     #[test]
     fn lagrange_coeffs() {
-        let base = super::generator::<pallas::Affine>();
+        let base = super::generator();
         test_lagrange_coeffs(base, NUM_WINDOWS);
     }
 
     #[test]
     fn z() {
-        let base = super::generator::<pallas::Affine>();
+        let base = super::generator();
         test_zs_and_us(base, &Z, &U, NUM_WINDOWS);
     }
 }

--- a/src/constants/nullifier_k.rs
+++ b/src/constants/nullifier_k.rs
@@ -1,4 +1,7 @@
-use halo2::arithmetic::{CurveAffine, FieldExt};
+use pasta_curves::{
+    arithmetic::{CurveAffine, FieldExt},
+    pallas,
+};
 
 pub const GENERATOR: ([u8; 32], [u8; 32]) = (
     [
@@ -2916,10 +2919,10 @@ pub const U: [[[u8; 32]; super::H]; super::NUM_WINDOWS] = [
     ],
 ];
 
-pub fn generator<C: CurveAffine>() -> C {
-    C::from_xy(
-        C::Base::from_bytes(&GENERATOR.0).unwrap(),
-        C::Base::from_bytes(&GENERATOR.1).unwrap(),
+pub fn generator() -> pallas::Affine {
+    pallas::Affine::from_xy(
+        pallas::Base::from_bytes(&GENERATOR.0).unwrap(),
+        pallas::Base::from_bytes(&GENERATOR.1).unwrap(),
     )
     .unwrap()
 }
@@ -2931,9 +2934,9 @@ mod tests {
     };
     use super::*;
     use group::Curve;
-    use halo2::{
-        arithmetic::{CurveAffine, CurveExt, FieldExt},
-        pasta::pallas,
+    use pasta_curves::{
+        arithmetic::{CurveExt, FieldExt},
+        pallas,
     };
 
     #[test]
@@ -2948,13 +2951,13 @@ mod tests {
 
     #[test]
     fn lagrange_coeffs() {
-        let base = super::generator::<pallas::Affine>();
+        let base = super::generator();
         test_lagrange_coeffs(base, NUM_WINDOWS);
     }
 
     #[test]
     fn z() {
-        let base = super::generator::<pallas::Affine>();
+        let base = super::generator();
         test_zs_and_us(base, &Z, &U, NUM_WINDOWS);
     }
 }

--- a/src/constants/spend_auth_g.rs
+++ b/src/constants/spend_auth_g.rs
@@ -1,4 +1,7 @@
-use halo2::arithmetic::{CurveAffine, FieldExt};
+use pasta_curves::{
+    arithmetic::{CurveAffine, FieldExt},
+    pallas,
+};
 
 /// The value commitment is used to check balance between inputs and outputs. The value is
 /// placed over this generator.
@@ -2918,10 +2921,10 @@ pub const U: [[[u8; 32]; super::H]; super::NUM_WINDOWS] = [
     ],
 ];
 
-pub fn generator<C: CurveAffine>() -> C {
-    C::from_xy(
-        C::Base::from_bytes(&GENERATOR.0).unwrap(),
-        C::Base::from_bytes(&GENERATOR.1).unwrap(),
+pub fn generator() -> pallas::Affine {
+    pallas::Affine::from_xy(
+        pallas::Base::from_bytes(&GENERATOR.0).unwrap(),
+        pallas::Base::from_bytes(&GENERATOR.1).unwrap(),
     )
     .unwrap()
 }
@@ -2933,9 +2936,9 @@ mod tests {
     };
     use super::*;
     use group::Curve;
-    use halo2::{
+    use pasta_curves::{
         arithmetic::{CurveAffine, CurveExt, FieldExt},
-        pasta::pallas,
+        pallas,
     };
 
     #[test]
@@ -2950,13 +2953,13 @@ mod tests {
 
     #[test]
     fn lagrange_coeffs() {
-        let base = super::generator::<pallas::Affine>();
+        let base = super::generator();
         test_lagrange_coeffs(base, NUM_WINDOWS);
     }
 
     #[test]
     fn z() {
-        let base = super::generator::<pallas::Affine>();
+        let base = super::generator();
         test_zs_and_us(base, &Z, &U, NUM_WINDOWS);
     }
 }

--- a/src/constants/value_commit_r.rs
+++ b/src/constants/value_commit_r.rs
@@ -1,4 +1,7 @@
-use halo2::arithmetic::{CurveAffine, FieldExt};
+use pasta_curves::{
+    arithmetic::{CurveAffine, FieldExt},
+    pallas,
+};
 
 /// The value commitment is used to check balance between inputs and outputs. The value is
 /// placed over this generator.
@@ -2918,10 +2921,10 @@ pub const U: [[[u8; 32]; super::H]; super::NUM_WINDOWS] = [
     ],
 ];
 
-pub fn generator<C: CurveAffine>() -> C {
-    C::from_xy(
-        C::Base::from_bytes(&GENERATOR.0).unwrap(),
-        C::Base::from_bytes(&GENERATOR.1).unwrap(),
+pub fn generator() -> pallas::Affine {
+    pallas::Affine::from_xy(
+        pallas::Base::from_bytes(&GENERATOR.0).unwrap(),
+        pallas::Base::from_bytes(&GENERATOR.1).unwrap(),
     )
     .unwrap()
 }
@@ -2933,9 +2936,9 @@ mod tests {
     };
     use super::*;
     use group::Curve;
-    use halo2::{
+    use pasta_curves::{
         arithmetic::{CurveAffine, CurveExt, FieldExt},
-        pasta::pallas,
+        pallas,
     };
 
     #[test]
@@ -2950,13 +2953,13 @@ mod tests {
 
     #[test]
     fn lagrange_coeffs() {
-        let base = super::generator::<pallas::Affine>();
+        let base = super::generator();
         test_lagrange_coeffs(base, NUM_WINDOWS);
     }
 
     #[test]
     fn z() {
-        let base = super::generator::<pallas::Affine>();
+        let base = super::generator();
         test_zs_and_us(base, &Z, &U, NUM_WINDOWS);
     }
 }

--- a/src/constants/value_commit_v.rs
+++ b/src/constants/value_commit_v.rs
@@ -1,4 +1,7 @@
-use halo2::arithmetic::{CurveAffine, FieldExt};
+use pasta_curves::{
+    arithmetic::{CurveAffine, FieldExt},
+    pallas,
+};
 
 /// The value commitment is used to check balance between inputs and outputs. The value is
 /// placed over this generator.
@@ -771,10 +774,10 @@ pub const U_SHORT: [[[u8; 32]; super::H]; super::NUM_WINDOWS_SHORT] = [
     ],
 ];
 
-pub fn generator<C: CurveAffine>() -> C {
-    C::from_xy(
-        C::Base::from_bytes(&GENERATOR.0).unwrap(),
-        C::Base::from_bytes(&GENERATOR.1).unwrap(),
+pub fn generator() -> pallas::Affine {
+    pallas::Affine::from_xy(
+        pallas::Base::from_bytes(&GENERATOR.0).unwrap(),
+        pallas::Base::from_bytes(&GENERATOR.1).unwrap(),
     )
     .unwrap()
 }
@@ -786,9 +789,9 @@ mod tests {
     };
     use super::*;
     use group::Curve;
-    use halo2::{
+    use pasta_curves::{
         arithmetic::{CurveAffine, CurveExt, FieldExt},
-        pasta::pallas,
+        pallas,
     };
 
     #[test]
@@ -803,13 +806,13 @@ mod tests {
 
     #[test]
     fn lagrange_coeffs_short() {
-        let base = super::generator::<pallas::Affine>();
+        let base = super::generator();
         test_lagrange_coeffs(base, NUM_WINDOWS_SHORT);
     }
 
     #[test]
     fn z_short() {
-        let base = super::generator::<pallas::Affine>();
+        let base = super::generator();
         test_zs_and_us(base, &Z_SHORT, &U_SHORT, NUM_WINDOWS_SHORT);
     }
 }


### PR DESCRIPTION
The Orchard fixed bases are Pallas curve points and are not generic over other curves.