### PR TITLE
nonempty 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lazy_static = "1"
 pasta_curves = "0.1"
 proptest = { version = "1.0.0", optional = true }
 rand = "0.8"
-nonempty = "0.6"
+nonempty = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 subtle = "2.3"
 zcash_note_encryption = "0.0"

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -360,9 +360,7 @@ impl<V> Bundle<Authorized, V> {
     /// Returns the amount of heap-allocated memory used by this bundle.
     pub fn dynamic_usage(&self) -> usize {
         // NonEmpty<T> stores its head element separately from its tail Vec<T>.
-        // TODO: This underestimates the dynamic usage; switch to NonEmpty::capacity once
-        // https://github.com/cloudhead/nonempty/issues/33 is closed.
-        (self.actions.len() - 1) * mem::size_of::<Action<redpallas::Signature<SpendAuth>>>()
+        (self.actions.capacity() - 1) * mem::size_of::<Action<redpallas::Signature<SpendAuth>>>()
             + self.authorization.proof.dynamic_usage()
     }
 


### PR DESCRIPTION
We can now correctly measure the heap-allocated memory used by a bundle.