### PR TITLE
Add `orchard::circuit::Instance::from_parts()`

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -817,6 +817,27 @@ pub struct Instance {
 }
 
 impl Instance {
+    /// Constructs an [`Instance`] from its constituent parts
+    pub fn from_parts(
+        anchor: Anchor,
+        cv_net: ValueCommitment,
+        nf_old: Nullifier,
+        rk: VerificationKey<SpendAuth>,
+        cmx: ExtractedNoteCommitment,
+        enable_spend: bool,
+        enable_output: bool,
+    ) -> Self {
+        Instance {
+            anchor,
+            cv_net,
+            nf_old,
+            rk,
+            cmx,
+            enable_spend,
+            enable_output,
+        }
+    }
+
     fn to_halo2_instance(&self) -> [[vesta::Scalar; 9]; 1] {
         let mut instance = [vesta::Scalar::zero(); 9];
 

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -805,7 +805,7 @@ impl ProvingKey {
 }
 
 /// Public inputs to the Orchard Action circuit.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Instance {
     pub(crate) anchor: Anchor,
     pub(crate) cv_net: ValueCommitment,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -817,7 +817,13 @@ pub struct Instance {
 }
 
 impl Instance {
-    /// Constructs an [`Instance`] from its constituent parts
+    /// Constructs an [`Instance`] from its constituent parts.
+    ///
+    /// This API can be used in combination with [`Proof::verify`] to build verification
+    /// pipelines for many proofs, where you don't want to pass around the full bundle.
+    /// Use [`Bundle::verify_proof`] instead if you have the full bundle.
+    ///
+    /// [`Bundle::verify_proof`]: crate::Bundle::verify_proof
     pub fn from_parts(
         anchor: Anchor,
         cv_net: ValueCommitment,


### PR DESCRIPTION
When using `orchard` to validate Halo2 proofs, the only public option right now is to use `orchard::Bundle::verify_proof()`, which requires us to construct a whole `Bundle` instance, including encrypted ciphertext, ephemeral keys, and other data we don't need to verify the proof. 

Adding a public constructor for `orchard::circuit::Instance` will allow us to call `orchard::circuit::Proof::verify()` directly with less unnecessary data shuffling.