### PR TITLE
Introduce `LookupRangeCheckConfig`s for each Sinsemilla advice column

### DIFF
--- a/src/circuit/gadget/sinsemilla.rs
+++ b/src/circuit/gadget/sinsemilla.rs
@@ -139,8 +139,8 @@ where
         Self {
             chip,
             inner: pieces
-                .iter()
-                .map(|piece| piece.inner.clone())
+                .into_iter()
+                .map(|piece| piece.inner)
                 .collect::<Vec<_>>()
                 .into(),
         }
@@ -354,13 +354,11 @@ mod tests {
                 meta.fixed_column(),
                 meta.fixed_column(),
             ];
-            let constants_3 = meta.fixed_column();
 
             let perm = meta.permutation(
                 &advices
                     .iter()
                     .map(|advice| (*advice).into())
-                    .chain(Some(constants_3.into()))
                     .chain(constants_1.iter().map(|fixed| (*fixed).into()))
                     .chain(constants_2.iter().map(|fixed| (*fixed).into()))
                     .collect::<Vec<_>>(),

--- a/src/circuit/gadget/sinsemilla.rs
+++ b/src/circuit/gadget/sinsemilla.rs
@@ -337,12 +337,32 @@ mod tests {
                 meta.advice_column(),
             ];
 
-            let constants = meta.fixed_column();
+            // TODO: Replace with public inputs API
+            let constants_1 = [
+                meta.fixed_column(),
+                meta.fixed_column(),
+                meta.fixed_column(),
+                meta.fixed_column(),
+                meta.fixed_column(),
+                meta.fixed_column(),
+            ];
+            let constants_2 = [
+                meta.fixed_column(),
+                meta.fixed_column(),
+                meta.fixed_column(),
+                meta.fixed_column(),
+                meta.fixed_column(),
+                meta.fixed_column(),
+            ];
+            let constants_3 = meta.fixed_column();
+
             let perm = meta.permutation(
                 &advices
                     .iter()
                     .map(|advice| (*advice).into())
-                    .chain(Some(constants.into()))
+                    .chain(Some(constants_3.into()))
+                    .chain(constants_1.iter().map(|fixed| (*fixed).into()))
+                    .chain(constants_2.iter().map(|fixed| (*fixed).into()))
                     .collect::<Vec<_>>(),
             );
 
@@ -359,14 +379,14 @@ mod tests {
                 meta,
                 advices[..5].try_into().unwrap(),
                 lookup,
-                constants,
+                constants_1,
                 perm.clone(),
             );
             let config2 = SinsemillaChip::configure(
                 meta,
                 advices[5..].try_into().unwrap(),
                 lookup,
-                constants,
+                constants_2,
                 perm,
             );
             (ecc_config, config1, config2)

--- a/src/circuit/gadget/sinsemilla/chip.rs
+++ b/src/circuit/gadget/sinsemilla/chip.rs
@@ -60,13 +60,19 @@ pub struct SinsemillaConfig {
     lambda_2: Column<Advice>,
     /// The lookup table where $(\mathsf{idx}, x_p, y_p)$ are loaded for the $2^K$
     /// generators of the Sinsemilla hash.
-    generator_table: GeneratorTableConfig,
+    pub(super) generator_table: GeneratorTableConfig,
     /// Fixed column shared by the whole circuit. This is used to load the
     /// x-coordinate of the domain $Q$, which is then constrained to equal the
     /// initial $x_a$.
     constants: Column<Fixed>,
-    /// Permutation over all advice columns and the `constants` fixed column.
-    perm: Permutation,
+    // Permutation over all advice columns and the `constants` fixed column.
+    pub(super) perm: Permutation,
+}
+
+impl SinsemillaConfig {
+    pub fn advices(&self) -> [Column<Advice>; 5] {
+        [self.bits, self.lambda_1, self.lambda_2, self.x_a, self.x_p]
+    }
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]

--- a/src/circuit/gadget/sinsemilla/chip.rs
+++ b/src/circuit/gadget/sinsemilla/chip.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     circuit::gadget::{
         ecc::chip::EccPoint,
-        utilities::{CellValue, Var},
+        utilities::{lookup_range_check::LookupRangeCheckConfig, CellValue, Var},
     },
     primitives::sinsemilla::{
         self, Q_COMMIT_IVK_M_GENERATOR, Q_MERKLE_CRH, Q_NOTE_COMMITMENT_M_GENERATOR,
@@ -62,8 +62,14 @@ pub struct SinsemillaConfig {
     /// x-coordinate of the domain $Q$, which is then constrained to equal the
     /// initial $x_a$.
     constants: Column<Fixed>,
-    // Permutation over all advice columns and the `constants` fixed column.
+    /// Permutation over all advice columns and the `constants` fixed column.
     pub(super) perm: Permutation,
+    /// Configure each advice column to be able to perform lookup range checks.
+    pub(super) lookup_config_0: LookupRangeCheckConfig<pallas::Base, { sinsemilla::K }>,
+    pub(super) lookup_config_1: LookupRangeCheckConfig<pallas::Base, { sinsemilla::K }>,
+    pub(super) lookup_config_2: LookupRangeCheckConfig<pallas::Base, { sinsemilla::K }>,
+    pub(super) lookup_config_3: LookupRangeCheckConfig<pallas::Base, { sinsemilla::K }>,
+    pub(super) lookup_config_4: LookupRangeCheckConfig<pallas::Base, { sinsemilla::K }>,
 }
 
 impl SinsemillaConfig {
@@ -109,7 +115,7 @@ impl SinsemillaChip {
         meta: &mut ConstraintSystem<pallas::Base>,
         advices: [Column<Advice>; 5],
         lookup: (Column<Fixed>, Column<Fixed>, Column<Fixed>),
-        constants: Column<Fixed>,
+        constants: [Column<Fixed>; 6], // TODO: replace with public inputs API
         perm: Permutation,
     ) -> <Self as Chip<pallas::Base>>::Config {
         let config = SinsemillaConfig {
@@ -126,7 +132,42 @@ impl SinsemillaChip {
                 table_x: lookup.1,
                 table_y: lookup.2,
             },
-            constants,
+            constants: constants[5],
+            lookup_config_0: LookupRangeCheckConfig::configure(
+                meta,
+                advices[0],
+                constants[0],
+                lookup.0,
+                perm.clone(),
+            ),
+            lookup_config_1: LookupRangeCheckConfig::configure(
+                meta,
+                advices[1],
+                constants[1],
+                lookup.0,
+                perm.clone(),
+            ),
+            lookup_config_2: LookupRangeCheckConfig::configure(
+                meta,
+                advices[2],
+                constants[2],
+                lookup.0,
+                perm.clone(),
+            ),
+            lookup_config_3: LookupRangeCheckConfig::configure(
+                meta,
+                advices[3],
+                constants[3],
+                lookup.0,
+                perm.clone(),
+            ),
+            lookup_config_4: LookupRangeCheckConfig::configure(
+                meta,
+                advices[4],
+                constants[4],
+                lookup.0,
+                perm.clone(),
+            ),
             perm,
         };
 

--- a/src/circuit/gadget/sinsemilla/chip.rs
+++ b/src/circuit/gadget/sinsemilla/chip.rs
@@ -72,12 +72,6 @@ pub struct SinsemillaConfig {
     pub(super) lookup_config_4: LookupRangeCheckConfig<pallas::Base, { sinsemilla::K }>,
 }
 
-impl SinsemillaConfig {
-    pub fn advices(&self) -> [Column<Advice>; 5] {
-        [self.bits, self.lambda_1, self.lambda_2, self.x_a, self.x_p]
-    }
-}
-
 #[derive(Eq, PartialEq, Clone, Debug)]
 pub struct SinsemillaChip {
     config: SinsemillaConfig,

--- a/src/circuit/gadget/sinsemilla/message.rs
+++ b/src/circuit/gadget/sinsemilla/message.rs
@@ -34,25 +34,17 @@ impl<F: FieldExt + PrimeFieldBits, const K: usize, const MAX_WORDS: usize> std::
 /// cannot exceed the base field's `NUM_BITS`.
 #[derive(Copy, Clone, Debug)]
 pub struct MessagePiece<F: FieldExt, const K: usize> {
-    cell: Cell,
-    field_elem: Option<F>,
+    cell_value: CellValue<F>,
     /// The number of K-bit words in this message piece.
     num_words: usize,
-}
-
-#[allow(clippy::from_over_into)]
-impl<F: FieldExt + PrimeFieldBits, const K: usize> Into<CellValue<F>> for MessagePiece<F, K> {
-    fn into(self) -> CellValue<F> {
-        CellValue::new(self.cell(), self.field_elem())
-    }
 }
 
 impl<F: FieldExt + PrimeFieldBits, const K: usize> MessagePiece<F, K> {
     pub fn new(cell: Cell, field_elem: Option<F>, num_words: usize) -> Self {
         assert!(num_words * K < F::NUM_BITS as usize);
+        let cell_value = CellValue::new(cell, field_elem);
         Self {
-            cell,
-            field_elem,
+            cell_value,
             num_words,
         }
     }
@@ -62,10 +54,14 @@ impl<F: FieldExt + PrimeFieldBits, const K: usize> MessagePiece<F, K> {
     }
 
     pub fn cell(&self) -> Cell {
-        self.cell
+        self.cell_value.cell()
     }
 
     pub fn field_elem(&self) -> Option<F> {
-        self.field_elem
+        self.cell_value.value()
+    }
+
+    pub fn cell_value(&self) -> CellValue<F> {
+        self.cell_value
     }
 }


### PR DESCRIPTION
Based on #132.

Inputs to Sinsemilla are commonly decomposed into subpieces and packed into field elements. These subpieces have to be range-checked. This PR includes a `LookupRangeCheckConfig` for each Sinsemilla advice column, to enable subpieces to be looked up in any advice column.

This PR also moves certain APIs from the instruction level to the gadget level.