### PR TITLE
Switch from crates.io patches to git revision dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,15 +36,21 @@ rand = "0.8"
 nonempty = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 subtle = "2.3"
-zcash_note_encryption = "0.0"
-incrementalmerkletree = "0.1"
 
 # Developer tooling dependencies
 plotters = { version = "0.3.0", optional = true }
 
+[dependencies.incrementalmerkletree]
+git = "https://github.com/zcash/incrementalmerkletree.git"
+rev = "b7bd6246122a6e9ace8edb51553fbf5228906cbb"
+
 [dependencies.reddsa]
 git = "https://github.com/str4d/redjubjub.git"
 rev = "416a6a8ebf8bd42c114c938883016c04f338de72"
+
+[dependencies.zcash_note_encryption]
+git = "https://github.com/zcash/librustzcash.git"
+rev = "13b023387bafdc7b5712c933dc0e16ee94b96a6a"
 
 [dev-dependencies]
 criterion = "0.3"
@@ -82,7 +88,3 @@ debug = true
 
 [profile.bench]
 debug = true
-
-[patch.crates-io]
-zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "13b023387bafdc7b5712c933dc0e16ee94b96a6a" }
-incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "b7bd6246122a6e9ace8edb51553fbf5228906cbb" }


### PR DESCRIPTION
This is going to cause `zcash_note_encryption` to be present twice in the dependency tree of downstream users, until we cut a versioned release of it.