### PR TITLE
Partial fixes from NCC draft report

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -157,6 +157,11 @@ fn compute_lagrange_coeffs<C: CurveAffine>(base: C, num_windows: usize) -> Vec<[
 /// - $z + y = u^2$ (some square in the field); and
 /// - $z - y$ is not a square.
 /// If successful, return a vector of `(z: u64, us: [C::Base; H])` for each window.
+///
+/// This function was used to generate the `z`s and `u`s for the Orchard fixed
+/// bases. The outputs of this function have been stored as constants, and it
+/// is not called anywhere in this codebase. However, we keep this function here
+/// as a utility for those who wish to use it with different parameters.
 fn find_zs_and_us<C: CurveAffine>(base: C, num_windows: usize) -> Option<Vec<(u64, [C::Base; H])>> {
     // Closure to find z and u's for one window
     let find_z_and_us = |window_points: &[C]| {

--- a/src/constants/util.rs
+++ b/src/constants/util.rs
@@ -37,7 +37,9 @@ pub fn evaluate<C: CurveAffine>(x: u8, coeffs: &[C::Base]) -> C::Base {
     coeffs
         .iter()
         .rev()
-        .fold(C::Base::zero(), |acc, coeff| acc * x + coeff)
+        .cloned()
+        .reduce(|acc, coeff| acc * x + coeff)
+        .unwrap_or_else(C::Base::zero)
 }
 
 /// Takes in an FnMut closure and returns a constant-length array with elements of

--- a/src/constants/util.rs
+++ b/src/constants/util.rs
@@ -1,4 +1,4 @@
-use ff::PrimeFieldBits;
+use ff::{Field, PrimeFieldBits};
 use halo2::arithmetic::{CurveAffine, FieldExt};
 
 /// Decompose a scalar into `window_num_bits` bits (little-endian)
@@ -37,7 +37,7 @@ pub fn evaluate<C: CurveAffine>(x: u8, coeffs: &[C::Base]) -> C::Base {
     coeffs
         .iter()
         .rev()
-        .fold(C::Base::default(), |acc, coeff| acc * x + coeff)
+        .fold(C::Base::zero(), |acc, coeff| acc * x + coeff)
 }
 
 /// Takes in an FnMut closure and returns a constant-length array with elements of

--- a/src/note/commitment.rs
+++ b/src/note/commitment.rs
@@ -5,7 +5,12 @@ use ff::PrimeFieldBits;
 use pasta_curves::{arithmetic::FieldExt, pallas};
 use subtle::{ConstantTimeEq, CtOption};
 
-use crate::{constants::L_ORCHARD_BASE, primitives::sinsemilla, spec::extract_p, value::NoteValue};
+use crate::{
+    constants::{L_ORCHARD_BASE, NOTE_COMMITMENT_PERSONALIZATION},
+    primitives::sinsemilla,
+    spec::extract_p,
+    value::NoteValue,
+};
 
 pub(super) struct NoteCommitTrapdoor(pub(super) pallas::Scalar);
 
@@ -27,7 +32,7 @@ impl NoteCommitment {
         psi: pallas::Base,
         rcm: NoteCommitTrapdoor,
     ) -> CtOption<Self> {
-        let domain = sinsemilla::CommitDomain::new("z.cash:Orchard-NoteCommit");
+        let domain = sinsemilla::CommitDomain::new(NOTE_COMMITMENT_PERSONALIZATION);
         domain
             .commit(
                 iter::empty()

--- a/src/primitives/sinsemilla.rs
+++ b/src/primitives/sinsemilla.rs
@@ -127,6 +127,10 @@ impl HashDomain {
     /// $\mathsf{SinsemillaHash}$ from [§ 5.4.1.9][concretesinsemillahash].
     ///
     /// [concretesinsemillahash]: https://zips.z.cash/protocol/nu5.pdf#concretesinsemillahash
+    ///
+    /// # Panics
+    ///
+    /// This panics if the message length is greater than [`K`] * [`C`]
     pub(crate) fn hash(&self, msg: impl Iterator<Item = bool>) -> CtOption<pallas::Base> {
         extract_p_bottom(self.hash_to_point(msg))
     }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -11,7 +11,10 @@ use pasta_curves::pallas;
 use subtle::{ConditionallySelectable, CtOption};
 
 use crate::{
-    constants::{util::gen_const_array, L_ORCHARD_BASE},
+    constants::{
+        util::gen_const_array, COMMIT_IVK_PERSONALIZATION, KEY_DIVERSIFICATION_PERSONALIZATION,
+        L_ORCHARD_BASE,
+    },
     primitives::{poseidon, sinsemilla},
 };
 
@@ -171,7 +174,7 @@ pub(crate) fn commit_ivk(
 ) -> CtOption<NonZeroPallasBase> {
     // We rely on the API contract that to_le_bits() returns at least PrimeField::NUM_BITS
     // bits, which is equal to L_ORCHARD_BASE.
-    let domain = sinsemilla::CommitDomain::new("z.cash:Orchard-CommitIvk");
+    let domain = sinsemilla::CommitDomain::new(COMMIT_IVK_PERSONALIZATION);
     domain
         .short_commit(
             iter::empty()
@@ -192,7 +195,7 @@ pub(crate) fn commit_ivk(
 ///
 /// [concretediversifyhash]: https://zips.z.cash/protocol/nu5.pdf#concretediversifyhash
 pub(crate) fn diversify_hash(d: &[u8; 11]) -> NonIdentityPallasPoint {
-    let hasher = pallas::Point::hash_to_curve("z.cash:Orchard-gd");
+    let hasher = pallas::Point::hash_to_curve(KEY_DIVERSIFICATION_PERSONALIZATION);
     let pk_d = hasher(d);
     // If the identity occurs, we replace it with a different fixed point.
     // TODO: Replace the unwrap_or_else with a cached fixed point.


### PR DESCRIPTION
Minor fixes involving constants:
- document that `find_zs_and_us()` is not meant to be used anywhere;
- use `F::zero()` instead of `F::default()` in `constants/util.rs`;
- use personalisations from `constants` in `spec.rs`.

In `primitives/sinsemilla.rs`: document that `hash()` panics if the message is longer than `K * C`.