### PR TITLE
poseidon::Domain: Remove Spec trait bound.

### DIFF
--- a/src/circuit/gadget/poseidon.rs
+++ b/src/circuit/gadget/poseidon.rs
@@ -43,14 +43,14 @@ pub trait PoseidonDuplexInstructions<
     fn initial_state(
         &self,
         layouter: &mut impl Layouter<F>,
-        domain: &impl Domain<F, S, T, RATE>,
+        domain: &impl Domain<F, T, RATE>,
     ) -> Result<State<Self::Word, T>, Error>;
 
     /// Pads the given input (according to the specified domain) and adds it to the state.
     fn pad_and_add(
         &self,
         layouter: &mut impl Layouter<F>,
-        domain: &impl Domain<F, S, T, RATE>,
+        domain: &impl Domain<F, T, RATE>,
         initial_state: &State<Self::Word, T>,
         input: &SpongeState<Self::Word, RATE>,
     ) -> Result<State<Self::Word, T>, Error>;
@@ -91,7 +91,7 @@ fn poseidon_duplex<
     F: FieldExt,
     PoseidonChip: PoseidonDuplexInstructions<F, S, T, RATE>,
     S: Spec<F, T, RATE>,
-    D: Domain<F, S, T, RATE>,
+    D: Domain<F, T, RATE>,
     const T: usize,
     const RATE: usize,
 >(
@@ -111,7 +111,7 @@ pub struct Duplex<
     F: FieldExt,
     PoseidonChip: PoseidonDuplexInstructions<F, S, T, RATE>,
     S: Spec<F, T, RATE>,
-    D: Domain<F, S, T, RATE>,
+    D: Domain<F, T, RATE>,
     const T: usize,
     const RATE: usize,
 > {
@@ -125,7 +125,7 @@ impl<
         F: FieldExt,
         PoseidonChip: PoseidonDuplexInstructions<F, S, T, RATE>,
         S: Spec<F, T, RATE>,
-        D: Domain<F, S, T, RATE>,
+        D: Domain<F, T, RATE>,
         const T: usize,
         const RATE: usize,
     > Duplex<F, PoseidonChip, S, D, T, RATE>
@@ -215,7 +215,7 @@ pub struct Hash<
     F: FieldExt,
     PoseidonChip: PoseidonDuplexInstructions<F, S, T, RATE>,
     S: Spec<F, T, RATE>,
-    D: Domain<F, S, T, RATE>,
+    D: Domain<F, T, RATE>,
     const T: usize,
     const RATE: usize,
 > {
@@ -226,7 +226,7 @@ impl<
         F: FieldExt,
         PoseidonChip: PoseidonDuplexInstructions<F, S, T, RATE>,
         S: Spec<F, T, RATE>,
-        D: Domain<F, S, T, RATE>,
+        D: Domain<F, T, RATE>,
         const T: usize,
         const RATE: usize,
     > Hash<F, PoseidonChip, S, D, T, RATE>

--- a/src/circuit/gadget/poseidon/pow5t3.rs
+++ b/src/circuit/gadget/poseidon/pow5t3.rs
@@ -273,7 +273,7 @@ impl<F: FieldExt, S: Spec<F, WIDTH, 2>> PoseidonDuplexInstructions<F, S, WIDTH, 
     fn initial_state(
         &self,
         layouter: &mut impl Layouter<F>,
-        domain: &impl Domain<F, S, WIDTH, 2>,
+        domain: &impl Domain<F, WIDTH, 2>,
     ) -> Result<State<Self::Word, WIDTH>, Error> {
         let config = self.config();
         layouter.assign_region(
@@ -304,7 +304,7 @@ impl<F: FieldExt, S: Spec<F, WIDTH, 2>> PoseidonDuplexInstructions<F, S, WIDTH, 
     fn pad_and_add(
         &self,
         layouter: &mut impl Layouter<F>,
-        domain: &impl Domain<F, S, WIDTH, 2>,
+        domain: &impl Domain<F, WIDTH, 2>,
         initial_state: &State<Self::Word, WIDTH>,
         input: &SpongeState<Self::Word, 2>,
     ) -> Result<State<Self::Word, WIDTH>, Error> {

--- a/src/primitives/poseidon.rs
+++ b/src/primitives/poseidon.rs
@@ -242,9 +242,7 @@ impl<F: FieldExt, S: Spec<F, T, RATE>, const T: usize, const RATE: usize> Duplex
 }
 
 /// A domain in which a Poseidon hash function is being used.
-pub trait Domain<F: FieldExt, S: Spec<F, T, RATE>, const T: usize, const RATE: usize>:
-    Copy + fmt::Debug
-{
+pub trait Domain<F: FieldExt, const T: usize, const RATE: usize>: Copy + fmt::Debug {
     /// The initial capacity element, encoding this domain.
     fn initial_capacity_element(&self) -> F;
 
@@ -262,8 +260,8 @@ pub trait Domain<F: FieldExt, S: Spec<F, T, RATE>, const T: usize, const RATE: u
 #[derive(Clone, Copy, Debug)]
 pub struct ConstantLength<const L: usize>;
 
-impl<F: FieldExt, S: Spec<F, T, RATE>, const T: usize, const RATE: usize, const L: usize>
-    Domain<F, S, T, RATE> for ConstantLength<L>
+impl<F: FieldExt, const T: usize, const RATE: usize, const L: usize> Domain<F, T, RATE>
+    for ConstantLength<L>
 {
     fn initial_capacity_element(&self) -> F {
         // Capacity value is $length \cdot 2^64 + (o-1)$ where o is the output length.
@@ -300,7 +298,7 @@ impl<F: FieldExt, S: Spec<F, T, RATE>, const T: usize, const RATE: usize, const 
 pub struct Hash<
     F: FieldExt,
     S: Spec<F, T, RATE>,
-    D: Domain<F, S, T, RATE>,
+    D: Domain<F, T, RATE>,
     const T: usize,
     const RATE: usize,
 > {
@@ -311,7 +309,7 @@ pub struct Hash<
 impl<
         F: FieldExt,
         S: Spec<F, T, RATE>,
-        D: Domain<F, S, T, RATE>,
+        D: Domain<F, T, RATE>,
         const T: usize,
         const RATE: usize,
     > fmt::Debug for Hash<F, S, D, T, RATE>
@@ -330,7 +328,7 @@ impl<
 impl<
         F: FieldExt,
         S: Spec<F, T, RATE>,
-        D: Domain<F, S, T, RATE>,
+        D: Domain<F, T, RATE>,
         const T: usize,
         const RATE: usize,
     > Hash<F, S, D, T, RATE>


### PR DESCRIPTION
The methods in the `Domain` trait are not generic over `Spec`.