### PR TITLE
Use patches for halo2 and zcash_note_encryption dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,27 +26,21 @@ blake2b_simd = "0.5"
 ff = "0.10"
 fpe = "0.4"
 group = "0.10"
+halo2 = "0.0"
 lazy_static = "1"
 pasta_curves = "0.1"
 proptest = { version = "1.0.0", optional = true }
 rand = "0.8"
 nonempty = "0.6"
 subtle = "2.3"
+zcash_note_encryption = "0.0"
 
 # Developer tooling dependencies
 plotters = { version = "0.3.0", optional = true }
 
-[dependencies.halo2]
-git = "https://github.com/zcash/halo2.git"
-rev = "d04b532368d05b505e622f8cac4c0693574fbd93"
-
 [dependencies.reddsa]
 git = "https://github.com/str4d/redjubjub.git"
 rev = "d5d8c5f3bb704bad8ae88fe4a29ae1f744774cb2"
-
-[dependencies.zcash_note_encryption]
-git = "https://github.com/zcash/librustzcash.git"
-rev = "cc533a9da4f6a7209a7be05f82b12a03969152c9"
 
 [dev-dependencies]
 criterion = "0.3"
@@ -63,3 +57,7 @@ test-dependencies = ["proptest"]
 [[bench]]
 name = "small"
 harness = false
+
+[patch.crates-io]
+halo2 = { git = "https://github.com/zcash/halo2.git", rev = "d04b532368d05b505e622f8cac4c0693574fbd93" }
+zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "cc533a9da4f6a7209a7be05f82b12a03969152c9" }


### PR DESCRIPTION
While these two are in flux, it's hard to keep these revisions consistent
(e.g. https://github.com/zcash/zcash/pull/5217 currently depends on two
different versions of zcash_note_encryption). Using patches allows the
downstream users (i.e. zcashd) to define its own set of patches, and keep
everything in sync. This works fine now because we aren't actively making
changes to the public APIs, only additions.