### PR TITLE
[book] decomposition.md: avoid introducing `m` when we already have `range`

### DIFF
--- a/book/src/design/circuit/gadgets/decomposition.md
+++ b/book/src/design/circuit/gadgets/decomposition.md
@@ -73,4 +73,4 @@ $$q_\mathit{lookup} \cdot \left(q_\mathit{running} \cdot (z_i - 2^K \cdot z_{i+1
 where $z_i$ and $\textsf{word}$ are the same cell (but distinguished here for clarity of usage).
 
 ## Short range decomposition
-For a short range (for instance, $[0, m)$ where $m \leq 8$), we can range-constrain each word using a degree-$m$ polynomial constraint instead of a lookup: $$\texttt{range\_check(word, range)} = \texttt{word} \cdot (1 - \texttt{word}) \cdots (\texttt{range} - 1 - \texttt{word}).$$
+For a short range (for instance, $[0, \texttt{range})$ where $\texttt{range} \leq 8$), we can range-constrain each word using a degree-$\texttt{range}$ polynomial constraint instead of a lookup: $$\texttt{range\_check(word, range)} = \texttt{word} \cdot (1 - \texttt{word}) \cdots (\texttt{range} - 1 - \texttt{word}).$$


### PR DESCRIPTION
This is a small follow-up to #162.

Signed-off-by: Daira Hopwood <daira@jacaranda.org>