### PR TITLE
Add license exceptions for ECC and ZF projects

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,35 @@
-Copyright 2020 The Electric Coin Company
+Copyright 2020-2021 The Electric Coin Company
 
-You may use this package under the Bootstrap Open Source Licence, version 1.0,
-or at your option, any later version. See the file ./LICENSE-BOSL for the terms
-of the Bootstrap Open Source Licence, version 1.0.
+This package ("Original Work") is licensed under the terms of the Bootstrap Open
+Source License, version 1.0, or at your option, any later version ("BOSL"). See
+the file ./LICENSE-BOSL for the terms of the Bootstrap Open Source Licence,
+version 1.0.
+
+Only if this Original Work is included as part of the distribution of one of the
+following projects ("the Project"):
+
+- The Zcash projects published by the Electric Coin Company,
+- The Zebra project published by the Zcash Foundation,
+
+then License is granted to use this package under the BOSL as modified by the
+following clarification and special exception. This exception applies only to
+the Original Work when linked or combined with the Project and not to the
+Original Work when linked, combined, or included in or with any other software
+or project or on a standalone basis.
+
+    Under the terms of the BOSL, linking or combining this Original Work with
+    the Project creates a Derivative Work based upon the Original Work and the
+    terms of the BOSL thus apply to both the Original Work and that Derivative
+    Work. As a special exception to the BOSL, and to allow this Original Work to
+    be linked and combined with the Project without having to apply the BOSL to
+    the other portions of the Project, you are granted permission to link or
+    combine this Original Work with the Project and to copy and distribute the
+    resulting work ("Resulting Work") under the open source license applicable
+    to the Project ("Project License"), provided that any portions of this
+    Original Work included in the Resulting Work remain subject to the BOSL. For
+    clarity, you may continue to treat all other portions of the Project under
+    the Project License, provided that you comply with the BOSL with respect to
+    the Original Work. If you modify this Original Work, your version of the
+    Original Work must remain under the BOSL. You may also extend this exception
+    to your version, but you are not obligated to do so. If you do not wish to
+    do so, delete this exception statement from your version.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ group = "0.11"
 halo2 = "0.0"
 lazy_static = "1"
 memuse = { version = "0.2", features = ["nonempty"] }
-pasta_curves = "0.2"
+pasta_curves = "0.2.1"
 proptest = { version = "1.0.0", optional = true }
 rand = "0.8"
 nonempty = "0.7"
@@ -84,6 +84,6 @@ debug = true
 debug = true
 
 [patch.crates-io]
-halo2 = { git = "https://github.com/zcash/halo2.git", rev = "26047eaf323929935fd1e6aa3ae100b1113706e0" }
+halo2 = { git = "https://github.com/zcash/halo2.git", rev = "a7cd600eb60b1528159b92af5e426adcc615de1a" }
 zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "13b023387bafdc7b5712c933dc0e16ee94b96a6a" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "b7bd6246122a6e9ace8edb51553fbf5228906cbb" }

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Requires Rust 1.51+.
 
 ## License
 
-Copyright 2020 The Electric Coin Company.
+Copyright 2020-2021 The Electric Coin Company.
 
 You may use this package under the Bootstrap Open Source Licence, version 1.0,
-or at your option, any later version. See the file
-[`LICENSE-BOSL`](LICENSE-BOSL) for the terms of the Bootstrap Open Source
-Licence, version 1.0.
+or at your option, any later version. See the file [`COPYING`](COPYING) for
+more details, and [`LICENSE-BOSL`](LICENSE-BOSL) for the terms of the Bootstrap
+Open Source Licence, version 1.0.
 
 The purpose of the BOSL is to allow commercial improvements to the package
 while ensuring that all improvements are open source. See


### PR DESCRIPTION
Also bumps the `pasta_curves` and `halo2` dependencies for compatibility.