### PR TITLE
Add `Bundle<Authorized, _>::dynamic_usage` method

### DIFF
--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -1,5 +1,7 @@
 //! Structs related to bundles of Orchard actions.
 
+use std::mem;
+
 use nonempty::NonEmpty;
 
 use crate::{
@@ -355,6 +357,15 @@ impl Authorized {
 }
 
 impl<V> Bundle<Authorized, V> {
+    /// Returns the amount of heap-allocated memory used by this bundle.
+    pub fn dynamic_usage(&self) -> usize {
+        // NonEmpty<T> stores its head element separately from its tail Vec<T>.
+        // TODO: This underestimates the dynamic usage; switch to NonEmpty::capacity once
+        // https://github.com/cloudhead/nonempty/issues/33 is closed.
+        (self.actions.len() - 1) * mem::size_of::<Action<redpallas::Signature<SpendAuth>>>()
+            + self.authorization.proof.dynamic_usage()
+    }
+
     /// Computes a commitment to the authorizing data within for this bundle.
     ///
     /// This together with `Bundle::commitment` bind the entire bundle.

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -1,5 +1,7 @@
 //! The Orchard Action circuit implementation.
 
+use std::mem;
+
 use group::Curve;
 use halo2::{
     plonk,
@@ -130,6 +132,11 @@ impl AsRef<[u8]> for Proof {
 }
 
 impl Proof {
+    /// Returns the amount of heap-allocated memory used by this proof.
+    pub(crate) fn dynamic_usage(&self) -> usize {
+        self.0.capacity() * mem::size_of::<u8>()
+    }
+
     /// Creates a proof for the given circuits and instances.
     pub fn create(
         pk: &ProvingKey,


### PR DESCRIPTION
This will be used by `zcashd` as part of tracking the memory usage of transactions.