### PR TITLE
Add Action circuit benchmarks, fix Builder bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ criterion = "0.3"
 hex = "0.4"
 proptest = "1.0.0"
 
+[target.'cfg(unix)'.dev-dependencies]
+pprof = { version = "0.4.2", features = ["criterion", "flamegraph"] }
+
 [lib]
 bench = false
 
@@ -60,6 +63,16 @@ test-dependencies = ["proptest"]
 [[bench]]
 name = "small"
 harness = false
+
+[[bench]]
+name = "circuit"
+harness = false
+
+[profile.release]
+debug = true
+
+[profile.bench]
+debug = true
 
 [patch.crates-io]
 halo2 = { git = "https://github.com/zcash/halo2.git", rev = "27c4187673a9c6ade13fbdbd4f20955530c22d7f" }

--- a/benches/circuit.rs
+++ b/benches/circuit.rs
@@ -1,0 +1,86 @@
+#[macro_use]
+extern crate criterion;
+
+use criterion::{BenchmarkId, Criterion};
+
+#[cfg(unix)]
+use pprof::criterion::{Output, PProfProfiler};
+
+use orchard::{
+    builder::Builder,
+    bundle::Flags,
+    circuit::{ProvingKey, VerifyingKey},
+    keys::{FullViewingKey, SpendingKey},
+    value::NoteValue,
+    Anchor, Bundle,
+};
+use rand::rngs::OsRng;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let rng = OsRng;
+
+    let sk = SpendingKey::from_bytes([7; 32]).unwrap();
+    let recipient = FullViewingKey::from(&sk).default_address();
+
+    let vk = VerifyingKey::build();
+    let pk = ProvingKey::build();
+
+    for num_recipients in 1..4 {
+        let mut builder = Builder::new(
+            Flags::from_parts(true, true),
+            Anchor::from_bytes([0; 32]).unwrap(),
+        );
+        for _ in 0..num_recipients {
+            builder
+                .add_recipient(None, recipient, NoteValue::from_raw(10), None)
+                .unwrap();
+        }
+        let bundle: Bundle<_, i64> = builder.build(rng).unwrap();
+
+        let instances: Vec<_> = bundle
+            .actions()
+            .iter()
+            .map(|a| a.to_instance(*bundle.flags(), *bundle.anchor()))
+            .collect();
+
+        {
+            let mut group = c.benchmark_group("proving");
+            group.sample_size(10);
+            group.bench_function(BenchmarkId::new("bundle", num_recipients), |b| {
+                b.iter(|| {
+                    bundle
+                        .authorization()
+                        .create_proof(&pk, &instances)
+                        .unwrap()
+                });
+            });
+        }
+
+        {
+            let mut group = c.benchmark_group("verifying");
+            let bundle = bundle
+                .create_proof(&pk)
+                .unwrap()
+                .apply_signatures(rng, [0; 32], &[])
+                .unwrap();
+            assert_eq!(bundle.verify_proof(&vk), Ok(()));
+            group.bench_function(BenchmarkId::new("bundle", num_recipients), |b| {
+                b.iter(|| bundle.authorization().proof().verify(&vk, &instances));
+            });
+        }
+    }
+}
+
+#[cfg(unix)]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+#[cfg(windows)]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/benches/circuit.rs
+++ b/benches/circuit.rs
@@ -25,7 +25,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let vk = VerifyingKey::build();
     let pk = ProvingKey::build();
 
-    for num_recipients in 1..4 {
+    for num_recipients in 1..=4 {
         let mut builder = Builder::new(
             Flags::from_parts(true, true),
             Anchor::from_bytes([0; 32]).unwrap(),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -130,7 +130,7 @@ impl ActionInfo {
     /// [orchardsend]: https://zips.z.cash/protocol/nu5.pdf#orchardsend
     fn build(self, mut rng: impl RngCore) -> (Action<SigningMetadata>, Circuit) {
         let v_net = self.value_sum().expect("already checked this");
-        let cv_net = ValueCommitment::derive(v_net, self.rcv);
+        let cv_net = ValueCommitment::derive(v_net, self.rcv.clone());
 
         let nf_old = self.spend.note.nullifier(&self.spend.fvk);
         let sender_address = self.spend.fvk.default_address();
@@ -196,7 +196,7 @@ impl ActionInfo {
                 v_new: Some(note.value()),
                 psi_new: Some(note.rseed().psi(&note.rho())),
                 rcm_new: Some(note.rseed().rcm(&note.rho())),
-                rcv: Some(ValueCommitTrapdoor::zero()),
+                rcv: Some(self.rcv),
             },
         )
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -281,7 +281,7 @@ impl Builder {
     ///
     /// This API assumes that none of the notes being spent are controlled by (threshold)
     /// multisignatures, and immediately constructs the bundle proof.
-    fn build<V: TryFrom<i64>>(
+    pub fn build<V: TryFrom<i64>>(
         mut self,
         mut rng: impl RngCore,
     ) -> Result<Bundle<InProgress<Unproven, Unauthorized>, V>, Error> {

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -110,7 +110,9 @@ impl<T> Action<T> {
         })
     }
 
-    pub(crate) fn to_instance(&self, flags: Flags, anchor: Anchor) -> Instance {
+    /// Prepares the public instance for this action, for creating and verifying the
+    /// bundle proof.
+    pub fn to_instance(&self, flags: Flags, anchor: Anchor) -> Instance {
         Instance {
             anchor,
             cv_net: self.cv_net.clone(),


### PR DESCRIPTION
This benchmarks the prover and verifier for `Bundle`s produced by the `Builder` with between 1 and 3 outputs; in particular this means the `Bundle`s will follow any defaults set by the `Builder` (currently that it has a minimum of two `Action`s).

In order to enable benchmarking the prover with minimal changes to the public API, `Builder::build` has been altered to not create the proof. The caller can now choose when to perform this, at any point after then but before signature finalization.

The PR also fixes a bug in the `Builder`'s `Circuit` initialization (from #101).