### PR TITLE
Add short range check to `lookup_range_check` util

### DIFF
--- a/src/circuit/gadget/utilities.rs
+++ b/src/circuit/gadget/utilities.rs
@@ -4,19 +4,19 @@ use halo2::{
 };
 use pasta_curves::arithmetic::FieldExt;
 
-mod cond_swap;
-mod enable_flag;
-mod lookup_range_check;
-mod plonk;
+pub(crate) mod cond_swap;
+pub(crate) mod enable_flag;
+pub(crate) mod lookup_range_check;
+pub(crate) mod plonk;
 
-/// A variable representing a number.
+/// A variable representing a field element.
 #[derive(Copy, Clone, Debug)]
 pub struct CellValue<F: FieldExt> {
     cell: Cell,
     value: Option<F>,
 }
 
-pub trait Var<F: FieldExt> {
+pub trait Var<F: FieldExt>: Copy + Clone + std::fmt::Debug {
     fn new(cell: Cell, value: Option<F>) -> Self;
     fn cell(&self) -> Cell;
     fn value(&self) -> Option<F>;

--- a/src/circuit/gadget/utilities/cond_swap.rs
+++ b/src/circuit/gadget/utilities/cond_swap.rs
@@ -12,7 +12,6 @@ pub trait CondSwapInstructions<F: FieldExt>: UtilitiesInstructions<F> {
     /// Given an input pair (a,b) and a `swap` boolean flag, returns
     /// (b,a) if `swap` is set, else (a,b) if `swap` is not set.
     ///
-    ///
     /// The second element of the pair is required to be a witnessed
     /// value, not a variable that already exists in the circuit.
     fn swap(

--- a/src/circuit/gadget/utilities/lookup_range_check.rs
+++ b/src/circuit/gadget/utilities/lookup_range_check.rs
@@ -67,7 +67,7 @@ impl<F: FieldExt + PrimeFieldBits, const K: usize> LookupRangeCheckConfig<F, K> 
             vec![(q_lookup * word, table)]
         });
 
-        // Lookup for range checks up to S bits, where S < K.
+        // Lookup used in range checks up to S bits, where S < K.
         meta.lookup(|meta| {
             let q_lookup_short = meta.query_selector(config.q_lookup_short);
             let word = meta.query_advice(config.running_sum, Rotation::cur());
@@ -345,8 +345,6 @@ impl<F: FieldExt + PrimeFieldBits, const K: usize> LookupRangeCheckConfig<F, K> 
             let shift = F::from_u64(1 << (K - num_bits));
             element * shift
         });
-        print!("element: {:?}", element.value());
-        print!("shifted: {:?}", shifted);
 
         region.assign_advice(
             || format!("element * 2^({}-{})", K, num_bits),


### PR DESCRIPTION
This PR introduces a range check for field elements <= `K` bits, using two lookups in a `K`-bit table.

This also introduces a `strict` mode for the full-length lookup (for field elements greater than `K` bits) to constrain the final running sum to 0.