### PR TITLE
Fix clippy lints

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -322,7 +322,7 @@ impl Builder {
         // Create the proof.
         let instances: Vec<_> = actions
             .iter()
-            .map(|a| a.to_instance(flags, anchor.clone()))
+            .map(|a| a.to_instance(flags, anchor))
             .collect();
         let proof = Proof::create(pk, &circuits, &instances)?;
 

--- a/src/note/commitment.rs
+++ b/src/note/commitment.rs
@@ -53,7 +53,7 @@ impl ExtractedNoteCommitment {
     }
 
     /// Serialize the value commitment to its canonical byte representation.
-    pub fn to_bytes(&self) -> [u8; 32] {
+    pub fn to_bytes(self) -> [u8; 32] {
         self.0.to_bytes()
     }
 }

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -259,7 +259,7 @@ impl<T> From<&Action<T>> for CompactAction {
     fn from(action: &Action<T>) -> Self {
         CompactAction {
             ephemeral_key: action.ephemeral_key(),
-            cmx: action.cmx().clone(),
+            cmx: *action.cmx(),
             enc_ciphertext: action.encrypted_note().enc_ciphertext[..52]
                 .try_into()
                 .unwrap(),


### PR DESCRIPTION
This makes `orchard` clippy-clean on stable, beta, and nightly.

Signed-off-by: Daira Hopwood <daira@jacaranda.org>