### PR TITLE
Migrate to latest `halo2::plonk::Circuit` API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,5 +62,5 @@ name = "small"
 harness = false
 
 [patch.crates-io]
-halo2 = { git = "https://github.com/zcash/halo2.git", rev = "d04b532368d05b505e622f8cac4c0693574fbd93" }
+halo2 = { git = "https://github.com/zcash/halo2.git", rev = "d5be50a8488a433a9b20f1127ff1e21f121c5a2c" }
 zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "cc533a9da4f6a7209a7be05f82b12a03969152c9" }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -4,6 +4,7 @@ use std::mem;
 
 use group::Curve;
 use halo2::{
+    circuit::{Layouter, SimpleFloorPlanner},
     plonk,
     poly::{EvaluationDomain, LagrangeCoeff, Polynomial, Rotation},
     transcript::{Blake2bRead, Blake2bWrite},
@@ -28,6 +29,11 @@ pub struct Circuit {}
 
 impl plonk::Circuit<pallas::Base> for Circuit {
     type Config = ();
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Circuit {}
+    }
 
     fn configure(meta: &mut plonk::ConstraintSystem<pallas::Base>) -> Self::Config {
         // Placeholder so the proving key is correctly built.
@@ -42,8 +48,8 @@ impl plonk::Circuit<pallas::Base> for Circuit {
 
     fn synthesize(
         &self,
-        _cs: &mut impl plonk::Assignment<pallas::Base>,
         _config: Self::Config,
+        _layouter: impl Layouter<pallas::Base>,
     ) -> Result<(), plonk::Error> {
         Ok(())
     }

--- a/src/circuit/gadget/sinsemilla/merkle.rs
+++ b/src/circuit/gadget/sinsemilla/merkle.rs
@@ -149,15 +149,16 @@ pub mod tests {
     use ff::PrimeFieldBits;
     use halo2::{
         arithmetic::FieldExt,
-        circuit::{layouter::SingleChipLayouter, Layouter},
+        circuit::{Layouter, SimpleFloorPlanner},
         dev::MockProver,
         pasta::pallas,
-        plonk::{Assignment, Circuit, ConstraintSystem, Error},
+        plonk::{Circuit, ConstraintSystem, Error},
     };
 
     use rand::random;
     use std::convert::TryInto;
 
+    #[derive(Default)]
     struct MyCircuit {
         leaf: Option<pallas::Base>,
         leaf_pos: Option<u32>,
@@ -166,6 +167,11 @@ pub mod tests {
 
     impl Circuit<pallas::Base> for MyCircuit {
         type Config = (MerkleConfig, MerkleConfig);
+        type FloorPlanner = SimpleFloorPlanner;
+
+        fn without_witnesses(&self) -> Self {
+            Self::default()
+        }
 
         fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
             let advices = [
@@ -239,11 +245,9 @@ pub mod tests {
 
         fn synthesize(
             &self,
-            cs: &mut impl Assignment<pallas::Base>,
             config: Self::Config,
+            mut layouter: impl Layouter<pallas::Base>,
         ) -> Result<(), Error> {
-            let mut layouter = SingleChipLayouter::new(cs)?;
-
             // Load generator table (shared across both configs)
             SinsemillaChip::load(config.0.sinsemilla_config.clone(), &mut layouter)?;
 


### PR DESCRIPTION
- The `Circuit` trait now has a `FloorPlanner` associated type.
- `circuit_layout` has been replaced by `CircuitLayout`.