### PR TITLE
Use w-NAF in `ka_orchard`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ fpe = "0.4"
 group = "0.10"
 halo2 = "0.0"
 lazy_static = "1"
-pasta_curves = "0.1"
+pasta_curves = "0.1.2"
 proptest = { version = "1.0.0", optional = true }
 rand = "0.8"
 nonempty = "0.7"

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -218,7 +218,8 @@ pub(crate) fn ka_orchard(
     sk: &NonZeroPallasScalar,
     b: &NonIdentityPallasPoint,
 ) -> NonIdentityPallasPoint {
-    NonIdentityPallasPoint(b.deref() * sk.deref())
+    let mut wnaf = group::Wnaf::new();
+    NonIdentityPallasPoint(wnaf.scalar(sk.deref()).base(*b.deref()))
 }
 
 /// Coordinate extractor for Pallas.


### PR DESCRIPTION
Improves the base-line cost of trial decryption by over 40%.