### PR TITLE
Simple proving optimizations in `ecc/chip/mul_fixed.rs`

### DIFF
--- a/src/circuit/gadget/ecc/chip/mul_fixed.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed.rs
@@ -211,7 +211,9 @@ impl<const NUM_WINDOWS: usize> Config<NUM_WINDOWS> {
         base: OrchardFixedBases,
         fixed_column: Column<Fixed>,
     ) -> Result<(), Error> {
-        let (lagrange_coeffs, z) = match base {
+        let mut constants = None;
+
+        let build_constants = || match base {
             OrchardFixedBases::ValueCommitV => {
                 assert_eq!(NUM_WINDOWS, constants::NUM_WINDOWS_SHORT);
                 let base = ValueCommitV::get();
@@ -250,7 +252,13 @@ impl<const NUM_WINDOWS: usize> Config<NUM_WINDOWS> {
                     },
                     self.lagrange_coeffs[k],
                     window + offset,
-                    || Ok(lagrange_coeffs[window].0[k]),
+                    || {
+                        if constants.as_ref().is_none() {
+                            constants = Some(build_constants());
+                        }
+                        let lagrange_coeffs = &constants.as_ref().unwrap().0;
+                        Ok(lagrange_coeffs[window].0[k])
+                    },
                 )?;
             }
 
@@ -259,7 +267,10 @@ impl<const NUM_WINDOWS: usize> Config<NUM_WINDOWS> {
                 || format!("z-value for window: {:?}", window),
                 self.fixed_z,
                 window + offset,
-                || Ok(z[window]),
+                || {
+                    let z = &constants.as_ref().unwrap().1;
+                    Ok(z[window])
+                }
             )?;
         }
 

--- a/src/circuit/gadget/ecc/chip/mul_fixed.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed.rs
@@ -48,20 +48,14 @@ impl OrchardFixedBases {
     pub fn generator(self) -> pallas::Affine {
         match self {
             Self::ValueCommitV => constants::value_commit_v::generator(),
-            Self::Full(base) => {
-                let base: OrchardFixedBase = base.into();
-                base.generator
-            }
+            Self::Full(base) => base.generator(),
         }
     }
 
     pub fn u(self) -> Vec<WindowUs> {
         match self {
             Self::ValueCommitV => ValueCommitV::get().u_short.0.as_ref().to_vec(),
-            Self::Full(base) => {
-                let base: OrchardFixedBase = base.into();
-                base.u.0.as_ref().to_vec()
-            }
+            Self::Full(base) => base.u().0.as_ref().to_vec(),
         }
     }
 }

--- a/src/constants/load.rs
+++ b/src/constants/load.rs
@@ -12,6 +12,28 @@ pub enum OrchardFixedBasesFull {
     SpendAuthG,
 }
 
+impl OrchardFixedBasesFull {
+    pub fn generator(&self) -> pallas::Affine {
+        match self {
+            OrchardFixedBasesFull::CommitIvkR => super::commit_ivk_r::generator(),
+            OrchardFixedBasesFull::NoteCommitR => super::note_commit_r::generator(),
+            OrchardFixedBasesFull::NullifierK => super::nullifier_k::generator(),
+            OrchardFixedBasesFull::ValueCommitR => super::value_commit_r::generator(),
+            OrchardFixedBasesFull::SpendAuthG => super::spend_auth_g::generator(),
+        }
+    }
+
+    pub fn u(&self) -> U {
+        match self {
+            OrchardFixedBasesFull::CommitIvkR => super::commit_ivk_r::U.into(),
+            OrchardFixedBasesFull::NoteCommitR => super::note_commit_r::U.into(),
+            OrchardFixedBasesFull::NullifierK => super::nullifier_k::U.into(),
+            OrchardFixedBasesFull::ValueCommitR => super::value_commit_r::U.into(),
+            OrchardFixedBasesFull::SpendAuthG => super::spend_auth_g::U.into(),
+        }
+    }
+}
+
 /// A fixed base to be used in scalar multiplication with a full-width scalar.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OrchardFixedBase {


### PR DESCRIPTION
Together these decrease proving time in the Action circuit by 60%.