### PR TITLE
Store anchors as pallas::Base instead of [u8; 32]

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -594,6 +594,7 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
+    use pasta_curves::pallas;
     use rand::rngs::OsRng;
 
     use super::Builder;
@@ -601,7 +602,6 @@ mod tests {
         bundle::{Authorized, Bundle, Flags},
         circuit::ProvingKey,
         keys::{FullViewingKey, SpendingKey},
-        tree::Anchor,
         value::NoteValue,
     };
 
@@ -614,7 +614,7 @@ mod tests {
         let fvk = FullViewingKey::from(&sk);
         let recipient = fvk.default_address();
 
-        let mut builder = Builder::new(Flags::from_parts(true, true), Anchor([0; 32]));
+        let mut builder = Builder::new(Flags::from_parts(true, true), pallas::Base::zero().into());
         builder
             .add_recipient(None, recipient, NoteValue::from_raw(5000), None)
             .unwrap();

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -355,6 +355,7 @@ pub struct BundleAuthorizingCommitment;
 #[cfg(any(test, feature = "test-dependencies"))]
 pub mod testing {
     use nonempty::NonEmpty;
+    use pasta_curves::{arithmetic::FieldExt, pallas};
     use rand::{rngs::StdRng, SeedableRng};
     use reddsa::orchard::SpendAuth;
 
@@ -512,6 +513,15 @@ pub mod testing {
     }
 
     prop_compose! {
+        fn arb_base()(bytes in prop::array::uniform32(0u8..)) -> pallas::Base {
+            // Instead of rejecting out-of-range bytes, let's reduce them.
+            let mut buf = [0; 64];
+            buf[..32].copy_from_slice(&bytes);
+            pallas::Base::from_bytes_wide(&buf)
+        }
+    }
+
+    prop_compose! {
         /// Generate an arbitrary unauthorized bundle. This bundle does not
         /// necessarily respect consensus rules; for that use
         /// [`crate::builder::testing::arb_bundle`]
@@ -522,7 +532,7 @@ pub mod testing {
         )
         (
             acts in vec(arb_unauthorized_action_n(n_actions, flags), n_actions),
-            anchor in prop::array::uniform32(prop::num::u8::ANY).prop_map(Anchor),
+            anchor in arb_base().prop_map(Anchor::from),
             flags in Just(flags)
         ) -> Bundle<Unauthorized, ValueSum> {
             let (balances, actions): (Vec<ValueSum>, Vec<Action<_>>) = acts.into_iter().unzip();
@@ -548,7 +558,7 @@ pub mod testing {
         )
         (
             acts in vec(arb_action_n(n_actions, flags), n_actions),
-            anchor in prop::array::uniform32(prop::num::u8::ANY).prop_map(Anchor),
+            anchor in arb_base().prop_map(Anchor::from),
             sk in arb_binding_signing_key(),
             rng_seed in prop::array::uniform32(prop::num::u8::ANY),
             fake_proof in vec(prop::num::u8::ANY, 1973),

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -182,7 +182,6 @@ mod tests {
     use crate::{
         keys::SpendValidatingKey,
         note::Note,
-        tree::Anchor,
         value::{ValueCommitTrapdoor, ValueCommitment},
     };
 
@@ -208,7 +207,7 @@ mod tests {
                 (
                     Circuit {},
                     Instance {
-                        anchor: Anchor([0; 32]),
+                        anchor: pallas::Base::zero().into(),
                         cv_net,
                         nf_old,
                         rk,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -5,7 +5,7 @@ use crate::{
     note::commitment::ExtractedNoteCommitment,
     primitives::sinsemilla::{i2lebsp_k, HashDomain},
 };
-use pasta_curves::{arithmetic::FieldExt, pallas};
+use pasta_curves::pallas;
 
 use ff::{Field, PrimeFieldBits};
 use rand::RngCore;
@@ -13,11 +13,11 @@ use std::iter;
 
 /// The root of an Orchard commitment tree.
 #[derive(Eq, PartialEq, Clone, Debug)]
-pub struct Anchor(pub [u8; 32]);
+pub struct Anchor(pallas::Base);
 
 impl From<pallas::Base> for Anchor {
     fn from(anchor_field: pallas::Base) -> Anchor {
-        Anchor(anchor_field.to_bytes())
+        Anchor(anchor_field)
     }
 }
 
@@ -53,7 +53,7 @@ impl MerklePath {
                 let swap = self.position & (1 << l_star) != 0;
                 hash_layer(l_star, cond_swap(swap, node, *sibling))
             });
-        Anchor(node.to_bytes())
+        Anchor(node)
     }
 
     /// Returns the position of the leaf using this Merkle path.


### PR DESCRIPTION
This matches what we store in `MerklePath`, and better enforces the required type.