### PR TITLE
Fix `IncomingViewingKey::to_bytes`

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -544,7 +544,7 @@ impl IncomingViewingKey {
     /// [orchardrawinviewingkeys]: https://zips.z.cash/protocol/protocol.pdf#orchardinviewingkeyencoding
     pub fn to_bytes(&self) -> [u8; 64] {
         let mut result = [0u8; 64];
-        result.copy_from_slice(self.dk.to_bytes());
+        result[..32].copy_from_slice(self.dk.to_bytes());
         result[32..].copy_from_slice(&self.ivk.0.to_bytes());
         result
     }


### PR DESCRIPTION
`slice::copy_from_slice` panics if the source and destination slices are not the same length.

Closes zcash/orchard#228.