### PR TITLE
Make this crate clippy clean for warnings on nightly

### DIFF
--- a/src/circuit/gadget/poseidon.rs
+++ b/src/circuit/gadget/poseidon.rs
@@ -149,7 +149,7 @@ impl<
                     layouter.namespace(|| "PoseidonDuplex"),
                     &self.domain,
                     &mut self.state,
-                    &input,
+                    input,
                 )?;
                 self.sponge = Sponge::absorb(value.inner);
             }
@@ -175,7 +175,7 @@ impl<
                         layouter.namespace(|| "PoseidonDuplex"),
                         &self.domain,
                         &mut self.state,
-                        &input,
+                        input,
                     )?);
                 }
                 Sponge::Squeezing(ref mut output) => {

--- a/src/circuit/gadget/poseidon/pow5t3.rs
+++ b/src/circuit/gadget/poseidon/pow5t3.rs
@@ -243,17 +243,17 @@ impl<F: FieldExt, S: Spec<F, WIDTH, 2>> PoseidonInstructions<F, S, WIDTH, 2> for
             || "permute state",
             |mut region| {
                 // Load the initial state into this region.
-                let state = Pow5T3State::load(&mut region, &config, initial_state)?;
+                let state = Pow5T3State::load(&mut region, config, initial_state)?;
 
                 let state = (0..config.half_full_rounds).fold(Ok(state), |res, r| {
-                    res.and_then(|state| state.full_round(&mut region, &config, r, r))
+                    res.and_then(|state| state.full_round(&mut region, config, r, r))
                 })?;
 
                 let state = (0..config.half_partial_rounds).fold(Ok(state), |res, r| {
                     res.and_then(|state| {
                         state.partial_round(
                             &mut region,
-                            &config,
+                            config,
                             config.half_full_rounds + 2 * r,
                             config.half_full_rounds + r,
                         )
@@ -264,7 +264,7 @@ impl<F: FieldExt, S: Spec<F, WIDTH, 2>> PoseidonInstructions<F, S, WIDTH, 2> for
                     res.and_then(|state| {
                         state.full_round(
                             &mut region,
-                            &config,
+                            config,
                             config.half_full_rounds + 2 * config.half_partial_rounds + r,
                             config.half_full_rounds + config.half_partial_rounds + r,
                         )

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -449,7 +449,7 @@ impl DiversifiedTransmissionKey {
     }
 
     fn derive_inner(ivk: &KeyAgreementPrivateKey, d: &Diversifier) -> Self {
-        let g_d = diversify_hash(&d.as_array());
+        let g_d = diversify_hash(d.as_array());
         DiversifiedTransmissionKey(ka_orchard(&ivk.0, &g_d))
     }
 

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -129,7 +129,7 @@ impl Domain for OrchardDomain {
     }
 
     fn kdf(secret: Self::SharedSecret, ephemeral_key: &EphemeralKeyBytes) -> Self::SymmetricKey {
-        secret.kdf_orchard(&ephemeral_key)
+        secret.kdf_orchard(ephemeral_key)
     }
 
     fn note_plaintext_bytes(
@@ -189,7 +189,7 @@ impl Domain for OrchardDomain {
         ivk: &Self::IncomingViewingKey,
         plaintext: &[u8],
     ) -> Option<(Self::Note, Self::Recipient)> {
-        orchard_parse_note_plaintext_without_memo(&self, plaintext, |diversifier| {
+        orchard_parse_note_plaintext_without_memo(self, plaintext, |diversifier| {
             Some(DiversifiedTransmissionKey::derive(ivk, diversifier))
         })
     }
@@ -201,7 +201,7 @@ impl Domain for OrchardDomain {
         ephemeral_key: &EphemeralKeyBytes,
         plaintext: &[u8],
     ) -> Option<(Self::Note, Self::Recipient)> {
-        orchard_parse_note_plaintext_without_memo(&self, plaintext, |diversifier| {
+        orchard_parse_note_plaintext_without_memo(self, plaintext, |diversifier| {
             if esk
                 .derive_public(diversify_hash(diversifier.as_array()))
                 .to_bytes()
@@ -351,7 +351,7 @@ mod tests {
                 rho,
                 // We don't need a valid rk for this test.
                 redpallas::VerificationKey::dummy(),
-                cmx.clone(),
+                cmx,
                 TransmittedNoteCiphertext {
                     epk_bytes: ephemeral_key.0,
                     enc_ciphertext: tv.c_enc,

--- a/src/primitives/poseidon.rs
+++ b/src/primitives/poseidon.rs
@@ -197,7 +197,7 @@ impl<F: FieldExt, S: Spec<F, T, RATE>, const T: usize, const RATE: usize> Duplex
                 // We've already absorbed as many elements as we can
                 let _ = poseidon_duplex::<F, S, T, RATE>(
                     &mut self.state,
-                    &input,
+                    input,
                     &self.pad_and_add,
                     &self.mds_matrix,
                     &self.round_constants,
@@ -218,7 +218,7 @@ impl<F: FieldExt, S: Spec<F, T, RATE>, const T: usize, const RATE: usize> Duplex
                 Sponge::Absorbing(ref input) => {
                     self.sponge = Sponge::Squeezing(poseidon_duplex::<F, S, T, RATE>(
                         &mut self.state,
-                        &input,
+                        input,
                         &self.pad_and_add,
                         &self.mds_matrix,
                         &self.round_constants,

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -171,7 +171,7 @@ pub(crate) fn commit_ivk(
 ) -> CtOption<NonZeroPallasBase> {
     // We rely on the API contract that to_le_bits() returns at least PrimeField::NUM_BITS
     // bits, which is equal to L_ORCHARD_BASE.
-    let domain = sinsemilla::CommitDomain::new(&"z.cash:Orchard-CommitIvk");
+    let domain = sinsemilla::CommitDomain::new("z.cash:Orchard-CommitIvk");
     domain
         .short_commit(
             iter::empty()


### PR DESCRIPTION
One .clone() removal; all of the other changes are removing needless borrows that are immediately
dereferenced: https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

Signed-off-by: Daira Hopwood <daira@jacaranda.org>