### PR TITLE
Correct handling of ⊥ for MerkleCRH

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -940,7 +940,7 @@ mod tests {
                 let cv_net = ValueCommitment::derive(value.unwrap(), ValueCommitTrapdoor::zero());
 
                 let path = MerklePath::dummy(&mut rng);
-                let anchor = path.root(spent_note.commitment().into()).unwrap();
+                let anchor = path.root(spent_note.commitment().into());
 
                 (
                     Circuit {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -96,7 +96,7 @@ impl MerklePath {
     ///      - when hashing two leaves, we produce a node on the layer above the leaves, i.e.
     ///        layer = 31, l = 0
     ///      - when hashing to the final root, we produce the anchor with layer = 0, l = 31.
-    pub fn root(&self, cmx: ExtractedNoteCommitment) -> CtOption<Anchor> {
+    pub fn root(&self, cmx: ExtractedNoteCommitment) -> Anchor {
         self.auth_path
             .iter()
             .enumerate()
@@ -107,7 +107,8 @@ impl MerklePath {
                     node.and_then(|n| hash_with_l(l, cond_swap(swap, n, *sibling)))
                 },
             )
-            .map(Anchor)
+            .unwrap_or_else(pallas::Base::zero)
+            .into()
     }
 
     /// Returns the position of the leaf using this Merkle path.
@@ -405,7 +406,7 @@ pub mod testing {
             };
 
             // Compute anchor for this tree
-            let anchor = auth_paths[0].root(notes[0].commitment().into()).unwrap();
+            let anchor = auth_paths[0].root(notes[0].commitment().into());
 
             (
                 notes.into_iter().zip(auth_paths.into_iter()).map(|(note, auth_path)| (note, auth_path)).collect(),
@@ -422,7 +423,7 @@ pub mod testing {
             (notes_and_auth_paths, anchor) in (1usize..4).prop_flat_map(|n_notes| arb_tree(n_notes))
         ) {
             for (note, auth_path) in notes_and_auth_paths.iter() {
-                let computed_anchor = auth_path.root(note.commitment().into()).unwrap();
+                let computed_anchor = auth_path.root(note.commitment().into());
                 assert_eq!(anchor, computed_anchor);
             }
         }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -88,6 +88,14 @@ impl MerklePath {
         }
     }
 
+    /// Instantiates a new Merkle path given a leaf position and authentication path.
+    pub(crate) fn new(position: u32, auth_path: [pallas::Base; MERKLE_DEPTH_ORCHARD]) -> Self {
+        Self {
+            position,
+            auth_path,
+        }
+    }
+
     /// <https://zips.z.cash/protocol/protocol.pdf#orchardmerklecrh>
     /// The layer with 2^n nodes is called "layer n":
     ///      - leaves are at layer MERKLE_DEPTH_ORCHARD = 32;


### PR DESCRIPTION
MerkleCRH is now total, so if ⊥ occurs as an intermediate value, it is replaced with 0, which needs to become the input to the next MerkleCRH (instead of skipping all subsequent MerkleCRH calls).