### PR TITLE
circuit: Refactor `EccConfig` away from `impl From<EccConfig>`.

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -236,7 +236,7 @@ impl plonk::Circuit<pallas::Base> for Circuit {
 
         // Configuration for curve point operations.
         // This uses 10 advice columns and spans the whole circuit.
-        let ecc_config = EccChip::configure(meta, advices, lagrange_coeffs, range_check.clone());
+        let ecc_config = EccChip::configure(meta, advices, lagrange_coeffs, range_check);
 
         // Configuration for the Poseidon hash.
         let poseidon_config = PoseidonChip::configure(
@@ -261,7 +261,7 @@ impl plonk::Circuit<pallas::Base> for Circuit {
                 advices[6],
                 lagrange_coeffs[0],
                 lookup,
-                range_check.clone(),
+                range_check,
             );
             let merkle_config_1 = MerkleChip::configure(meta, sinsemilla_config_1.clone());
 

--- a/src/circuit/gadget/ecc/chip.rs
+++ b/src/circuit/gadget/ecc/chip.rs
@@ -145,9 +145,9 @@ pub struct EccConfig {
     add: add::Config,
 
     /// Variable-base scalar multiplication (hi half)
-    pub q_mul_hi: (Selector, Selector, Selector),
+    mul_hi: mul::incomplete::Config<{ mul::INCOMPLETE_HI_LEN }>,
     /// Variable-base scalar multiplication (lo half)
-    pub q_mul_lo: (Selector, Selector, Selector),
+    mul_lo: mul::incomplete::Config<{ mul::INCOMPLETE_LO_LEN }>,
     /// Selector used to enforce boolean decomposition in variable-base scalar mul
     pub q_mul_decompose_var: Selector,
     /// Selector used to enforce switching logic on LSB in variable-base scalar mul
@@ -253,14 +253,23 @@ impl EccChip {
             advices[6], advices[7], advices[8],
         );
 
+        // Components of mul::Config
+        // TODO: Move this into mul::Config.
+        let mul_hi = mul::incomplete::Config::configure(
+            meta, advices[9], advices[3], advices[0], advices[1], advices[4], advices[5],
+        );
+        let mul_lo = mul::incomplete::Config::configure(
+            meta, advices[6], advices[7], advices[0], advices[1], advices[8], advices[2],
+        );
+
         let config = EccConfig {
             advices,
             lagrange_coeffs,
             fixed_z: meta.fixed_column(),
             add_incomplete,
             add,
-            q_mul_hi: (meta.selector(), meta.selector(), meta.selector()),
-            q_mul_lo: (meta.selector(), meta.selector(), meta.selector()),
+            mul_hi,
+            mul_lo,
             q_mul_decompose_var: meta.selector(),
             q_mul_overflow: meta.selector(),
             q_mul_lsb: meta.selector(),

--- a/src/circuit/gadget/ecc/chip.rs
+++ b/src/circuit/gadget/ecc/chip.rs
@@ -149,7 +149,7 @@ pub struct EccConfig {
     /// Variable-base scalar multiplication (lo half)
     mul_lo: mul::incomplete::Config<{ mul::INCOMPLETE_LO_LEN }>,
     /// Selector used to enforce boolean decomposition in variable-base scalar mul
-    pub q_mul_decompose_var: Selector,
+    pub mul_complete: mul::complete::Config,
     /// Selector used to enforce switching logic on LSB in variable-base scalar mul
     pub q_mul_lsb: Selector,
     /// Variable-base scalar multiplication (overflow check)
@@ -228,9 +228,6 @@ impl EccChip {
         // - advices[4]: lambda1
         // - advices[9]: z
         //
-        // mul::complete::Config:
-        // - advices[9]: z_complete
-        //
         // TODO: Refactor away from `impl From<EccConfig> for _` so that sub-configs can
         // equality-enable the columns they need to.
         for column in &advices {
@@ -261,6 +258,7 @@ impl EccChip {
         let mul_lo = mul::incomplete::Config::configure(
             meta, advices[6], advices[7], advices[0], advices[1], advices[8], advices[2],
         );
+        let mul_complete = mul::complete::Config::configure(meta, advices[9], add);
 
         let config = EccConfig {
             advices,
@@ -270,7 +268,7 @@ impl EccChip {
             add,
             mul_hi,
             mul_lo,
-            q_mul_decompose_var: meta.selector(),
+            mul_complete,
             q_mul_overflow: meta.selector(),
             q_mul_lsb: meta.selector(),
             q_mul_fixed_full: meta.selector(),

--- a/src/circuit/gadget/ecc/chip.rs
+++ b/src/circuit/gadget/ecc/chip.rs
@@ -143,9 +143,6 @@ pub struct EccConfig {
     /// Variable-base scalar multiplication
     mul: mul::Config,
 
-    /// TODO: Remove this.
-    pub mul_fixed: mul_fixed::Config,
-
     /// Fixed-base full-width scalar multiplication
     mul_fixed_full: mul_fixed::full_width::Config,
     /// Fixed-base signed short scalar multiplication
@@ -198,12 +195,6 @@ impl EccChip {
         lagrange_coeffs: [Column<Fixed>; 8],
         range_check: LookupRangeCheckConfig<pallas::Base, { sinsemilla::K }>,
     ) -> <Self as Chip<pallas::Base>>::Config {
-        // TODO: Refactor away from `impl From<EccConfig> for _` so that sub-configs can
-        // equality-enable the columns they need to.
-        for column in &advices {
-            meta.enable_equality((*column).into());
-        }
-
         // Create witness point gate
         let witness_point = witness_point::Config::configure(meta, advices[0], advices[1]);
         // Create incomplete point addition gate
@@ -246,20 +237,17 @@ impl EccChip {
             mul_fixed,
         );
 
-        let config = EccConfig {
+        EccConfig {
             advices,
             add_incomplete,
             add,
             mul,
-            mul_fixed,
             mul_fixed_full,
             mul_fixed_short,
             mul_fixed_base_field,
             witness_point,
             lookup_config: range_check,
-        };
-
-        config
+        }
     }
 }
 

--- a/src/circuit/gadget/ecc/chip/add.rs
+++ b/src/circuit/gadget/ecc/chip/add.rs
@@ -1,6 +1,6 @@
 use std::array;
 
-use super::{copy, CellValue, EccConfig, EccPoint, Var};
+use super::{copy, CellValue, EccPoint, Var};
 use ff::{BatchInvert, Field};
 use halo2::{
     circuit::Region,
@@ -10,7 +10,7 @@ use halo2::{
 use pasta_curves::{arithmetic::FieldExt, pallas};
 use std::collections::HashSet;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Config {
     q_add: Selector,
     // lambda
@@ -33,24 +33,43 @@ pub struct Config {
     delta: Column<Advice>,
 }
 
-impl From<&EccConfig> for Config {
-    fn from(ecc_config: &EccConfig) -> Self {
-        Self {
-            q_add: ecc_config.q_add,
-            x_p: ecc_config.advices[0],
-            y_p: ecc_config.advices[1],
-            x_qr: ecc_config.advices[2],
-            y_qr: ecc_config.advices[3],
-            lambda: ecc_config.advices[4],
-            alpha: ecc_config.advices[5],
-            beta: ecc_config.advices[6],
-            gamma: ecc_config.advices[7],
-            delta: ecc_config.advices[8],
-        }
-    }
-}
-
 impl Config {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn configure(
+        meta: &mut ConstraintSystem<pallas::Base>,
+        x_p: Column<Advice>,
+        y_p: Column<Advice>,
+        x_qr: Column<Advice>,
+        y_qr: Column<Advice>,
+        lambda: Column<Advice>,
+        alpha: Column<Advice>,
+        beta: Column<Advice>,
+        gamma: Column<Advice>,
+        delta: Column<Advice>,
+    ) -> Self {
+        meta.enable_equality(x_p.into());
+        meta.enable_equality(y_p.into());
+        meta.enable_equality(x_qr.into());
+        meta.enable_equality(y_qr.into());
+
+        let config = Self {
+            q_add: meta.selector(),
+            x_p,
+            y_p,
+            x_qr,
+            y_qr,
+            lambda,
+            alpha,
+            beta,
+            gamma,
+            delta,
+        };
+
+        config.create_gate(meta);
+
+        config
+    }
+
     pub(crate) fn advice_columns(&self) -> HashSet<Column<Advice>> {
         core::array::IntoIter::new([
             self.x_p,
@@ -70,7 +89,7 @@ impl Config {
         core::array::IntoIter::new([self.x_qr, self.y_qr]).collect()
     }
 
-    pub(crate) fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
         meta.create_gate("complete addition gates", |meta| {
             let q_add = meta.query_selector(self.q_add);
             let x_p = meta.query_advice(self.x_p, Rotation::cur());

--- a/src/circuit/gadget/ecc/chip/mul.rs
+++ b/src/circuit/gadget/ecc/chip/mul.rs
@@ -61,7 +61,7 @@ impl From<&EccConfig> for Config {
     fn from(ecc_config: &EccConfig) -> Self {
         let config = Self {
             q_mul_lsb: ecc_config.q_mul_lsb,
-            add_config: ecc_config.into(),
+            add_config: ecc_config.add,
             hi_config: ecc_config.into(),
             lo_config: ecc_config.into(),
             complete_config: ecc_config.into(),

--- a/src/circuit/gadget/ecc/chip/mul.rs
+++ b/src/circuit/gadget/ecc/chip/mul.rs
@@ -20,7 +20,8 @@ use pasta_curves::pallas;
 pub(crate) mod complete;
 // TODO: Undo this pub(crate).
 pub(crate) mod incomplete;
-mod overflow;
+// TODO: Undo this pub(crate).
+pub(crate) mod overflow;
 
 /// Number of bits for which complete addition needs to be used in variable-base
 /// scalar multiplication
@@ -69,7 +70,7 @@ impl From<&EccConfig> for Config {
             hi_config: ecc_config.mul_hi,
             lo_config: ecc_config.mul_lo,
             complete_config: ecc_config.mul_complete,
-            overflow_config: ecc_config.into(),
+            overflow_config: ecc_config.mul_overflow,
         };
 
         assert_eq!(
@@ -112,8 +113,6 @@ impl From<&EccConfig> for Config {
 
 impl Config {
     pub(super) fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
-        self.overflow_config.create_gate(meta);
-
         // If `lsb` is 0, (x, y) = (x_p, -y_p). If `lsb` is 1, (x, y) = (0,0).
         meta.create_gate("LSB check", |meta| {
             let q_mul_lsb = meta.query_selector(self.q_mul_lsb);

--- a/src/circuit/gadget/ecc/chip/mul.rs
+++ b/src/circuit/gadget/ecc/chip/mul.rs
@@ -43,8 +43,8 @@ const INCOMPLETE_HI_LEN: usize = INCOMPLETE_LEN / 2;
 
 // Bits k_{254} to k_{4} inclusive are used in incomplete addition.
 // The `lo` half is k_{129} to k_{4} inclusive (length 126 bits).
-const INCOMPLETE_LO_RANGE: Range<usize> = (INCOMPLETE_LEN / 2)..INCOMPLETE_LEN;
-const INCOMPLETE_LO_LEN: usize = (INCOMPLETE_LEN / 2) + 1;
+const INCOMPLETE_LO_RANGE: Range<usize> = INCOMPLETE_HI_LEN..INCOMPLETE_LEN;
+const INCOMPLETE_LO_LEN: usize = INCOMPLETE_LEN - INCOMPLETE_HI_LEN;
 
 // Bits k_{3} to k_{1} inclusive are used in complete addition.
 // Bit k_{0} is handled separately.

--- a/src/circuit/gadget/ecc/chip/mul.rs
+++ b/src/circuit/gadget/ecc/chip/mul.rs
@@ -98,6 +98,11 @@ impl From<&EccConfig> for Config {
 
 impl Config {
     pub(super) fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+        self.hi_config.create_gate(meta);
+        self.lo_config.create_gate(meta);
+        self.complete_config.create_gate(meta);
+        self.overflow_config.create_gate(meta);
+
         // If `lsb` is 0, (x, y) = (x_p, -y_p). If `lsb` is 1, (x, y) = (0,0).
         meta.create_gate("LSB check", |meta| {
             let q_mul_lsb = meta.query_selector(self.q_mul_lsb);
@@ -127,11 +132,6 @@ impl Config {
             ])
             .map(move |(name, poly)| (name, q_mul_lsb.clone() * poly))
         });
-
-        self.hi_config.create_gate(meta);
-        self.lo_config.create_gate(meta);
-        self.complete_config.create_gate(meta);
-        self.overflow_config.create_gate(meta);
     }
 
     pub(super) fn assign(

--- a/src/circuit/gadget/ecc/chip/mul.rs
+++ b/src/circuit/gadget/ecc/chip/mul.rs
@@ -16,7 +16,8 @@ use halo2::{
 
 use pasta_curves::pallas;
 
-mod complete;
+// TODO: Undo this pub(crate).
+pub(crate) mod complete;
 // TODO: Undo this pub(crate).
 pub(crate) mod incomplete;
 mod overflow;
@@ -67,7 +68,7 @@ impl From<&EccConfig> for Config {
             add_config: ecc_config.add,
             hi_config: ecc_config.mul_hi,
             lo_config: ecc_config.mul_lo,
-            complete_config: ecc_config.into(),
+            complete_config: ecc_config.mul_complete,
             overflow_config: ecc_config.into(),
         };
 
@@ -111,7 +112,6 @@ impl From<&EccConfig> for Config {
 
 impl Config {
     pub(super) fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
-        self.complete_config.create_gate(meta);
         self.overflow_config.create_gate(meta);
 
         // If `lsb` is 0, (x, y) = (x_p, -y_p). If `lsb` is 1, (x, y) = (0,0).

--- a/src/circuit/gadget/ecc/chip/mul/complete.rs
+++ b/src/circuit/gadget/ecc/chip/mul/complete.rs
@@ -24,7 +24,7 @@ impl From<&EccConfig> for Config {
         let config = Self {
             q_mul_decompose_var: ecc_config.q_mul_decompose_var,
             z_complete: ecc_config.advices[9],
-            add_config: ecc_config.into(),
+            add_config: ecc_config.add,
         };
 
         let add_config_advices = config.add_config.advice_columns();

--- a/src/circuit/gadget/ecc/chip/mul/complete.rs
+++ b/src/circuit/gadget/ecc/chip/mul/complete.rs
@@ -1,4 +1,4 @@
-use super::super::{add, copy, CellValue, EccConfig, EccPoint, Var};
+use super::super::{add, copy, CellValue, EccPoint, Var};
 use super::{COMPLETE_RANGE, X, Y, Z};
 use crate::circuit::gadget::utilities::{bool_check, ternary};
 
@@ -10,6 +10,7 @@ use halo2::{
 
 use pasta_curves::{arithmetic::FieldExt, pallas};
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Config {
     // Selector used to constrain the cells used in complete addition.
     q_mul_decompose_var: Selector,
@@ -19,30 +20,31 @@ pub struct Config {
     add_config: add::Config,
 }
 
-impl From<&EccConfig> for Config {
-    fn from(ecc_config: &EccConfig) -> Self {
+impl Config {
+    /// TODO: Make this pub(super).
+    pub(crate) fn configure(
+        meta: &mut ConstraintSystem<pallas::Base>,
+        z_complete: Column<Advice>,
+        add_config: add::Config,
+    ) -> Self {
+        meta.enable_equality(z_complete.into());
+
         let config = Self {
-            q_mul_decompose_var: ecc_config.q_mul_decompose_var,
-            z_complete: ecc_config.advices[9],
-            add_config: ecc_config.add,
+            q_mul_decompose_var: meta.selector(),
+            z_complete,
+            add_config,
         };
 
-        let add_config_advices = config.add_config.advice_columns();
-        assert!(
-            !add_config_advices.contains(&config.z_complete),
-            "z_complete cannot overlap with complete addition columns."
-        );
+        config.create_gate(meta);
 
         config
     }
-}
 
-impl Config {
     /// Gate used to check scalar decomposition is correct.
     /// This is used to check the bits used in complete addition, since the incomplete
     /// addition gate (controlled by `q_mul`) already checks scalar decomposition for
     /// the other bits.
-    pub(super) fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
         // | y_p | z_complete |
         // --------------------
         // | y_p | z_{i + 1}  |

--- a/src/circuit/gadget/ecc/chip/mul/complete.rs
+++ b/src/circuit/gadget/ecc/chip/mul/complete.rs
@@ -21,8 +21,7 @@ pub struct Config {
 }
 
 impl Config {
-    /// TODO: Make this pub(super).
-    pub(crate) fn configure(
+    pub(super) fn configure(
         meta: &mut ConstraintSystem<pallas::Base>,
         z_complete: Column<Advice>,
         add_config: add::Config,

--- a/src/circuit/gadget/ecc/chip/mul/incomplete.rs
+++ b/src/circuit/gadget/ecc/chip/mul/incomplete.rs
@@ -29,8 +29,7 @@ pub(crate) struct Config<const NUM_BITS: usize> {
 }
 
 impl<const NUM_BITS: usize> Config<NUM_BITS> {
-    // TODO: Make this pub(super).
-    pub(crate) fn configure(
+    pub(super) fn configure(
         meta: &mut ConstraintSystem<pallas::Base>,
         z: Column<Advice>,
         x_a: Column<Advice>,

--- a/src/circuit/gadget/ecc/chip/mul/overflow.rs
+++ b/src/circuit/gadget/ecc/chip/mul/overflow.rs
@@ -26,8 +26,7 @@ pub struct Config {
 }
 
 impl Config {
-    // TODO: Make this pub(super).
-    pub(crate) fn configure(
+    pub(super) fn configure(
         meta: &mut ConstraintSystem<pallas::Base>,
         lookup_config: LookupRangeCheckConfig<pallas::Base, { sinsemilla::K }>,
         advices: [Column<Advice>; 3],

--- a/src/circuit/gadget/ecc/chip/mul/overflow.rs
+++ b/src/circuit/gadget/ecc/chip/mul/overflow.rs
@@ -28,7 +28,7 @@ impl From<&EccConfig> for Config {
     fn from(ecc_config: &EccConfig) -> Self {
         Self {
             q_mul_overflow: ecc_config.q_mul_overflow,
-            lookup_config: ecc_config.lookup_config.clone(),
+            lookup_config: ecc_config.lookup_config,
             // Use advice columns that don't conflict with the either the incomplete
             // additions in fixed-base scalar mul, or the lookup range checks.
             advices: [

--- a/src/circuit/gadget/ecc/chip/mul/overflow.rs
+++ b/src/circuit/gadget/ecc/chip/mul/overflow.rs
@@ -1,4 +1,4 @@
-use super::super::{copy, CellValue, EccConfig, Var};
+use super::super::{copy, CellValue, Var};
 use super::Z;
 use crate::{
     circuit::gadget::utilities::lookup_range_check::LookupRangeCheckConfig, constants::T_Q,
@@ -15,6 +15,7 @@ use pasta_curves::{arithmetic::FieldExt, pallas};
 
 use std::iter;
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Config {
     // Selector to check z_0 = alpha + t_q (mod p)
     q_mul_overflow: Selector,
@@ -24,24 +25,29 @@ pub struct Config {
     advices: [Column<Advice>; 3],
 }
 
-impl From<&EccConfig> for Config {
-    fn from(ecc_config: &EccConfig) -> Self {
-        Self {
-            q_mul_overflow: ecc_config.q_mul_overflow,
-            lookup_config: ecc_config.lookup_config,
-            // Use advice columns that don't conflict with the either the incomplete
-            // additions in fixed-base scalar mul, or the lookup range checks.
-            advices: [
-                ecc_config.advices[6],
-                ecc_config.advices[7],
-                ecc_config.advices[8],
-            ],
-        }
-    }
-}
-
 impl Config {
-    pub(super) fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    // TODO: Make this pub(super).
+    pub(crate) fn configure(
+        meta: &mut ConstraintSystem<pallas::Base>,
+        lookup_config: LookupRangeCheckConfig<pallas::Base, { sinsemilla::K }>,
+        advices: [Column<Advice>; 3],
+    ) -> Self {
+        for advice in advices.iter() {
+            meta.enable_equality((*advice).into());
+        }
+
+        let config = Self {
+            q_mul_overflow: meta.selector(),
+            lookup_config,
+            advices,
+        };
+
+        config.create_gate(meta);
+
+        config
+    }
+
+    fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
         meta.create_gate("overflow checks", |meta| {
             let q_mul_overflow = meta.query_selector(self.q_mul_overflow);
 

--- a/src/circuit/gadget/ecc/chip/mul_fixed.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed.rs
@@ -1,6 +1,6 @@
 use super::{
-    add, add_incomplete, CellValue, EccBaseFieldElemFixed, EccConfig, EccScalarFixed,
-    EccScalarFixedShort, NonIdentityEccPoint, Var,
+    add, add_incomplete, CellValue, EccBaseFieldElemFixed, EccScalarFixed, EccScalarFixedShort,
+    NonIdentityEccPoint, Var,
 };
 use crate::constants::{
     self,
@@ -75,8 +75,8 @@ impl OrchardFixedBases {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct Config<const NUM_WINDOWS: usize> {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Config {
     q_mul_fixed_running_sum: Selector,
     // The fixed Lagrange interpolation coefficients for `x_p`.
     lagrange_coeffs: [Column<Fixed>; constants::H],
@@ -97,18 +97,32 @@ pub struct Config<const NUM_WINDOWS: usize> {
     add_incomplete_config: add_incomplete::Config,
 }
 
-impl<const NUM_WINDOWS: usize> From<&EccConfig> for Config<NUM_WINDOWS> {
-    fn from(ecc_config: &EccConfig) -> Self {
+impl Config {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn configure(
+        meta: &mut ConstraintSystem<pallas::Base>,
+        q_mul_fixed_running_sum: Selector,
+        lagrange_coeffs: [Column<Fixed>; constants::H],
+        window: Column<Advice>,
+        x_p: Column<Advice>,
+        y_p: Column<Advice>,
+        u: Column<Advice>,
+        add_config: add::Config,
+        add_incomplete_config: add_incomplete::Config,
+    ) -> Self {
+        meta.enable_equality(window.into());
+        meta.enable_equality(u.into());
+
         let config = Self {
-            q_mul_fixed_running_sum: ecc_config.q_mul_fixed_running_sum,
-            lagrange_coeffs: ecc_config.lagrange_coeffs,
-            fixed_z: ecc_config.fixed_z,
-            x_p: ecc_config.advices[0],
-            y_p: ecc_config.advices[1],
-            window: ecc_config.advices[4],
-            u: ecc_config.advices[5],
-            add_config: ecc_config.add,
-            add_incomplete_config: ecc_config.add_incomplete,
+            q_mul_fixed_running_sum,
+            lagrange_coeffs,
+            fixed_z: meta.fixed_column(),
+            window,
+            x_p,
+            y_p,
+            u,
+            add_config,
+            add_incomplete_config,
         };
 
         // Check relationships between this config and `add_config`.
@@ -141,11 +155,11 @@ impl<const NUM_WINDOWS: usize> From<&EccConfig> for Config<NUM_WINDOWS> {
             );
         }
 
+        config.running_sum_coords_gate(meta);
+
         config
     }
-}
 
-impl<const NUM_WINDOWS: usize> Config<NUM_WINDOWS> {
     /// Check that each window in the running sum decomposition uses the correct y_p
     /// and interpolated x_p.
     ///
@@ -155,7 +169,7 @@ impl<const NUM_WINDOWS: usize> Config<NUM_WINDOWS> {
     /// This gate is not used in the mul_fixed::full_width helper, since the full-width
     /// scalar is witnessed directly as three-bit windows instead of being decomposed
     /// via a running sum.
-    pub(crate) fn running_sum_coords_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    fn running_sum_coords_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
         meta.create_gate("Running sum coordinates check", |meta| {
             let q_mul_fixed_running_sum = meta.query_selector(self.q_mul_fixed_running_sum);
 
@@ -213,7 +227,7 @@ impl<const NUM_WINDOWS: usize> Config<NUM_WINDOWS> {
     }
 
     #[allow(clippy::type_complexity)]
-    fn assign_region_inner(
+    fn assign_region_inner<const NUM_WINDOWS: usize>(
         &self,
         region: &mut Region<'_, pallas::Base>,
         offset: usize,
@@ -222,7 +236,7 @@ impl<const NUM_WINDOWS: usize> Config<NUM_WINDOWS> {
         coords_check_toggle: Selector,
     ) -> Result<(NonIdentityEccPoint, NonIdentityEccPoint), Error> {
         // Assign fixed columns for given fixed base
-        self.assign_fixed_constants(region, offset, base, coords_check_toggle)?;
+        self.assign_fixed_constants::<NUM_WINDOWS>(region, offset, base, coords_check_toggle)?;
 
         // Initialize accumulator
         let acc = self.initialize_accumulator(region, offset, base, scalar)?;
@@ -231,12 +245,12 @@ impl<const NUM_WINDOWS: usize> Config<NUM_WINDOWS> {
         let acc = self.add_incomplete(region, offset, acc, base, scalar)?;
 
         // Process most significant window using complete addition
-        let mul_b = self.process_msb(region, offset, base, scalar)?;
+        let mul_b = self.process_msb::<NUM_WINDOWS>(region, offset, base, scalar)?;
 
         Ok((acc, mul_b))
     }
 
-    fn assign_fixed_constants(
+    fn assign_fixed_constants<const NUM_WINDOWS: usize>(
         &self,
         region: &mut Region<'_, pallas::Base>,
         offset: usize,
@@ -411,7 +425,7 @@ impl<const NUM_WINDOWS: usize> Config<NUM_WINDOWS> {
         Ok(acc)
     }
 
-    fn process_msb(
+    fn process_msb<const NUM_WINDOWS: usize>(
         &self,
         region: &mut Region<'_, pallas::Base>,
         offset: usize,

--- a/src/circuit/gadget/ecc/chip/mul_fixed.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed.rs
@@ -108,7 +108,7 @@ impl<const NUM_WINDOWS: usize> From<&EccConfig> for Config<NUM_WINDOWS> {
             window: ecc_config.advices[4],
             u: ecc_config.advices[5],
             add_config: ecc_config.into(),
-            add_incomplete_config: ecc_config.into(),
+            add_incomplete_config: ecc_config.add_incomplete,
         };
 
         // Check relationships between this config and `add_config`.

--- a/src/circuit/gadget/ecc/chip/mul_fixed.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed.rs
@@ -107,7 +107,7 @@ impl<const NUM_WINDOWS: usize> From<&EccConfig> for Config<NUM_WINDOWS> {
             y_p: ecc_config.advices[1],
             window: ecc_config.advices[4],
             u: ecc_config.advices[5],
-            add_config: ecc_config.into(),
+            add_config: ecc_config.add,
             add_incomplete_config: ecc_config.add_incomplete,
         };
 

--- a/src/circuit/gadget/ecc/chip/mul_fixed/base_field_elem.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/base_field_elem.rs
@@ -1,4 +1,4 @@
-use super::super::{EccBaseFieldElemFixed, EccConfig, EccPoint, NullifierK};
+use super::super::{EccBaseFieldElemFixed, EccPoint, NullifierK};
 use super::H_BASE;
 
 use crate::{
@@ -18,6 +18,7 @@ use pasta_curves::{arithmetic::FieldExt, pallas};
 
 use std::convert::TryInto;
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Config {
     q_mul_fixed_base_field: Selector,
     canon_advices: [Column<Advice>; 3],
@@ -25,13 +26,22 @@ pub struct Config {
     super_config: super::Config,
 }
 
-impl From<&EccConfig> for Config {
-    fn from(config: &EccConfig) -> Self {
+impl Config {
+    pub(crate) fn configure(
+        meta: &mut ConstraintSystem<pallas::Base>,
+        canon_advices: [Column<Advice>; 3],
+        lookup_config: LookupRangeCheckConfig<pallas::Base, { sinsemilla::K }>,
+        super_config: super::Config,
+    ) -> Self {
+        for advice in canon_advices.iter() {
+            meta.enable_equality((*advice).into());
+        }
+
         let config = Self {
-            q_mul_fixed_base_field: config.q_mul_fixed_base_field,
-            canon_advices: [config.advices[6], config.advices[7], config.advices[8]],
-            lookup_config: config.lookup_config,
-            super_config: config.mul_fixed,
+            q_mul_fixed_base_field: meta.selector(),
+            canon_advices,
+            lookup_config,
+            super_config,
         };
 
         let add_incomplete_advices = config.super_config.add_incomplete_config.advice_columns();
@@ -42,12 +52,12 @@ impl From<&EccConfig> for Config {
             );
         }
 
+        config.create_gate(meta);
+
         config
     }
-}
 
-impl Config {
-    pub fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
         // Check that the base field element is canonical.
         meta.create_gate("Canonicity checks", |meta| {
             let q_mul_fixed_base_field = meta.query_selector(self.q_mul_fixed_base_field);

--- a/src/circuit/gadget/ecc/chip/mul_fixed/base_field_elem.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/base_field_elem.rs
@@ -24,7 +24,7 @@ pub struct Config {
     canon_advices: [Column<Advice>; 3],
     lookup_config: LookupRangeCheckConfig<pallas::Base, { sinsemilla::K }>,
     running_sum_config: RunningSumConfig<pallas::Base, { constants::FIXED_BASE_WINDOW_SIZE }>,
-    super_config: super::Config<{ constants::NUM_WINDOWS }>,
+    super_config: super::Config,
 }
 
 impl From<&EccConfig> for Config {
@@ -35,7 +35,7 @@ impl From<&EccConfig> for Config {
             canon_advices: [config.advices[6], config.advices[7], config.advices[8]],
             lookup_config: config.lookup_config,
             running_sum_config: config.running_sum_config.clone(),
-            super_config: config.into(),
+            super_config: config.mul_fixed,
         };
 
         let add_incomplete_advices = config.super_config.add_incomplete_config.advice_columns();
@@ -180,13 +180,15 @@ impl Config {
                     }
                 };
 
-                let (acc, mul_b) = self.super_config.assign_region_inner(
-                    &mut region,
-                    offset,
-                    &(&scalar).into(),
-                    base.into(),
-                    self.q_mul_fixed_running_sum,
-                )?;
+                let (acc, mul_b) = self
+                    .super_config
+                    .assign_region_inner::<{ constants::NUM_WINDOWS }>(
+                        &mut region,
+                        offset,
+                        &(&scalar).into(),
+                        base.into(),
+                        self.q_mul_fixed_running_sum,
+                    )?;
 
                 Ok((scalar, acc, mul_b))
             },

--- a/src/circuit/gadget/ecc/chip/mul_fixed/base_field_elem.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/base_field_elem.rs
@@ -33,7 +33,7 @@ impl From<&EccConfig> for Config {
             q_mul_fixed_running_sum: config.q_mul_fixed_running_sum,
             q_mul_fixed_base_field: config.q_mul_fixed_base_field,
             canon_advices: [config.advices[6], config.advices[7], config.advices[8]],
-            lookup_config: config.lookup_config.clone(),
+            lookup_config: config.lookup_config,
             running_sum_config: config.running_sum_config.clone(),
             super_config: config.into(),
         };

--- a/src/circuit/gadget/ecc/chip/mul_fixed/full_width.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/full_width.rs
@@ -14,14 +14,14 @@ use pasta_curves::{arithmetic::FieldExt, pallas};
 
 pub struct Config {
     q_mul_fixed_full: Selector,
-    super_config: super::Config<NUM_WINDOWS>,
+    super_config: super::Config,
 }
 
 impl From<&EccConfig> for Config {
     fn from(config: &EccConfig) -> Self {
         Self {
             q_mul_fixed_full: config.q_mul_fixed_full,
-            super_config: config.into(),
+            super_config: config.mul_fixed,
         }
     }
 }
@@ -124,7 +124,7 @@ impl Config {
 
                 let scalar = self.witness(&mut region, offset, scalar)?;
 
-                let (acc, mul_b) = self.super_config.assign_region_inner(
+                let (acc, mul_b) = self.super_config.assign_region_inner::<NUM_WINDOWS>(
                     &mut region,
                     offset,
                     &(&scalar).into(),

--- a/src/circuit/gadget/ecc/chip/mul_fixed/full_width.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/full_width.rs
@@ -124,13 +124,15 @@ impl Config {
 
                 let scalar = self.witness(&mut region, offset, scalar)?;
 
-                let (acc, mul_b) = self.super_config.assign_region_inner::<NUM_WINDOWS>(
-                    &mut region,
-                    offset,
-                    &(&scalar).into(),
-                    base.into(),
-                    self.q_mul_fixed_full,
-                )?;
+                let (acc, mul_b) = self
+                    .super_config
+                    .assign_region_inner::<{ constants::NUM_WINDOWS }>(
+                        &mut region,
+                        offset,
+                        &(&scalar).into(),
+                        base.into(),
+                        self.q_mul_fixed_full,
+                    )?;
 
                 Ok((scalar, acc, mul_b))
             },

--- a/src/circuit/gadget/ecc/chip/mul_fixed/full_width.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/full_width.rs
@@ -1,4 +1,4 @@
-use super::super::{EccConfig, EccPoint, EccScalarFixed, OrchardFixedBasesFull};
+use super::super::{EccPoint, EccScalarFixed, OrchardFixedBasesFull};
 
 use crate::{
     circuit::gadget::utilities::{range_check, CellValue, Var},
@@ -12,22 +12,28 @@ use halo2::{
 };
 use pasta_curves::{arithmetic::FieldExt, pallas};
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Config {
     q_mul_fixed_full: Selector,
     super_config: super::Config,
 }
 
-impl From<&EccConfig> for Config {
-    fn from(config: &EccConfig) -> Self {
-        Self {
-            q_mul_fixed_full: config.q_mul_fixed_full,
-            super_config: config.mul_fixed,
-        }
-    }
-}
-
 impl Config {
-    pub fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    pub(crate) fn configure(
+        meta: &mut ConstraintSystem<pallas::Base>,
+        super_config: super::Config,
+    ) -> Self {
+        let config = Self {
+            q_mul_fixed_full: meta.selector(),
+            super_config,
+        };
+
+        config.create_gate(meta);
+
+        config
+    }
+
+    fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
         // Check that each window `k` is within 3 bits
         meta.create_gate("Full-width fixed-base scalar mul", |meta| {
             let q_mul_fixed_full = meta.query_selector(self.q_mul_fixed_full);

--- a/src/circuit/gadget/ecc/chip/mul_fixed/short.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/short.rs
@@ -21,7 +21,7 @@ pub struct Config {
     q_mul_fixed_short: Selector,
     q_mul_fixed_running_sum: Selector,
     running_sum_config: RunningSumConfig<pallas::Base, { FIXED_BASE_WINDOW_SIZE }>,
-    super_config: super::Config<NUM_WINDOWS_SHORT>,
+    super_config: super::Config,
 }
 
 impl From<&EccConfig> for Config {
@@ -30,7 +30,7 @@ impl From<&EccConfig> for Config {
             q_mul_fixed_short: config.q_mul_fixed_short,
             q_mul_fixed_running_sum: config.q_mul_fixed_running_sum,
             running_sum_config: config.running_sum_config.clone(),
-            super_config: config.into(),
+            super_config: config.mul_fixed,
         }
     }
 }
@@ -110,7 +110,7 @@ impl Config {
                 // Decompose the scalar
                 let scalar = self.decompose(&mut region, offset, magnitude_sign)?;
 
-                let (acc, mul_b) = self.super_config.assign_region_inner(
+                let (acc, mul_b) = self.super_config.assign_region_inner::<NUM_WINDOWS_SHORT>(
                     &mut region,
                     offset,
                     &(&scalar).into(),

--- a/src/circuit/gadget/sinsemilla.rs
+++ b/src/circuit/gadget/sinsemilla.rs
@@ -487,8 +487,7 @@ mod tests {
 
             let range_check = LookupRangeCheckConfig::configure(meta, advices[9], table_idx);
 
-            let ecc_config =
-                EccChip::configure(meta, advices, lagrange_coeffs, range_check.clone());
+            let ecc_config = EccChip::configure(meta, advices, lagrange_coeffs, range_check);
 
             let config1 = SinsemillaChip::configure(
                 meta,
@@ -496,7 +495,7 @@ mod tests {
                 advices[2],
                 lagrange_coeffs[0],
                 lookup,
-                range_check.clone(),
+                range_check,
             );
             let config2 = SinsemillaChip::configure(
                 meta,

--- a/src/circuit/gadget/sinsemilla/commit_ivk.rs
+++ b/src/circuit/gadget/sinsemilla/commit_ivk.rs
@@ -722,7 +722,7 @@ mod tests {
                     advices[2],
                     lagrange_coeffs[0],
                     lookup,
-                    range_check.clone(),
+                    range_check,
                 );
 
                 let commit_ivk_config =

--- a/src/circuit/gadget/sinsemilla/merkle.rs
+++ b/src/circuit/gadget/sinsemilla/merkle.rs
@@ -210,7 +210,7 @@ pub mod tests {
                 advices[7],
                 fixed_y_q_1,
                 lookup,
-                range_check.clone(),
+                range_check,
             );
             let config1 = MerkleChip::configure(meta, sinsemilla_config_1);
 

--- a/src/circuit/gadget/sinsemilla/note_commit.rs
+++ b/src/circuit/gadget/sinsemilla/note_commit.rs
@@ -1528,7 +1528,7 @@ mod tests {
                     advices[2],
                     lagrange_coeffs[0],
                     lookup,
-                    range_check.clone(),
+                    range_check,
                 );
                 let note_commit_config =
                     NoteCommitConfig::configure(meta, advices, sinsemilla_config);

--- a/src/circuit/gadget/utilities/decompose_running_sum.rs
+++ b/src/circuit/gadget/utilities/decompose_running_sum.rs
@@ -44,9 +44,9 @@ impl<F: FieldExt + PrimeFieldBits> std::ops::Deref for RunningSum<F> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct RunningSumConfig<F: FieldExt + PrimeFieldBits, const WINDOW_NUM_BITS: usize> {
-    q_range_check: Selector,
+    pub q_range_check: Selector,
     pub z: Column<Advice>,
     _marker: PhantomData<F>,
 }

--- a/src/circuit/gadget/utilities/lookup_range_check.rs
+++ b/src/circuit/gadget/utilities/lookup_range_check.rs
@@ -23,7 +23,7 @@ impl<F: FieldExt + PrimeFieldBits> std::ops::Deref for RunningSum<F> {
     }
 }
 
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Clone, Copy)]
 pub struct LookupRangeCheckConfig<F: FieldExt + PrimeFieldBits, const K: usize> {
     pub q_lookup: Selector,
     pub q_running: Selector,

--- a/src/circuit_description
+++ b/src/circuit_description
@@ -45,23 +45,27 @@ PinnedVerificationKey {
                 column_type: Fixed,
             },
             Column {
-                index: 18,
-                column_type: Fixed,
-            },
-            Column {
-                index: 18,
-                column_type: Fixed,
-            },
-            Column {
-                index: 18,
-                column_type: Fixed,
-            },
-            Column {
                 index: 20,
                 column_type: Fixed,
             },
             Column {
                 index: 20,
+                column_type: Fixed,
+            },
+            Column {
+                index: 18,
+                column_type: Fixed,
+            },
+            Column {
+                index: 18,
+                column_type: Fixed,
+            },
+            Column {
+                index: 18,
+                column_type: Fixed,
+            },
+            Column {
+                index: 21,
                 column_type: Fixed,
             },
             Column {
@@ -85,23 +89,19 @@ PinnedVerificationKey {
                 column_type: Fixed,
             },
             Column {
-                index: 21,
-                column_type: Fixed,
-            },
-            Column {
                 index: 23,
                 column_type: Fixed,
             },
             Column {
-                index: 23,
+                index: 22,
                 column_type: Fixed,
             },
             Column {
-                index: 23,
+                index: 22,
                 column_type: Fixed,
             },
             Column {
-                index: 23,
+                index: 22,
                 column_type: Fixed,
             },
             Column {
@@ -1186,20 +1186,20 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
                                 },
                                 Sum(
                                     Constant(
-                                        0x0000000000000000000000000000000000000000000000000000000000000001,
+                                        0x0000000000000000000000000000000000000000000000000000000000000002,
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 23,
-                                            column_index: 23,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -1213,8 +1213,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 23,
-                                        column_index: 23,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -1228,8 +1228,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -1304,20 +1304,20 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
                                 },
                                 Sum(
                                     Constant(
-                                        0x0000000000000000000000000000000000000000000000000000000000000001,
+                                        0x0000000000000000000000000000000000000000000000000000000000000002,
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 23,
-                                            column_index: 23,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -1331,8 +1331,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 23,
-                                        column_index: 23,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -1346,8 +1346,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -1421,8 +1421,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -1433,8 +1433,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 23,
-                                        column_index: 23,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -1444,12 +1444,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000002,
+                                0x0000000000000000000000000000000000000000000000000000000000000003,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -1463,8 +1463,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -1538,7 +1538,7 @@ PinnedVerificationKey {
                             },
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
                                 ),
                                 Negated(
                                     Fixed {
@@ -1553,7 +1553,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
@@ -1702,7 +1702,7 @@ PinnedVerificationKey {
                             },
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
                                 ),
                                 Negated(
                                     Fixed {
@@ -1717,7 +1717,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
@@ -1852,7 +1852,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
@@ -1867,7 +1867,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                            0x0000000000000000000000000000000000000000000000000000000000000003,
                         ),
                         Negated(
                             Fixed {
@@ -1978,7 +1978,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
@@ -1993,7 +1993,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                            0x0000000000000000000000000000000000000000000000000000000000000003,
                         ),
                         Negated(
                             Fixed {
@@ -2117,7 +2117,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
@@ -2132,7 +2132,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                            0x0000000000000000000000000000000000000000000000000000000000000003,
                         ),
                         Negated(
                             Fixed {
@@ -2261,7 +2261,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
@@ -2276,7 +2276,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                            0x0000000000000000000000000000000000000000000000000000000000000003,
                         ),
                         Negated(
                             Fixed {
@@ -2405,7 +2405,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
@@ -2420,7 +2420,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                            0x0000000000000000000000000000000000000000000000000000000000000003,
                         ),
                         Negated(
                             Fixed {
@@ -2547,7 +2547,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
@@ -2562,7 +2562,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                            0x0000000000000000000000000000000000000000000000000000000000000003,
                         ),
                         Negated(
                             Fixed {
@@ -2689,7 +2689,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
@@ -2704,7 +2704,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                            0x0000000000000000000000000000000000000000000000000000000000000003,
                         ),
                         Negated(
                             Fixed {
@@ -2789,7 +2789,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
@@ -2804,7 +2804,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                            0x0000000000000000000000000000000000000000000000000000000000000003,
                         ),
                         Negated(
                             Fixed {
@@ -2889,7 +2889,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
@@ -2904,7 +2904,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                            0x0000000000000000000000000000000000000000000000000000000000000003,
                         ),
                         Negated(
                             Fixed {
@@ -2989,7 +2989,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
@@ -3004,7 +3004,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                            0x0000000000000000000000000000000000000000000000000000000000000003,
                         ),
                         Negated(
                             Fixed {
@@ -3089,7 +3089,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
@@ -3104,7 +3104,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                            0x0000000000000000000000000000000000000000000000000000000000000003,
                         ),
                         Negated(
                             Fixed {
@@ -3218,7 +3218,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
@@ -3233,7 +3233,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                            0x0000000000000000000000000000000000000000000000000000000000000003,
                         ),
                         Negated(
                             Fixed {
@@ -3323,37 +3323,21 @@ PinnedVerificationKey {
                 Product(
                     Product(
                         Product(
-                            Product(
-                                Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                                Sum(
-                                    Constant(
-                                        0x0000000000000000000000000000000000000000000000000000000000000001,
-                                    ),
-                                    Negated(
-                                        Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
-                                            rotation: Rotation(
-                                                0,
-                                            ),
-                                        },
-                                    ),
+                            Fixed {
+                                query_index: 22,
+                                column_index: 22,
+                                rotation: Rotation(
+                                    0,
                                 ),
-                            ),
+                            },
                             Sum(
                                 Constant(
                                     0x0000000000000000000000000000000000000000000000000000000000000002,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -3367,8 +3351,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -3378,12 +3362,12 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000005,
+                            0x0000000000000000000000000000000000000000000000000000000000000004,
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -3447,37 +3431,21 @@ PinnedVerificationKey {
                 Product(
                     Product(
                         Product(
-                            Product(
-                                Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                                Sum(
-                                    Constant(
-                                        0x0000000000000000000000000000000000000000000000000000000000000001,
-                                    ),
-                                    Negated(
-                                        Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
-                                            rotation: Rotation(
-                                                0,
-                                            ),
-                                        },
-                                    ),
+                            Fixed {
+                                query_index: 22,
+                                column_index: 22,
+                                rotation: Rotation(
+                                    0,
                                 ),
-                            ),
+                            },
                             Sum(
                                 Constant(
                                     0x0000000000000000000000000000000000000000000000000000000000000002,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -3491,8 +3459,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -3502,12 +3470,12 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000005,
+                            0x0000000000000000000000000000000000000000000000000000000000000004,
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -3600,37 +3568,21 @@ PinnedVerificationKey {
                 Product(
                     Product(
                         Product(
-                            Product(
-                                Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                                Sum(
-                                    Constant(
-                                        0x0000000000000000000000000000000000000000000000000000000000000001,
-                                    ),
-                                    Negated(
-                                        Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
-                                            rotation: Rotation(
-                                                0,
-                                            ),
-                                        },
-                                    ),
+                            Fixed {
+                                query_index: 22,
+                                column_index: 22,
+                                rotation: Rotation(
+                                    0,
                                 ),
-                            ),
+                            },
                             Sum(
                                 Constant(
                                     0x0000000000000000000000000000000000000000000000000000000000000002,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -3644,8 +3596,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -3655,12 +3607,12 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000005,
+                            0x0000000000000000000000000000000000000000000000000000000000000004,
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -5682,21 +5634,37 @@ PinnedVerificationKey {
                 Product(
                     Product(
                         Product(
-                            Fixed {
-                                query_index: 20,
-                                column_index: 20,
-                                rotation: Rotation(
-                                    0,
+                            Product(
+                                Fixed {
+                                    query_index: 21,
+                                    column_index: 21,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                                Sum(
+                                    Constant(
+                                        0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    ),
+                                    Negated(
+                                        Fixed {
+                                            query_index: 21,
+                                            column_index: 21,
+                                            rotation: Rotation(
+                                                0,
+                                            ),
+                                        },
+                                    ),
                                 ),
-                            },
+                            ),
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000001,
+                                    0x0000000000000000000000000000000000000000000000000000000000000003,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -5706,12 +5674,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000002,
+                                0x0000000000000000000000000000000000000000000000000000000000000004,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -5721,12 +5689,12 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                            0x0000000000000000000000000000000000000000000000000000000000000005,
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -5820,21 +5788,37 @@ PinnedVerificationKey {
                 Product(
                     Product(
                         Product(
-                            Fixed {
-                                query_index: 20,
-                                column_index: 20,
-                                rotation: Rotation(
-                                    0,
+                            Product(
+                                Fixed {
+                                    query_index: 21,
+                                    column_index: 21,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                                Sum(
+                                    Constant(
+                                        0x0000000000000000000000000000000000000000000000000000000000000001,
+                                    ),
+                                    Negated(
+                                        Fixed {
+                                            query_index: 21,
+                                            column_index: 21,
+                                            rotation: Rotation(
+                                                0,
+                                            ),
+                                        },
+                                    ),
                                 ),
-                            },
+                            ),
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000001,
+                                    0x0000000000000000000000000000000000000000000000000000000000000003,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -5844,12 +5828,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000002,
+                                0x0000000000000000000000000000000000000000000000000000000000000004,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -5859,12 +5843,12 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000003,
+                            0x0000000000000000000000000000000000000000000000000000000000000005,
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -5895,21 +5879,37 @@ PinnedVerificationKey {
                 Product(
                     Product(
                         Product(
-                            Fixed {
-                                query_index: 20,
-                                column_index: 20,
-                                rotation: Rotation(
-                                    0,
+                            Product(
+                                Fixed {
+                                    query_index: 21,
+                                    column_index: 21,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                                Sum(
+                                    Constant(
+                                        0x0000000000000000000000000000000000000000000000000000000000000001,
+                                    ),
+                                    Negated(
+                                        Fixed {
+                                            query_index: 21,
+                                            column_index: 21,
+                                            rotation: Rotation(
+                                                0,
+                                            ),
+                                        },
+                                    ),
                                 ),
-                            },
+                            ),
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000001,
+                                    0x0000000000000000000000000000000000000000000000000000000000000003,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -5919,12 +5919,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000002,
+                                0x0000000000000000000000000000000000000000000000000000000000000004,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -5934,12 +5934,12 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000003,
+                            0x0000000000000000000000000000000000000000000000000000000000000005,
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -5970,21 +5970,37 @@ PinnedVerificationKey {
                 Product(
                     Product(
                         Product(
-                            Fixed {
-                                query_index: 20,
-                                column_index: 20,
-                                rotation: Rotation(
-                                    0,
+                            Product(
+                                Fixed {
+                                    query_index: 21,
+                                    column_index: 21,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                                Sum(
+                                    Constant(
+                                        0x0000000000000000000000000000000000000000000000000000000000000001,
+                                    ),
+                                    Negated(
+                                        Fixed {
+                                            query_index: 21,
+                                            column_index: 21,
+                                            rotation: Rotation(
+                                                0,
+                                            ),
+                                        },
+                                    ),
                                 ),
-                            },
+                            ),
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000001,
+                                    0x0000000000000000000000000000000000000000000000000000000000000003,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -5994,12 +6010,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000002,
+                                0x0000000000000000000000000000000000000000000000000000000000000004,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -6009,12 +6025,12 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000003,
+                            0x0000000000000000000000000000000000000000000000000000000000000005,
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -6078,21 +6094,37 @@ PinnedVerificationKey {
                 Product(
                     Product(
                         Product(
-                            Fixed {
-                                query_index: 20,
-                                column_index: 20,
-                                rotation: Rotation(
-                                    0,
+                            Product(
+                                Fixed {
+                                    query_index: 21,
+                                    column_index: 21,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                                Sum(
+                                    Constant(
+                                        0x0000000000000000000000000000000000000000000000000000000000000001,
+                                    ),
+                                    Negated(
+                                        Fixed {
+                                            query_index: 21,
+                                            column_index: 21,
+                                            rotation: Rotation(
+                                                0,
+                                            ),
+                                        },
+                                    ),
                                 ),
-                            },
+                            ),
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000001,
+                                    0x0000000000000000000000000000000000000000000000000000000000000003,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -6102,12 +6134,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000002,
+                                0x0000000000000000000000000000000000000000000000000000000000000004,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -6117,12 +6149,12 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000003,
+                            0x0000000000000000000000000000000000000000000000000000000000000005,
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -6278,21 +6310,37 @@ PinnedVerificationKey {
                 Product(
                     Product(
                         Product(
-                            Fixed {
-                                query_index: 20,
-                                column_index: 20,
-                                rotation: Rotation(
-                                    0,
+                            Product(
+                                Fixed {
+                                    query_index: 21,
+                                    column_index: 21,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                                Sum(
+                                    Constant(
+                                        0x0000000000000000000000000000000000000000000000000000000000000001,
+                                    ),
+                                    Negated(
+                                        Fixed {
+                                            query_index: 21,
+                                            column_index: 21,
+                                            rotation: Rotation(
+                                                0,
+                                            ),
+                                        },
+                                    ),
                                 ),
-                            },
+                            ),
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000001,
+                                    0x0000000000000000000000000000000000000000000000000000000000000003,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -6302,12 +6350,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000002,
+                                0x0000000000000000000000000000000000000000000000000000000000000004,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -6317,12 +6365,12 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000003,
+                            0x0000000000000000000000000000000000000000000000000000000000000005,
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -6415,21 +6463,37 @@ PinnedVerificationKey {
                 Product(
                     Product(
                         Product(
-                            Fixed {
-                                query_index: 20,
-                                column_index: 20,
-                                rotation: Rotation(
-                                    0,
+                            Product(
+                                Fixed {
+                                    query_index: 21,
+                                    column_index: 21,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                                Sum(
+                                    Constant(
+                                        0x0000000000000000000000000000000000000000000000000000000000000001,
+                                    ),
+                                    Negated(
+                                        Fixed {
+                                            query_index: 21,
+                                            column_index: 21,
+                                            rotation: Rotation(
+                                                0,
+                                            ),
+                                        },
+                                    ),
                                 ),
-                            },
+                            ),
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000001,
+                                    0x0000000000000000000000000000000000000000000000000000000000000003,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -6439,12 +6503,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000002,
+                                0x0000000000000000000000000000000000000000000000000000000000000004,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -6454,12 +6518,12 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000003,
+                            0x0000000000000000000000000000000000000000000000000000000000000005,
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -6657,7 +6721,7 @@ PinnedVerificationKey {
                                 },
                                 Sum(
                                     Constant(
-                                        0x0000000000000000000000000000000000000000000000000000000000000002,
+                                        0x0000000000000000000000000000000000000000000000000000000000000001,
                                     ),
                                     Negated(
                                         Fixed {
@@ -6672,7 +6736,7 @@ PinnedVerificationKey {
                             ),
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000003,
+                                    0x0000000000000000000000000000000000000000000000000000000000000002,
                                 ),
                                 Negated(
                                     Fixed {
@@ -6781,7 +6845,7 @@ PinnedVerificationKey {
                                 },
                                 Sum(
                                     Constant(
-                                        0x0000000000000000000000000000000000000000000000000000000000000002,
+                                        0x0000000000000000000000000000000000000000000000000000000000000001,
                                     ),
                                     Negated(
                                         Fixed {
@@ -6796,7 +6860,7 @@ PinnedVerificationKey {
                             ),
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000003,
+                                    0x0000000000000000000000000000000000000000000000000000000000000002,
                                 ),
                                 Negated(
                                     Fixed {
@@ -6997,7 +7061,7 @@ PinnedVerificationKey {
                                 },
                                 Sum(
                                     Constant(
-                                        0x0000000000000000000000000000000000000000000000000000000000000002,
+                                        0x0000000000000000000000000000000000000000000000000000000000000001,
                                     ),
                                     Negated(
                                         Fixed {
@@ -7012,7 +7076,7 @@ PinnedVerificationKey {
                             ),
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000003,
+                                    0x0000000000000000000000000000000000000000000000000000000000000002,
                                 ),
                                 Negated(
                                     Fixed {
@@ -7150,7 +7214,7 @@ PinnedVerificationKey {
                                 },
                                 Sum(
                                     Constant(
-                                        0x0000000000000000000000000000000000000000000000000000000000000002,
+                                        0x0000000000000000000000000000000000000000000000000000000000000001,
                                     ),
                                     Negated(
                                         Fixed {
@@ -7165,7 +7229,7 @@ PinnedVerificationKey {
                             ),
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000003,
+                                    0x0000000000000000000000000000000000000000000000000000000000000002,
                                 ),
                                 Negated(
                                     Fixed {
@@ -7350,7 +7414,7 @@ PinnedVerificationKey {
                             ),
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000003,
+                                    0x0000000000000000000000000000000000000000000000000000000000000002,
                                 ),
                                 Negated(
                                     Fixed {
@@ -7365,7 +7429,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000004,
+                                0x0000000000000000000000000000000000000000000000000000000000000003,
                             ),
                             Negated(
                                 Fixed {
@@ -7478,7 +7542,7 @@ PinnedVerificationKey {
                             ),
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000003,
+                                    0x0000000000000000000000000000000000000000000000000000000000000002,
                                 ),
                                 Negated(
                                     Fixed {
@@ -7493,7 +7557,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000004,
+                                0x0000000000000000000000000000000000000000000000000000000000000003,
                             ),
                             Negated(
                                 Fixed {
@@ -7659,7 +7723,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000004,
+                                0x0000000000000000000000000000000000000000000000000000000000000003,
                             ),
                             Negated(
                                 Fixed {
@@ -7674,7 +7738,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000005,
+                            0x0000000000000000000000000000000000000000000000000000000000000004,
                         ),
                         Negated(
                             Fixed {
@@ -7769,7 +7833,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000004,
+                                0x0000000000000000000000000000000000000000000000000000000000000003,
                             ),
                             Negated(
                                 Fixed {
@@ -7784,7 +7848,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000005,
+                            0x0000000000000000000000000000000000000000000000000000000000000004,
                         ),
                         Negated(
                             Fixed {
@@ -7867,7 +7931,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000004,
+                                0x0000000000000000000000000000000000000000000000000000000000000003,
                             ),
                             Negated(
                                 Fixed {
@@ -7882,7 +7946,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000005,
+                            0x0000000000000000000000000000000000000000000000000000000000000004,
                         ),
                         Negated(
                             Fixed {
@@ -7963,7 +8027,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000004,
+                                0x0000000000000000000000000000000000000000000000000000000000000003,
                             ),
                             Negated(
                                 Fixed {
@@ -7978,7 +8042,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000005,
+                            0x0000000000000000000000000000000000000000000000000000000000000004,
                         ),
                         Negated(
                             Fixed {
@@ -8052,7 +8116,7 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000004,
+                                0x0000000000000000000000000000000000000000000000000000000000000003,
                             ),
                             Negated(
                                 Fixed {
@@ -8067,7 +8131,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000005,
+                            0x0000000000000000000000000000000000000000000000000000000000000004,
                         ),
                         Negated(
                             Fixed {
@@ -9018,8 +9082,8 @@ PinnedVerificationKey {
             ),
             Product(
                 Fixed {
-                    query_index: 22,
-                    column_index: 22,
+                    query_index: 23,
+                    column_index: 23,
                     rotation: Rotation(
                         0,
                     ),
@@ -9405,8 +9469,8 @@ PinnedVerificationKey {
             ),
             Product(
                 Fixed {
-                    query_index: 22,
-                    column_index: 22,
+                    query_index: 23,
+                    column_index: 23,
                     rotation: Rotation(
                         0,
                     ),
@@ -9452,8 +9516,8 @@ PinnedVerificationKey {
             ),
             Product(
                 Fixed {
-                    query_index: 22,
-                    column_index: 22,
+                    query_index: 23,
+                    column_index: 23,
                     rotation: Rotation(
                         0,
                     ),
@@ -9513,8 +9577,8 @@ PinnedVerificationKey {
             ),
             Product(
                 Fixed {
-                    query_index: 22,
-                    column_index: 22,
+                    query_index: 23,
+                    column_index: 23,
                     rotation: Rotation(
                         0,
                     ),
@@ -9643,37 +9707,21 @@ PinnedVerificationKey {
                 Product(
                     Product(
                         Product(
-                            Product(
-                                Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                                Sum(
-                                    Constant(
-                                        0x0000000000000000000000000000000000000000000000000000000000000001,
-                                    ),
-                                    Negated(
-                                        Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
-                                            rotation: Rotation(
-                                                0,
-                                            ),
-                                        },
-                                    ),
+                            Fixed {
+                                query_index: 22,
+                                column_index: 22,
+                                rotation: Rotation(
+                                    0,
                                 ),
-                            ),
+                            },
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -9687,8 +9735,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -9702,8 +9750,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -9739,37 +9787,21 @@ PinnedVerificationKey {
                 Product(
                     Product(
                         Product(
-                            Product(
-                                Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                                Sum(
-                                    Constant(
-                                        0x0000000000000000000000000000000000000000000000000000000000000001,
-                                    ),
-                                    Negated(
-                                        Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
-                                            rotation: Rotation(
-                                                0,
-                                            ),
-                                        },
-                                    ),
+                            Fixed {
+                                query_index: 22,
+                                column_index: 22,
+                                rotation: Rotation(
+                                    0,
                                 ),
-                            ),
+                            },
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -9783,8 +9815,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -9798,8 +9830,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -9835,37 +9867,21 @@ PinnedVerificationKey {
                 Product(
                     Product(
                         Product(
-                            Product(
-                                Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                                Sum(
-                                    Constant(
-                                        0x0000000000000000000000000000000000000000000000000000000000000001,
-                                    ),
-                                    Negated(
-                                        Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
-                                            rotation: Rotation(
-                                                0,
-                                            ),
-                                        },
-                                    ),
+                            Fixed {
+                                query_index: 22,
+                                column_index: 22,
+                                rotation: Rotation(
+                                    0,
                                 ),
-                            ),
+                            },
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -9879,8 +9895,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -9894,8 +9910,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -9944,37 +9960,21 @@ PinnedVerificationKey {
                 Product(
                     Product(
                         Product(
-                            Product(
-                                Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                                Sum(
-                                    Constant(
-                                        0x0000000000000000000000000000000000000000000000000000000000000001,
-                                    ),
-                                    Negated(
-                                        Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
-                                            rotation: Rotation(
-                                                0,
-                                            ),
-                                        },
-                                    ),
+                            Fixed {
+                                query_index: 22,
+                                column_index: 22,
+                                rotation: Rotation(
+                                    0,
                                 ),
-                            ),
+                            },
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -9988,8 +9988,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10003,8 +10003,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10045,20 +10045,20 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
                             },
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 23,
-                                        column_index: 23,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10068,12 +10068,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10087,8 +10087,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10118,20 +10118,20 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
                             },
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 23,
-                                        column_index: 23,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10141,12 +10141,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10160,8 +10160,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10207,20 +10207,20 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
                             },
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 23,
-                                        column_index: 23,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10230,12 +10230,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10249,8 +10249,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10324,20 +10324,20 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
                             },
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 23,
-                                        column_index: 23,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10347,12 +10347,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10366,8 +10366,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10397,20 +10397,20 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
                             },
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 23,
-                                        column_index: 23,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10420,12 +10420,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10439,8 +10439,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10509,20 +10509,20 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
                             },
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 23,
-                                        column_index: 23,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10532,12 +10532,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10551,8 +10551,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10589,20 +10589,20 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
                             },
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 23,
-                                        column_index: 23,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10612,12 +10612,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10631,8 +10631,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10676,20 +10676,20 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
                             },
                             Sum(
                                 Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 23,
-                                        column_index: 23,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10699,12 +10699,12 @@ PinnedVerificationKey {
                         ),
                         Sum(
                             Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10718,8 +10718,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10777,8 +10777,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10789,8 +10789,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 23,
-                                        column_index: 23,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10804,8 +10804,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10819,8 +10819,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -11122,8 +11122,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -11134,8 +11134,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 23,
-                                        column_index: 23,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -11149,8 +11149,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -11164,8 +11164,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -11467,8 +11467,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -11479,8 +11479,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 23,
-                                        column_index: 23,
+                                        query_index: 22,
+                                        column_index: 22,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -11494,8 +11494,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 23,
-                                    column_index: 23,
+                                    query_index: 22,
+                                    column_index: 22,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -11509,8 +11509,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 23,
-                                column_index: 23,
+                                query_index: 22,
+                                column_index: 22,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -28334,10 +28334,10 @@ PinnedVerificationKey {
         (0x13d0bd76da4ace22c0e90b098d6073551322b8c734bf37eeca67fbf19687f550, 0x3d996cc9da5a31cefb453390b906eabbcc75797bc6a6b9c9e3af2fe7b6b8beed),
         (0x04cad7405b492a30db0a710c842cecc97d02059acf4c02aa79626dce68ac4837, 0x3d6d7b6698b258e61ebe0b25d9cbcd4a016cb0a2ae8d92752532d98cfb27720d),
         (0x0974ad1a3c0eb4c8d2c59cd820a82b7f28ea2f7a245008d403815131ff30879e, 0x00bb593cdf920cef4965f788d65eba3c3aa07d9718dfb62e3e385849a0d692a8),
-        (0x129898b6bcca9f9ff44f5dc76cb26bc229fa8b14ff47d9153680b0ba5c5efbf6, 0x1be1a12569bd9d26ac6225d404a52099198520eebec3ae1ef5de8a18d74b6116),
-        (0x3f30174d44efaca9cb31c8b6b6f4f4aaeedba6a974ea72f16ea9259099054bdc, 0x1f0de3c85053cd0d1f07c5edeb276c03c9c8614e78736626d7024eb6987c24ed),
+        (0x1b6f5383c5a0ae5bf457e1c8e17a933e892464d33fef9e9262411e01c117d87e, 0x0c552b960e8ce365b5f2302bcc0b7ce5cdf964e6036602cfc859c8769184f619),
+        (0x3fa4b5cc33e30de3ac7342c84f47f4fffe7ae77dda1689c2f08050d0ab743cb1, 0x327663e39b128ec28c94486b1e5d4429000626f65230ed572c66f80406a42176),
+        (0x2184a7d65b5000cc5c5f178c2f4ab5b11a67fdc626771c29ade508020c8da032, 0x34c98ee1f6dfa6c1e8cd915d1efeb484206e13e5e32e13118925913568e620b7),
         (0x1e355d783cffccafc120f462461fb312773442762383ac444009653f3d8d4be6, 0x3c60e17b18492aa2c41798b409d2bcc1857ca57ee9d2fb0001584cedc8e141d6),
-        (0x32059fe4e96eb002f24f6e6090014f7b3baf23946cc31a11341543a5a184903c, 0x3793fd512a65c7aa7c17a42e855eb8be26aa644165a9bc963c368baf0e5cce9d),
         (0x0a6fe1cc1ce659681079768ca8ff94d82c7d51ef39cd99b738b144de3a3027f6, 0x30cfc2f4e0ec95f623199970d8b762647ad2d7c3591a20781ee8187702babe5f),
         (0x00d87a2c430f1db50a63f18f8cf8807f4f70d3acb940d4130ba6811f8ba2d479, 0x13d5742320e1b2cecda6073b7f2bf5816b9067453deeaa829f356a65ef5621b2),
         (0x3118979ade023f3977d034f86eed6506d7e0586ead81f80bc5ca01a7660ee0c9, 0x30f6731193d5c786cf61b05523c05e2664a066c2d39a685588f02883057320ad),

--- a/src/circuit_description
+++ b/src/circuit_description
@@ -37,19 +37,15 @@ PinnedVerificationKey {
                 column_type: Fixed,
             },
             Column {
-                index: 20,
+                index: 19,
                 column_type: Fixed,
             },
             Column {
-                index: 20,
+                index: 19,
                 column_type: Fixed,
             },
             Column {
-                index: 20,
-                column_type: Fixed,
-            },
-            Column {
-                index: 20,
+                index: 19,
                 column_type: Fixed,
             },
             Column {
@@ -65,19 +61,23 @@ PinnedVerificationKey {
                 column_type: Fixed,
             },
             Column {
-                index: 21,
+                index: 20,
                 column_type: Fixed,
             },
             Column {
-                index: 21,
+                index: 20,
                 column_type: Fixed,
             },
             Column {
-                index: 21,
+                index: 20,
                 column_type: Fixed,
             },
             Column {
-                index: 21,
+                index: 20,
+                column_type: Fixed,
+            },
+            Column {
+                index: 20,
                 column_type: Fixed,
             },
             Column {
@@ -93,15 +93,15 @@ PinnedVerificationKey {
                 column_type: Fixed,
             },
             Column {
-                index: 22,
+                index: 21,
                 column_type: Fixed,
             },
             Column {
-                index: 22,
+                index: 21,
                 column_type: Fixed,
             },
             Column {
-                index: 22,
+                index: 21,
                 column_type: Fixed,
             },
             Column {
@@ -941,253 +941,13 @@ PinnedVerificationKey {
                 ),
             ),
             Product(
-                Fixed {
-                    query_index: 19,
-                    column_index: 19,
-                    rotation: Rotation(
-                        0,
-                    ),
-                },
-                Product(
-                    Product(
-                        Product(
-                            Product(
-                                Product(
-                                    Product(
-                                        Product(
-                                            Sum(
-                                                Advice {
-                                                    query_index: 4,
-                                                    column_index: 4,
-                                                    rotation: Rotation(
-                                                        0,
-                                                    ),
-                                                },
-                                                Negated(
-                                                    Scaled(
-                                                        Advice {
-                                                            query_index: 12,
-                                                            column_index: 4,
-                                                            rotation: Rotation(
-                                                                1,
-                                                            ),
-                                                        },
-                                                        0x0000000000000000000000000000000000000000000000000000000000000008,
-                                                    ),
-                                                ),
-                                            ),
-                                            Sum(
-                                                Constant(
-                                                    0x0000000000000000000000000000000000000000000000000000000000000001,
-                                                ),
-                                                Negated(
-                                                    Sum(
-                                                        Advice {
-                                                            query_index: 4,
-                                                            column_index: 4,
-                                                            rotation: Rotation(
-                                                                0,
-                                                            ),
-                                                        },
-                                                        Negated(
-                                                            Scaled(
-                                                                Advice {
-                                                                    query_index: 12,
-                                                                    column_index: 4,
-                                                                    rotation: Rotation(
-                                                                        1,
-                                                                    ),
-                                                                },
-                                                                0x0000000000000000000000000000000000000000000000000000000000000008,
-                                                            ),
-                                                        ),
-                                                    ),
-                                                ),
-                                            ),
-                                        ),
-                                        Sum(
-                                            Constant(
-                                                0x0000000000000000000000000000000000000000000000000000000000000002,
-                                            ),
-                                            Negated(
-                                                Sum(
-                                                    Advice {
-                                                        query_index: 4,
-                                                        column_index: 4,
-                                                        rotation: Rotation(
-                                                            0,
-                                                        ),
-                                                    },
-                                                    Negated(
-                                                        Scaled(
-                                                            Advice {
-                                                                query_index: 12,
-                                                                column_index: 4,
-                                                                rotation: Rotation(
-                                                                    1,
-                                                                ),
-                                                            },
-                                                            0x0000000000000000000000000000000000000000000000000000000000000008,
-                                                        ),
-                                                    ),
-                                                ),
-                                            ),
-                                        ),
-                                    ),
-                                    Sum(
-                                        Constant(
-                                            0x0000000000000000000000000000000000000000000000000000000000000003,
-                                        ),
-                                        Negated(
-                                            Sum(
-                                                Advice {
-                                                    query_index: 4,
-                                                    column_index: 4,
-                                                    rotation: Rotation(
-                                                        0,
-                                                    ),
-                                                },
-                                                Negated(
-                                                    Scaled(
-                                                        Advice {
-                                                            query_index: 12,
-                                                            column_index: 4,
-                                                            rotation: Rotation(
-                                                                1,
-                                                            ),
-                                                        },
-                                                        0x0000000000000000000000000000000000000000000000000000000000000008,
-                                                    ),
-                                                ),
-                                            ),
-                                        ),
-                                    ),
-                                ),
-                                Sum(
-                                    Constant(
-                                        0x0000000000000000000000000000000000000000000000000000000000000004,
-                                    ),
-                                    Negated(
-                                        Sum(
-                                            Advice {
-                                                query_index: 4,
-                                                column_index: 4,
-                                                rotation: Rotation(
-                                                    0,
-                                                ),
-                                            },
-                                            Negated(
-                                                Scaled(
-                                                    Advice {
-                                                        query_index: 12,
-                                                        column_index: 4,
-                                                        rotation: Rotation(
-                                                            1,
-                                                        ),
-                                                    },
-                                                    0x0000000000000000000000000000000000000000000000000000000000000008,
-                                                ),
-                                            ),
-                                        ),
-                                    ),
-                                ),
-                            ),
-                            Sum(
-                                Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000005,
-                                ),
-                                Negated(
-                                    Sum(
-                                        Advice {
-                                            query_index: 4,
-                                            column_index: 4,
-                                            rotation: Rotation(
-                                                0,
-                                            ),
-                                        },
-                                        Negated(
-                                            Scaled(
-                                                Advice {
-                                                    query_index: 12,
-                                                    column_index: 4,
-                                                    rotation: Rotation(
-                                                        1,
-                                                    ),
-                                                },
-                                                0x0000000000000000000000000000000000000000000000000000000000000008,
-                                            ),
-                                        ),
-                                    ),
-                                ),
-                            ),
-                        ),
-                        Sum(
-                            Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000006,
-                            ),
-                            Negated(
-                                Sum(
-                                    Advice {
-                                        query_index: 4,
-                                        column_index: 4,
-                                        rotation: Rotation(
-                                            0,
-                                        ),
-                                    },
-                                    Negated(
-                                        Scaled(
-                                            Advice {
-                                                query_index: 12,
-                                                column_index: 4,
-                                                rotation: Rotation(
-                                                    1,
-                                                ),
-                                            },
-                                            0x0000000000000000000000000000000000000000000000000000000000000008,
-                                        ),
-                                    ),
-                                ),
-                            ),
-                        ),
-                    ),
-                    Sum(
-                        Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000007,
-                        ),
-                        Negated(
-                            Sum(
-                                Advice {
-                                    query_index: 4,
-                                    column_index: 4,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                                Negated(
-                                    Scaled(
-                                        Advice {
-                                            query_index: 12,
-                                            column_index: 4,
-                                            rotation: Rotation(
-                                                1,
-                                            ),
-                                        },
-                                        0x0000000000000000000000000000000000000000000000000000000000000008,
-                                    ),
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-            Product(
                 Product(
                     Product(
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -1198,8 +958,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 20,
-                                            column_index: 20,
+                                            query_index: 19,
+                                            column_index: 19,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -1213,8 +973,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 19,
+                                        column_index: 19,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -1228,8 +988,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -1304,8 +1064,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -1316,8 +1076,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 20,
-                                            column_index: 20,
+                                            query_index: 19,
+                                            column_index: 19,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -1331,8 +1091,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 19,
+                                        column_index: 19,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -1346,8 +1106,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -1421,8 +1181,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -1433,8 +1193,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 19,
+                                        column_index: 19,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -1448,8 +1208,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -1463,8 +1223,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -1530,8 +1290,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -1542,8 +1302,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 19,
+                                        column_index: 19,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -1557,8 +1317,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -1572,8 +1332,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -1587,7 +1347,7 @@ PinnedVerificationKey {
                             Sum(
                                 Sum(
                                     Advice {
-                                        query_index: 13,
+                                        query_index: 12,
                                         column_index: 2,
                                         rotation: Rotation(
                                             1,
@@ -1694,8 +1454,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -1706,8 +1466,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 19,
+                                        column_index: 19,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -1721,8 +1481,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -1736,8 +1496,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -1749,7 +1509,7 @@ PinnedVerificationKey {
                     Product(
                         Sum(
                             Advice {
-                                query_index: 14,
+                                query_index: 13,
                                 column_index: 3,
                                 rotation: Rotation(
                                     1,
@@ -1812,7 +1572,7 @@ PinnedVerificationKey {
                                 },
                                 Negated(
                                     Advice {
-                                        query_index: 13,
+                                        query_index: 12,
                                         column_index: 2,
                                         rotation: Rotation(
                                             1,
@@ -1829,8 +1589,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -1841,8 +1601,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 19,
+                                        column_index: 19,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -1856,8 +1616,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -1871,8 +1631,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -1955,8 +1715,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -1967,8 +1727,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 19,
+                                        column_index: 19,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -1982,8 +1742,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -1997,8 +1757,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -2094,8 +1854,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -2106,8 +1866,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 19,
+                                        column_index: 19,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -2121,8 +1881,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -2136,8 +1896,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -2223,7 +1983,7 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Advice {
-                                query_index: 13,
+                                query_index: 12,
                                 column_index: 2,
                                 rotation: Rotation(
                                     1,
@@ -2238,8 +1998,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -2250,8 +2010,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 19,
+                                        column_index: 19,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -2265,8 +2025,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -2280,8 +2040,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -2346,7 +2106,7 @@ PinnedVerificationKey {
                                     },
                                     Negated(
                                         Advice {
-                                            query_index: 13,
+                                            query_index: 12,
                                             column_index: 2,
                                             rotation: Rotation(
                                                 1,
@@ -2367,7 +2127,7 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Advice {
-                                query_index: 14,
+                                query_index: 13,
                                 column_index: 3,
                                 rotation: Rotation(
                                     1,
@@ -2382,8 +2142,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -2394,8 +2154,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 19,
+                                        column_index: 19,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -2409,8 +2169,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -2424,8 +2184,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -2509,7 +2269,7 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Advice {
-                                query_index: 13,
+                                query_index: 12,
                                 column_index: 2,
                                 rotation: Rotation(
                                     1,
@@ -2524,8 +2284,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -2536,8 +2296,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 19,
+                                        column_index: 19,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -2551,8 +2311,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -2566,8 +2326,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -2630,7 +2390,7 @@ PinnedVerificationKey {
                                     },
                                     Negated(
                                         Advice {
-                                            query_index: 13,
+                                            query_index: 12,
                                             column_index: 2,
                                             rotation: Rotation(
                                                 1,
@@ -2651,7 +2411,7 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Advice {
-                                query_index: 14,
+                                query_index: 13,
                                 column_index: 3,
                                 rotation: Rotation(
                                     1,
@@ -2666,8 +2426,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -2678,8 +2438,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 19,
+                                        column_index: 19,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -2693,8 +2453,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -2708,8 +2468,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -2743,7 +2503,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Advice {
-                            query_index: 13,
+                            query_index: 12,
                             column_index: 2,
                             rotation: Rotation(
                                 1,
@@ -2766,8 +2526,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -2778,8 +2538,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 19,
+                                        column_index: 19,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -2793,8 +2553,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -2808,8 +2568,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -2843,7 +2603,7 @@ PinnedVerificationKey {
                     ),
                     Sum(
                         Advice {
-                            query_index: 14,
+                            query_index: 13,
                             column_index: 3,
                             rotation: Rotation(
                                 1,
@@ -2866,8 +2626,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -2878,8 +2638,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 19,
+                                        column_index: 19,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -2893,8 +2653,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -2908,8 +2668,108 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
+                                rotation: Rotation(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                Product(
+                    Sum(
+                        Constant(
+                            0x0000000000000000000000000000000000000000000000000000000000000001,
+                        ),
+                        Negated(
+                            Product(
+                                Advice {
+                                    query_index: 2,
+                                    column_index: 2,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                                Advice {
+                                    query_index: 7,
+                                    column_index: 7,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                            ),
+                        ),
+                    ),
+                    Sum(
+                        Advice {
+                            query_index: 12,
+                            column_index: 2,
+                            rotation: Rotation(
+                                1,
+                            ),
+                        },
+                        Negated(
+                            Advice {
+                                query_index: 0,
+                                column_index: 0,
+                                rotation: Rotation(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+            ),
+            Product(
+                Product(
+                    Product(
+                        Product(
+                            Fixed {
+                                query_index: 19,
+                                column_index: 19,
+                                rotation: Rotation(
+                                    0,
+                                ),
+                            },
+                            Sum(
+                                Constant(
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
+                                ),
+                                Negated(
+                                    Fixed {
+                                        query_index: 19,
+                                        column_index: 19,
+                                        rotation: Rotation(
+                                            0,
+                                        ),
+                                    },
+                                ),
+                            ),
+                        ),
+                        Sum(
+                            Constant(
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
+                            ),
+                            Negated(
+                                Fixed {
+                                    query_index: 19,
+                                    column_index: 19,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                            ),
+                        ),
+                    ),
+                    Sum(
+                        Constant(
+                            0x0000000000000000000000000000000000000000000000000000000000000003,
+                        ),
+                        Negated(
+                            Fixed {
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -2944,106 +2804,6 @@ PinnedVerificationKey {
                     Sum(
                         Advice {
                             query_index: 13,
-                            column_index: 2,
-                            rotation: Rotation(
-                                1,
-                            ),
-                        },
-                        Negated(
-                            Advice {
-                                query_index: 0,
-                                column_index: 0,
-                                rotation: Rotation(
-                                    0,
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-            ),
-            Product(
-                Product(
-                    Product(
-                        Product(
-                            Fixed {
-                                query_index: 20,
-                                column_index: 20,
-                                rotation: Rotation(
-                                    0,
-                                ),
-                            },
-                            Sum(
-                                Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000001,
-                                ),
-                                Negated(
-                                    Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
-                                        rotation: Rotation(
-                                            0,
-                                        ),
-                                    },
-                                ),
-                            ),
-                        ),
-                        Sum(
-                            Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000002,
-                            ),
-                            Negated(
-                                Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                            ),
-                        ),
-                    ),
-                    Sum(
-                        Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000003,
-                        ),
-                        Negated(
-                            Fixed {
-                                query_index: 20,
-                                column_index: 20,
-                                rotation: Rotation(
-                                    0,
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                Product(
-                    Sum(
-                        Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000001,
-                        ),
-                        Negated(
-                            Product(
-                                Advice {
-                                    query_index: 2,
-                                    column_index: 2,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                                Advice {
-                                    query_index: 7,
-                                    column_index: 7,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                            ),
-                        ),
-                    ),
-                    Sum(
-                        Advice {
-                            query_index: 14,
                             column_index: 3,
                             rotation: Rotation(
                                 1,
@@ -3066,8 +2826,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -3078,8 +2838,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
+                                        query_index: 19,
+                                        column_index: 19,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -3093,8 +2853,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
+                                    query_index: 19,
+                                    column_index: 19,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -3108,8 +2868,137 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 20,
-                                column_index: 20,
+                                query_index: 19,
+                                column_index: 19,
+                                rotation: Rotation(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                Product(
+                    Sum(
+                        Sum(
+                            Constant(
+                                0x0000000000000000000000000000000000000000000000000000000000000001,
+                            ),
+                            Negated(
+                                Product(
+                                    Sum(
+                                        Advice {
+                                            query_index: 2,
+                                            column_index: 2,
+                                            rotation: Rotation(
+                                                0,
+                                            ),
+                                        },
+                                        Negated(
+                                            Advice {
+                                                query_index: 0,
+                                                column_index: 0,
+                                                rotation: Rotation(
+                                                    0,
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    Advice {
+                                        query_index: 5,
+                                        column_index: 5,
+                                        rotation: Rotation(
+                                            0,
+                                        ),
+                                    },
+                                ),
+                            ),
+                        ),
+                        Negated(
+                            Product(
+                                Sum(
+                                    Advice {
+                                        query_index: 3,
+                                        column_index: 3,
+                                        rotation: Rotation(
+                                            0,
+                                        ),
+                                    },
+                                    Advice {
+                                        query_index: 1,
+                                        column_index: 1,
+                                        rotation: Rotation(
+                                            0,
+                                        ),
+                                    },
+                                ),
+                                Advice {
+                                    query_index: 8,
+                                    column_index: 8,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                            ),
+                        ),
+                    ),
+                    Advice {
+                        query_index: 12,
+                        column_index: 2,
+                        rotation: Rotation(
+                            1,
+                        ),
+                    },
+                ),
+            ),
+            Product(
+                Product(
+                    Product(
+                        Product(
+                            Fixed {
+                                query_index: 19,
+                                column_index: 19,
+                                rotation: Rotation(
+                                    0,
+                                ),
+                            },
+                            Sum(
+                                Constant(
+                                    0x0000000000000000000000000000000000000000000000000000000000000001,
+                                ),
+                                Negated(
+                                    Fixed {
+                                        query_index: 19,
+                                        column_index: 19,
+                                        rotation: Rotation(
+                                            0,
+                                        ),
+                                    },
+                                ),
+                            ),
+                        ),
+                        Sum(
+                            Constant(
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
+                            ),
+                            Negated(
+                                Fixed {
+                                    query_index: 19,
+                                    column_index: 19,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                            ),
+                        ),
+                    ),
+                    Sum(
+                        Constant(
+                            0x0000000000000000000000000000000000000000000000000000000000000003,
+                        ),
+                        Negated(
+                            Fixed {
+                                query_index: 19,
+                                column_index: 19,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -3183,135 +3072,6 @@ PinnedVerificationKey {
                     ),
                     Advice {
                         query_index: 13,
-                        column_index: 2,
-                        rotation: Rotation(
-                            1,
-                        ),
-                    },
-                ),
-            ),
-            Product(
-                Product(
-                    Product(
-                        Product(
-                            Fixed {
-                                query_index: 20,
-                                column_index: 20,
-                                rotation: Rotation(
-                                    0,
-                                ),
-                            },
-                            Sum(
-                                Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000001,
-                                ),
-                                Negated(
-                                    Fixed {
-                                        query_index: 20,
-                                        column_index: 20,
-                                        rotation: Rotation(
-                                            0,
-                                        ),
-                                    },
-                                ),
-                            ),
-                        ),
-                        Sum(
-                            Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000002,
-                            ),
-                            Negated(
-                                Fixed {
-                                    query_index: 20,
-                                    column_index: 20,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                            ),
-                        ),
-                    ),
-                    Sum(
-                        Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000003,
-                        ),
-                        Negated(
-                            Fixed {
-                                query_index: 20,
-                                column_index: 20,
-                                rotation: Rotation(
-                                    0,
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                Product(
-                    Sum(
-                        Sum(
-                            Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000001,
-                            ),
-                            Negated(
-                                Product(
-                                    Sum(
-                                        Advice {
-                                            query_index: 2,
-                                            column_index: 2,
-                                            rotation: Rotation(
-                                                0,
-                                            ),
-                                        },
-                                        Negated(
-                                            Advice {
-                                                query_index: 0,
-                                                column_index: 0,
-                                                rotation: Rotation(
-                                                    0,
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    Advice {
-                                        query_index: 5,
-                                        column_index: 5,
-                                        rotation: Rotation(
-                                            0,
-                                        ),
-                                    },
-                                ),
-                            ),
-                        ),
-                        Negated(
-                            Product(
-                                Sum(
-                                    Advice {
-                                        query_index: 3,
-                                        column_index: 3,
-                                        rotation: Rotation(
-                                            0,
-                                        ),
-                                    },
-                                    Advice {
-                                        query_index: 1,
-                                        column_index: 1,
-                                        rotation: Rotation(
-                                            0,
-                                        ),
-                                    },
-                                ),
-                                Advice {
-                                    query_index: 8,
-                                    column_index: 8,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                            ),
-                        ),
-                    ),
-                    Advice {
-                        query_index: 14,
                         column_index: 3,
                         rotation: Rotation(
                             1,
@@ -3420,7 +3180,7 @@ PinnedVerificationKey {
                             Product(
                                 Sum(
                                     Advice {
-                                        query_index: 12,
+                                        query_index: 14,
                                         column_index: 4,
                                         rotation: Rotation(
                                             1,
@@ -3436,7 +3196,7 @@ PinnedVerificationKey {
                                 ),
                                 Sum(
                                     Advice {
-                                        query_index: 14,
+                                        query_index: 13,
                                         column_index: 3,
                                         rotation: Rotation(
                                             1,
@@ -3447,14 +3207,14 @@ PinnedVerificationKey {
                                             Sum(
                                                 Product(
                                                     Advice {
-                                                        query_index: 12,
+                                                        query_index: 14,
                                                         column_index: 4,
                                                         rotation: Rotation(
                                                             1,
                                                         ),
                                                     },
                                                     Advice {
-                                                        query_index: 12,
+                                                        query_index: 14,
                                                         column_index: 4,
                                                         rotation: Rotation(
                                                             1,
@@ -3463,7 +3223,7 @@ PinnedVerificationKey {
                                                 ),
                                                 Negated(
                                                     Advice {
-                                                        query_index: 14,
+                                                        query_index: 13,
                                                         column_index: 3,
                                                         rotation: Rotation(
                                                             1,
@@ -4184,7 +3944,7 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Advice {
-                                    query_index: 14,
+                                    query_index: 13,
                                     column_index: 3,
                                     rotation: Rotation(
                                         1,
@@ -4352,7 +4112,7 @@ PinnedVerificationKey {
                                 },
                                 Negated(
                                     Advice {
-                                        query_index: 14,
+                                        query_index: 13,
                                         column_index: 3,
                                         rotation: Rotation(
                                             1,
@@ -4439,7 +4199,7 @@ PinnedVerificationKey {
                             Product(
                                 Sum(
                                     Advice {
-                                        query_index: 12,
+                                        query_index: 14,
                                         column_index: 4,
                                         rotation: Rotation(
                                             1,
@@ -4455,7 +4215,7 @@ PinnedVerificationKey {
                                 ),
                                 Sum(
                                     Advice {
-                                        query_index: 14,
+                                        query_index: 13,
                                         column_index: 3,
                                         rotation: Rotation(
                                             1,
@@ -4466,14 +4226,14 @@ PinnedVerificationKey {
                                             Sum(
                                                 Product(
                                                     Advice {
-                                                        query_index: 12,
+                                                        query_index: 14,
                                                         column_index: 4,
                                                         rotation: Rotation(
                                                             1,
                                                         ),
                                                     },
                                                     Advice {
-                                                        query_index: 12,
+                                                        query_index: 14,
                                                         column_index: 4,
                                                         rotation: Rotation(
                                                             1,
@@ -4482,7 +4242,7 @@ PinnedVerificationKey {
                                                 ),
                                                 Negated(
                                                     Advice {
-                                                        query_index: 14,
+                                                        query_index: 13,
                                                         column_index: 3,
                                                         rotation: Rotation(
                                                             1,
@@ -4989,7 +4749,7 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Advice {
-                                    query_index: 14,
+                                    query_index: 13,
                                     column_index: 3,
                                     rotation: Rotation(
                                         1,
@@ -5157,7 +4917,7 @@ PinnedVerificationKey {
                                 },
                                 Negated(
                                     Advice {
-                                        query_index: 14,
+                                        query_index: 13,
                                         column_index: 3,
                                         rotation: Rotation(
                                             1,
@@ -5241,7 +5001,7 @@ PinnedVerificationKey {
                     ),
                     Negated(
                         Advice {
-                            query_index: 12,
+                            query_index: 14,
                             column_index: 4,
                             rotation: Rotation(
                                 1,
@@ -5256,8 +5016,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -5268,8 +5028,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -5283,8 +5043,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -5298,8 +5058,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -5313,8 +5073,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -5342,7 +5102,7 @@ PinnedVerificationKey {
                                         ),
                                     },
                                     Advice {
-                                        query_index: 13,
+                                        query_index: 12,
                                         column_index: 2,
                                         rotation: Rotation(
                                             1,
@@ -5410,8 +5170,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -5422,8 +5182,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -5437,8 +5197,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -5452,8 +5212,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -5467,8 +5227,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -5501,8 +5261,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -5513,8 +5273,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -5528,8 +5288,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -5543,8 +5303,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -5558,8 +5318,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -5592,8 +5352,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -5604,8 +5364,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -5619,8 +5379,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -5634,8 +5394,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -5649,8 +5409,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -5716,8 +5476,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -5728,8 +5488,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -5743,8 +5503,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -5758,8 +5518,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -5773,8 +5533,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -5932,8 +5692,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -5944,8 +5704,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -5959,8 +5719,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -5974,8 +5734,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -5989,8 +5749,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -6085,8 +5845,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -6097,8 +5857,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -6112,8 +5872,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -6127,8 +5887,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -6142,8 +5902,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -6265,7 +6025,7 @@ PinnedVerificationKey {
                                         ),
                                     },
                                     Advice {
-                                        query_index: 13,
+                                        query_index: 12,
                                         column_index: 2,
                                         rotation: Rotation(
                                             1,
@@ -6333,8 +6093,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -6345,8 +6105,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -6360,8 +6120,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -6375,8 +6135,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -6390,8 +6150,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -6457,8 +6217,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -6469,8 +6229,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -6484,8 +6244,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -6499,8 +6259,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -6514,8 +6274,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -6673,8 +6433,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -6685,8 +6445,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -6700,8 +6460,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -6715,8 +6475,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -6730,8 +6490,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -6826,8 +6586,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -6838,8 +6598,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -6853,8 +6613,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -6868,8 +6628,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -6883,8 +6643,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -7011,8 +6771,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7023,8 +6783,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -7038,8 +6798,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -7053,8 +6813,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7068,8 +6828,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -7139,8 +6899,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7151,8 +6911,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -7166,8 +6926,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -7181,8 +6941,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7196,8 +6956,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -7305,8 +7065,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7317,8 +7077,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -7332,8 +7092,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -7347,8 +7107,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7362,8 +7122,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -7415,8 +7175,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7427,8 +7187,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -7442,8 +7202,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -7457,8 +7217,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7472,8 +7232,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -7513,8 +7273,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7525,8 +7285,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -7540,8 +7300,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -7555,8 +7315,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7570,8 +7330,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -7609,8 +7369,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7621,8 +7381,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -7636,8 +7396,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -7651,8 +7411,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7666,8 +7426,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -7698,8 +7458,8 @@ PinnedVerificationKey {
                         Product(
                             Product(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7710,8 +7470,8 @@ PinnedVerificationKey {
                                     ),
                                     Negated(
                                         Fixed {
-                                            query_index: 21,
-                                            column_index: 21,
+                                            query_index: 20,
+                                            column_index: 20,
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -7725,8 +7485,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 21,
-                                        column_index: 21,
+                                        query_index: 20,
+                                        column_index: 20,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -7740,8 +7500,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 21,
-                                    column_index: 21,
+                                    query_index: 20,
+                                    column_index: 20,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7755,8 +7515,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 21,
-                                column_index: 21,
+                                query_index: 20,
+                                column_index: 20,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -7818,8 +7578,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -7830,8 +7590,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -7845,8 +7605,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7860,8 +7620,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -7926,8 +7686,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -7938,8 +7698,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -7953,8 +7713,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -7968,8 +7728,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -8063,8 +7823,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -8075,8 +7835,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -8090,8 +7850,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -8105,8 +7865,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -8195,8 +7955,248 @@ PinnedVerificationKey {
             ),
             Product(
                 Fixed {
-                    query_index: 19,
-                    column_index: 19,
+                    query_index: 22,
+                    column_index: 22,
+                    rotation: Rotation(
+                        0,
+                    ),
+                },
+                Product(
+                    Product(
+                        Product(
+                            Product(
+                                Product(
+                                    Product(
+                                        Product(
+                                            Sum(
+                                                Advice {
+                                                    query_index: 4,
+                                                    column_index: 4,
+                                                    rotation: Rotation(
+                                                        0,
+                                                    ),
+                                                },
+                                                Negated(
+                                                    Scaled(
+                                                        Advice {
+                                                            query_index: 14,
+                                                            column_index: 4,
+                                                            rotation: Rotation(
+                                                                1,
+                                                            ),
+                                                        },
+                                                        0x0000000000000000000000000000000000000000000000000000000000000008,
+                                                    ),
+                                                ),
+                                            ),
+                                            Sum(
+                                                Constant(
+                                                    0x0000000000000000000000000000000000000000000000000000000000000001,
+                                                ),
+                                                Negated(
+                                                    Sum(
+                                                        Advice {
+                                                            query_index: 4,
+                                                            column_index: 4,
+                                                            rotation: Rotation(
+                                                                0,
+                                                            ),
+                                                        },
+                                                        Negated(
+                                                            Scaled(
+                                                                Advice {
+                                                                    query_index: 14,
+                                                                    column_index: 4,
+                                                                    rotation: Rotation(
+                                                                        1,
+                                                                    ),
+                                                                },
+                                                                0x0000000000000000000000000000000000000000000000000000000000000008,
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                        Sum(
+                                            Constant(
+                                                0x0000000000000000000000000000000000000000000000000000000000000002,
+                                            ),
+                                            Negated(
+                                                Sum(
+                                                    Advice {
+                                                        query_index: 4,
+                                                        column_index: 4,
+                                                        rotation: Rotation(
+                                                            0,
+                                                        ),
+                                                    },
+                                                    Negated(
+                                                        Scaled(
+                                                            Advice {
+                                                                query_index: 14,
+                                                                column_index: 4,
+                                                                rotation: Rotation(
+                                                                    1,
+                                                                ),
+                                                            },
+                                                            0x0000000000000000000000000000000000000000000000000000000000000008,
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                    Sum(
+                                        Constant(
+                                            0x0000000000000000000000000000000000000000000000000000000000000003,
+                                        ),
+                                        Negated(
+                                            Sum(
+                                                Advice {
+                                                    query_index: 4,
+                                                    column_index: 4,
+                                                    rotation: Rotation(
+                                                        0,
+                                                    ),
+                                                },
+                                                Negated(
+                                                    Scaled(
+                                                        Advice {
+                                                            query_index: 14,
+                                                            column_index: 4,
+                                                            rotation: Rotation(
+                                                                1,
+                                                            ),
+                                                        },
+                                                        0x0000000000000000000000000000000000000000000000000000000000000008,
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                Sum(
+                                    Constant(
+                                        0x0000000000000000000000000000000000000000000000000000000000000004,
+                                    ),
+                                    Negated(
+                                        Sum(
+                                            Advice {
+                                                query_index: 4,
+                                                column_index: 4,
+                                                rotation: Rotation(
+                                                    0,
+                                                ),
+                                            },
+                                            Negated(
+                                                Scaled(
+                                                    Advice {
+                                                        query_index: 14,
+                                                        column_index: 4,
+                                                        rotation: Rotation(
+                                                            1,
+                                                        ),
+                                                    },
+                                                    0x0000000000000000000000000000000000000000000000000000000000000008,
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Sum(
+                                Constant(
+                                    0x0000000000000000000000000000000000000000000000000000000000000005,
+                                ),
+                                Negated(
+                                    Sum(
+                                        Advice {
+                                            query_index: 4,
+                                            column_index: 4,
+                                            rotation: Rotation(
+                                                0,
+                                            ),
+                                        },
+                                        Negated(
+                                            Scaled(
+                                                Advice {
+                                                    query_index: 14,
+                                                    column_index: 4,
+                                                    rotation: Rotation(
+                                                        1,
+                                                    ),
+                                                },
+                                                0x0000000000000000000000000000000000000000000000000000000000000008,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Sum(
+                            Constant(
+                                0x0000000000000000000000000000000000000000000000000000000000000006,
+                            ),
+                            Negated(
+                                Sum(
+                                    Advice {
+                                        query_index: 4,
+                                        column_index: 4,
+                                        rotation: Rotation(
+                                            0,
+                                        ),
+                                    },
+                                    Negated(
+                                        Scaled(
+                                            Advice {
+                                                query_index: 14,
+                                                column_index: 4,
+                                                rotation: Rotation(
+                                                    1,
+                                                ),
+                                            },
+                                            0x0000000000000000000000000000000000000000000000000000000000000008,
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    Sum(
+                        Constant(
+                            0x0000000000000000000000000000000000000000000000000000000000000007,
+                        ),
+                        Negated(
+                            Sum(
+                                Advice {
+                                    query_index: 4,
+                                    column_index: 4,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                                Negated(
+                                    Scaled(
+                                        Advice {
+                                            query_index: 14,
+                                            column_index: 4,
+                                            rotation: Rotation(
+                                                1,
+                                            ),
+                                        },
+                                        0x0000000000000000000000000000000000000000000000000000000000000008,
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            Product(
+                Fixed {
+                    query_index: 22,
+                    column_index: 22,
                     rotation: Rotation(
                         0,
                     ),
@@ -8242,7 +8242,7 @@ PinnedVerificationKey {
                                                             Negated(
                                                                 Scaled(
                                                                     Advice {
-                                                                        query_index: 12,
+                                                                        query_index: 14,
                                                                         column_index: 4,
                                                                         rotation: Rotation(
                                                                             1,
@@ -8279,7 +8279,7 @@ PinnedVerificationKey {
                                                             Negated(
                                                                 Scaled(
                                                                     Advice {
-                                                                        query_index: 12,
+                                                                        query_index: 14,
                                                                         column_index: 4,
                                                                         rotation: Rotation(
                                                                             1,
@@ -8301,7 +8301,7 @@ PinnedVerificationKey {
                                                         Negated(
                                                             Scaled(
                                                                 Advice {
-                                                                    query_index: 12,
+                                                                    query_index: 14,
                                                                     column_index: 4,
                                                                     rotation: Rotation(
                                                                         1,
@@ -8339,7 +8339,7 @@ PinnedVerificationKey {
                                                             Negated(
                                                                 Scaled(
                                                                     Advice {
-                                                                        query_index: 12,
+                                                                        query_index: 14,
                                                                         column_index: 4,
                                                                         rotation: Rotation(
                                                                             1,
@@ -8361,7 +8361,7 @@ PinnedVerificationKey {
                                                         Negated(
                                                             Scaled(
                                                                 Advice {
-                                                                    query_index: 12,
+                                                                    query_index: 14,
                                                                     column_index: 4,
                                                                     rotation: Rotation(
                                                                         1,
@@ -8383,7 +8383,7 @@ PinnedVerificationKey {
                                                     Negated(
                                                         Scaled(
                                                             Advice {
-                                                                query_index: 12,
+                                                                query_index: 14,
                                                                 column_index: 4,
                                                                 rotation: Rotation(
                                                                     1,
@@ -8422,7 +8422,7 @@ PinnedVerificationKey {
                                                             Negated(
                                                                 Scaled(
                                                                     Advice {
-                                                                        query_index: 12,
+                                                                        query_index: 14,
                                                                         column_index: 4,
                                                                         rotation: Rotation(
                                                                             1,
@@ -8444,7 +8444,7 @@ PinnedVerificationKey {
                                                         Negated(
                                                             Scaled(
                                                                 Advice {
-                                                                    query_index: 12,
+                                                                    query_index: 14,
                                                                     column_index: 4,
                                                                     rotation: Rotation(
                                                                         1,
@@ -8466,7 +8466,7 @@ PinnedVerificationKey {
                                                     Negated(
                                                         Scaled(
                                                             Advice {
-                                                                query_index: 12,
+                                                                query_index: 14,
                                                                 column_index: 4,
                                                                 rotation: Rotation(
                                                                     1,
@@ -8488,7 +8488,7 @@ PinnedVerificationKey {
                                                 Negated(
                                                     Scaled(
                                                         Advice {
-                                                            query_index: 12,
+                                                            query_index: 14,
                                                             column_index: 4,
                                                             rotation: Rotation(
                                                                 1,
@@ -8528,7 +8528,7 @@ PinnedVerificationKey {
                                                             Negated(
                                                                 Scaled(
                                                                     Advice {
-                                                                        query_index: 12,
+                                                                        query_index: 14,
                                                                         column_index: 4,
                                                                         rotation: Rotation(
                                                                             1,
@@ -8550,7 +8550,7 @@ PinnedVerificationKey {
                                                         Negated(
                                                             Scaled(
                                                                 Advice {
-                                                                    query_index: 12,
+                                                                    query_index: 14,
                                                                     column_index: 4,
                                                                     rotation: Rotation(
                                                                         1,
@@ -8572,7 +8572,7 @@ PinnedVerificationKey {
                                                     Negated(
                                                         Scaled(
                                                             Advice {
-                                                                query_index: 12,
+                                                                query_index: 14,
                                                                 column_index: 4,
                                                                 rotation: Rotation(
                                                                     1,
@@ -8594,7 +8594,7 @@ PinnedVerificationKey {
                                                 Negated(
                                                     Scaled(
                                                         Advice {
-                                                            query_index: 12,
+                                                            query_index: 14,
                                                             column_index: 4,
                                                             rotation: Rotation(
                                                                 1,
@@ -8616,7 +8616,7 @@ PinnedVerificationKey {
                                             Negated(
                                                 Scaled(
                                                     Advice {
-                                                        query_index: 12,
+                                                        query_index: 14,
                                                         column_index: 4,
                                                         rotation: Rotation(
                                                             1,
@@ -8657,7 +8657,7 @@ PinnedVerificationKey {
                                                             Negated(
                                                                 Scaled(
                                                                     Advice {
-                                                                        query_index: 12,
+                                                                        query_index: 14,
                                                                         column_index: 4,
                                                                         rotation: Rotation(
                                                                             1,
@@ -8679,7 +8679,7 @@ PinnedVerificationKey {
                                                         Negated(
                                                             Scaled(
                                                                 Advice {
-                                                                    query_index: 12,
+                                                                    query_index: 14,
                                                                     column_index: 4,
                                                                     rotation: Rotation(
                                                                         1,
@@ -8701,7 +8701,7 @@ PinnedVerificationKey {
                                                     Negated(
                                                         Scaled(
                                                             Advice {
-                                                                query_index: 12,
+                                                                query_index: 14,
                                                                 column_index: 4,
                                                                 rotation: Rotation(
                                                                     1,
@@ -8723,7 +8723,7 @@ PinnedVerificationKey {
                                                 Negated(
                                                     Scaled(
                                                         Advice {
-                                                            query_index: 12,
+                                                            query_index: 14,
                                                             column_index: 4,
                                                             rotation: Rotation(
                                                                 1,
@@ -8745,7 +8745,7 @@ PinnedVerificationKey {
                                             Negated(
                                                 Scaled(
                                                     Advice {
-                                                        query_index: 12,
+                                                        query_index: 14,
                                                         column_index: 4,
                                                         rotation: Rotation(
                                                             1,
@@ -8767,7 +8767,7 @@ PinnedVerificationKey {
                                         Negated(
                                             Scaled(
                                                 Advice {
-                                                    query_index: 12,
+                                                    query_index: 14,
                                                     column_index: 4,
                                                     rotation: Rotation(
                                                         1,
@@ -8809,7 +8809,7 @@ PinnedVerificationKey {
                                                             Negated(
                                                                 Scaled(
                                                                     Advice {
-                                                                        query_index: 12,
+                                                                        query_index: 14,
                                                                         column_index: 4,
                                                                         rotation: Rotation(
                                                                             1,
@@ -8831,7 +8831,7 @@ PinnedVerificationKey {
                                                         Negated(
                                                             Scaled(
                                                                 Advice {
-                                                                    query_index: 12,
+                                                                    query_index: 14,
                                                                     column_index: 4,
                                                                     rotation: Rotation(
                                                                         1,
@@ -8853,7 +8853,7 @@ PinnedVerificationKey {
                                                     Negated(
                                                         Scaled(
                                                             Advice {
-                                                                query_index: 12,
+                                                                query_index: 14,
                                                                 column_index: 4,
                                                                 rotation: Rotation(
                                                                     1,
@@ -8875,7 +8875,7 @@ PinnedVerificationKey {
                                                 Negated(
                                                     Scaled(
                                                         Advice {
-                                                            query_index: 12,
+                                                            query_index: 14,
                                                             column_index: 4,
                                                             rotation: Rotation(
                                                                 1,
@@ -8897,7 +8897,7 @@ PinnedVerificationKey {
                                             Negated(
                                                 Scaled(
                                                     Advice {
-                                                        query_index: 12,
+                                                        query_index: 14,
                                                         column_index: 4,
                                                         rotation: Rotation(
                                                             1,
@@ -8919,7 +8919,7 @@ PinnedVerificationKey {
                                         Negated(
                                             Scaled(
                                                 Advice {
-                                                    query_index: 12,
+                                                    query_index: 14,
                                                     column_index: 4,
                                                     rotation: Rotation(
                                                         1,
@@ -8941,7 +8941,7 @@ PinnedVerificationKey {
                                     Negated(
                                         Scaled(
                                             Advice {
-                                                query_index: 12,
+                                                query_index: 14,
                                                 column_index: 4,
                                                 rotation: Rotation(
                                                     1,
@@ -8974,8 +8974,8 @@ PinnedVerificationKey {
             ),
             Product(
                 Fixed {
-                    query_index: 19,
-                    column_index: 19,
+                    query_index: 22,
+                    column_index: 22,
                     rotation: Rotation(
                         0,
                     ),
@@ -9021,8 +9021,8 @@ PinnedVerificationKey {
             ),
             Product(
                 Fixed {
-                    query_index: 19,
-                    column_index: 19,
+                    query_index: 22,
+                    column_index: 22,
                     rotation: Rotation(
                         0,
                     ),
@@ -9708,8 +9708,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -9720,8 +9720,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -9735,8 +9735,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -9750,8 +9750,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -9788,8 +9788,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -9800,8 +9800,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -9815,8 +9815,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -9830,8 +9830,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -9868,8 +9868,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -9880,8 +9880,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -9895,8 +9895,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -9910,8 +9910,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -9961,8 +9961,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -9973,8 +9973,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -9988,8 +9988,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10003,8 +10003,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10045,8 +10045,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10057,8 +10057,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10072,8 +10072,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10087,8 +10087,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10118,8 +10118,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10130,8 +10130,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10145,8 +10145,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10160,8 +10160,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10207,8 +10207,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10219,8 +10219,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10234,8 +10234,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10249,8 +10249,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10324,8 +10324,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10336,8 +10336,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10351,8 +10351,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10366,8 +10366,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10397,8 +10397,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10409,8 +10409,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10424,8 +10424,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10439,8 +10439,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10509,8 +10509,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10521,8 +10521,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10536,8 +10536,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10551,8 +10551,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10589,8 +10589,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10601,8 +10601,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10616,8 +10616,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10631,8 +10631,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10676,8 +10676,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10688,8 +10688,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10703,8 +10703,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10718,8 +10718,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10777,8 +10777,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -10789,8 +10789,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -10804,8 +10804,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -10819,8 +10819,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -11122,8 +11122,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -11134,8 +11134,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -11149,8 +11149,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -11164,8 +11164,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -11467,8 +11467,8 @@ PinnedVerificationKey {
                     Product(
                         Product(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -11479,8 +11479,8 @@ PinnedVerificationKey {
                                 ),
                                 Negated(
                                     Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
+                                        query_index: 21,
+                                        column_index: 21,
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -11494,8 +11494,8 @@ PinnedVerificationKey {
                             ),
                             Negated(
                                 Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
+                                    query_index: 21,
+                                    column_index: 21,
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -11509,8 +11509,8 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Fixed {
-                                query_index: 22,
-                                column_index: 22,
+                                query_index: 21,
+                                column_index: 21,
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -13295,14 +13295,14 @@ PinnedVerificationKey {
                                     Product(
                                         Sum(
                                             Advice {
-                                                query_index: 14,
+                                                query_index: 13,
                                                 column_index: 3,
                                                 rotation: Rotation(
                                                     1,
                                                 ),
                                             },
                                             Advice {
-                                                query_index: 12,
+                                                query_index: 14,
                                                 column_index: 4,
                                                 rotation: Rotation(
                                                     1,
@@ -13322,14 +13322,14 @@ PinnedVerificationKey {
                                                     Sum(
                                                         Product(
                                                             Advice {
-                                                                query_index: 14,
+                                                                query_index: 13,
                                                                 column_index: 3,
                                                                 rotation: Rotation(
                                                                     1,
                                                                 ),
                                                             },
                                                             Advice {
-                                                                query_index: 14,
+                                                                query_index: 13,
                                                                 column_index: 3,
                                                                 rotation: Rotation(
                                                                     1,
@@ -13389,7 +13389,7 @@ PinnedVerificationKey {
                                     0x0000000000000000000000000000000000000000000000000000000000000002,
                                 ),
                                 Advice {
-                                    query_index: 14,
+                                    query_index: 13,
                                     column_index: 3,
                                     rotation: Rotation(
                                         1,
@@ -13810,7 +13810,7 @@ PinnedVerificationKey {
                     ),
                     Negated(
                         Advice {
-                            query_index: 12,
+                            query_index: 14,
                             column_index: 4,
                             rotation: Rotation(
                                 1,
@@ -13941,7 +13941,7 @@ PinnedVerificationKey {
                                 ),
                                 Scaled(
                                     Advice {
-                                        query_index: 13,
+                                        query_index: 12,
                                         column_index: 2,
                                         rotation: Rotation(
                                             1,
@@ -14055,7 +14055,7 @@ PinnedVerificationKey {
                 Sum(
                     Sum(
                         Advice {
-                            query_index: 14,
+                            query_index: 13,
                             column_index: 3,
                             rotation: Rotation(
                                 1,
@@ -14182,7 +14182,7 @@ PinnedVerificationKey {
                     Negated(
                         Sum(
                             Advice {
-                                query_index: 13,
+                                query_index: 12,
                                 column_index: 2,
                                 rotation: Rotation(
                                     1,
@@ -14190,7 +14190,7 @@ PinnedVerificationKey {
                             },
                             Scaled(
                                 Advice {
-                                    query_index: 14,
+                                    query_index: 13,
                                     column_index: 3,
                                     rotation: Rotation(
                                         1,
@@ -15920,7 +15920,7 @@ PinnedVerificationKey {
                 ),
                 Product(
                     Advice {
-                        query_index: 12,
+                        query_index: 14,
                         column_index: 4,
                         rotation: Rotation(
                             1,
@@ -15932,7 +15932,7 @@ PinnedVerificationKey {
                         ),
                         Negated(
                             Advice {
-                                query_index: 12,
+                                query_index: 14,
                                 column_index: 4,
                                 rotation: Rotation(
                                     1,
@@ -16163,7 +16163,7 @@ PinnedVerificationKey {
                 ),
                 Sum(
                     Advice {
-                        query_index: 13,
+                        query_index: 12,
                         column_index: 2,
                         rotation: Rotation(
                             1,
@@ -16172,7 +16172,7 @@ PinnedVerificationKey {
                     Negated(
                         Sum(
                             Advice {
-                                query_index: 14,
+                                query_index: 13,
                                 column_index: 3,
                                 rotation: Rotation(
                                     1,
@@ -16180,7 +16180,7 @@ PinnedVerificationKey {
                             },
                             Scaled(
                                 Advice {
-                                    query_index: 12,
+                                    query_index: 14,
                                     column_index: 4,
                                     rotation: Rotation(
                                         1,
@@ -16435,7 +16435,7 @@ PinnedVerificationKey {
                             ),
                             Scaled(
                                 Advice {
-                                    query_index: 14,
+                                    query_index: 13,
                                     column_index: 3,
                                     rotation: Rotation(
                                         1,
@@ -16446,7 +16446,7 @@ PinnedVerificationKey {
                         ),
                         Scaled(
                             Advice {
-                                query_index: 12,
+                                query_index: 14,
                                 column_index: 4,
                                 rotation: Rotation(
                                     1,
@@ -16990,14 +16990,14 @@ PinnedVerificationKey {
                 ),
                 Product(
                     Advice {
-                        query_index: 12,
+                        query_index: 14,
                         column_index: 4,
                         rotation: Rotation(
                             1,
                         ),
                     },
                     Advice {
-                        query_index: 14,
+                        query_index: 13,
                         column_index: 3,
                         rotation: Rotation(
                             1,
@@ -17095,7 +17095,7 @@ PinnedVerificationKey {
                 ),
                 Product(
                     Advice {
-                        query_index: 12,
+                        query_index: 14,
                         column_index: 4,
                         rotation: Rotation(
                             1,
@@ -17331,7 +17331,7 @@ PinnedVerificationKey {
                 ),
                 Product(
                     Advice {
-                        query_index: 12,
+                        query_index: 14,
                         column_index: 4,
                         rotation: Rotation(
                             1,
@@ -27258,15 +27258,6 @@ PinnedVerificationKey {
             ),
             (
                 Column {
-                    index: 4,
-                    column_type: Advice,
-                },
-                Rotation(
-                    1,
-                ),
-            ),
-            (
-                Column {
                     index: 2,
                     column_type: Advice,
                 },
@@ -27277,6 +27268,15 @@ PinnedVerificationKey {
             (
                 Column {
                     index: 3,
+                    column_type: Advice,
+                },
+                Rotation(
+                    1,
+                ),
+            ),
+            (
+                Column {
+                    index: 4,
                     column_type: Advice,
                 },
                 Rotation(
@@ -27846,7 +27846,7 @@ PinnedVerificationKey {
                                             ),
                                         ),
                                         Advice {
-                                            query_index: 13,
+                                            query_index: 12,
                                             column_index: 2,
                                             rotation: Rotation(
                                                 1,
@@ -28333,10 +28333,10 @@ PinnedVerificationKey {
         (0x1f777f0e4263ec4a19f30813739c640335ffa951cc3cc586b6c4095e737f95be, 0x061c07fb12cb19582eefd858a08e689acd970c8cb9ed8f7b928d88e691a2f586),
         (0x13d0bd76da4ace22c0e90b098d6073551322b8c734bf37eeca67fbf19687f550, 0x3d996cc9da5a31cefb453390b906eabbcc75797bc6a6b9c9e3af2fe7b6b8beed),
         (0x04cad7405b492a30db0a710c842cecc97d02059acf4c02aa79626dce68ac4837, 0x3d6d7b6698b258e61ebe0b25d9cbcd4a016cb0a2ae8d92752532d98cfb27720d),
-        (0x0974ad1a3c0eb4c8d2c59cd820a82b7f28ea2f7a245008d403815131ff30879e, 0x00bb593cdf920cef4965f788d65eba3c3aa07d9718dfb62e3e385849a0d692a8),
         (0x1b6f5383c5a0ae5bf457e1c8e17a933e892464d33fef9e9262411e01c117d87e, 0x0c552b960e8ce365b5f2302bcc0b7ce5cdf964e6036602cfc859c8769184f619),
         (0x3fa4b5cc33e30de3ac7342c84f47f4fffe7ae77dda1689c2f08050d0ab743cb1, 0x327663e39b128ec28c94486b1e5d4429000626f65230ed572c66f80406a42176),
         (0x2184a7d65b5000cc5c5f178c2f4ab5b11a67fdc626771c29ade508020c8da032, 0x34c98ee1f6dfa6c1e8cd915d1efeb484206e13e5e32e13118925913568e620b7),
+        (0x0974ad1a3c0eb4c8d2c59cd820a82b7f28ea2f7a245008d403815131ff30879e, 0x00bb593cdf920cef4965f788d65eba3c3aa07d9718dfb62e3e385849a0d692a8),
         (0x1e355d783cffccafc120f462461fb312773442762383ac444009653f3d8d4be6, 0x3c60e17b18492aa2c41798b409d2bcc1857ca57ee9d2fb0001584cedc8e141d6),
         (0x0a6fe1cc1ce659681079768ca8ff94d82c7d51ef39cd99b738b144de3a3027f6, 0x30cfc2f4e0ec95f623199970d8b762647ad2d7c3591a20781ee8187702babe5f),
         (0x00d87a2c430f1db50a63f18f8cf8807f4f70d3acb940d4130ba6811f8ba2d479, 0x13d5742320e1b2cecda6073b7f2bf5816b9067453deeaa829f356a65ef5621b2),

--- a/src/circuit_description
+++ b/src/circuit_description
@@ -3323,386 +3323,6 @@ PinnedVerificationKey {
                 Product(
                     Product(
                         Product(
-                            Fixed {
-                                query_index: 22,
-                                column_index: 22,
-                                rotation: Rotation(
-                                    0,
-                                ),
-                            },
-                            Sum(
-                                Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
-                                ),
-                                Negated(
-                                    Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
-                                        rotation: Rotation(
-                                            0,
-                                        ),
-                                    },
-                                ),
-                            ),
-                        ),
-                        Sum(
-                            Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
-                            ),
-                            Negated(
-                                Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                            ),
-                        ),
-                    ),
-                    Sum(
-                        Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
-                        ),
-                        Negated(
-                            Fixed {
-                                query_index: 22,
-                                column_index: 22,
-                                rotation: Rotation(
-                                    0,
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                Product(
-                    Sum(
-                        Advice {
-                            query_index: 10,
-                            column_index: 9,
-                            rotation: Rotation(
-                                1,
-                            ),
-                        },
-                        Negated(
-                            Scaled(
-                                Advice {
-                                    query_index: 9,
-                                    column_index: 9,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                                0x0000000000000000000000000000000000000000000000000000000000000002,
-                            ),
-                        ),
-                    ),
-                    Sum(
-                        Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000001,
-                        ),
-                        Negated(
-                            Sum(
-                                Advice {
-                                    query_index: 10,
-                                    column_index: 9,
-                                    rotation: Rotation(
-                                        1,
-                                    ),
-                                },
-                                Negated(
-                                    Scaled(
-                                        Advice {
-                                            query_index: 9,
-                                            column_index: 9,
-                                            rotation: Rotation(
-                                                0,
-                                            ),
-                                        },
-                                        0x0000000000000000000000000000000000000000000000000000000000000002,
-                                    ),
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-            Product(
-                Product(
-                    Product(
-                        Product(
-                            Fixed {
-                                query_index: 22,
-                                column_index: 22,
-                                rotation: Rotation(
-                                    0,
-                                ),
-                            },
-                            Sum(
-                                Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
-                                ),
-                                Negated(
-                                    Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
-                                        rotation: Rotation(
-                                            0,
-                                        ),
-                                    },
-                                ),
-                            ),
-                        ),
-                        Sum(
-                            Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
-                            ),
-                            Negated(
-                                Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                            ),
-                        ),
-                    ),
-                    Sum(
-                        Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
-                        ),
-                        Negated(
-                            Fixed {
-                                query_index: 22,
-                                column_index: 22,
-                                rotation: Rotation(
-                                    0,
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                Sum(
-                    Product(
-                        Sum(
-                            Advice {
-                                query_index: 10,
-                                column_index: 9,
-                                rotation: Rotation(
-                                    1,
-                                ),
-                            },
-                            Negated(
-                                Scaled(
-                                    Advice {
-                                        query_index: 9,
-                                        column_index: 9,
-                                        rotation: Rotation(
-                                            0,
-                                        ),
-                                    },
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
-                                ),
-                            ),
-                        ),
-                        Advice {
-                            query_index: 0,
-                            column_index: 0,
-                            rotation: Rotation(
-                                0,
-                            ),
-                        },
-                    ),
-                    Product(
-                        Sum(
-                            Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000001,
-                            ),
-                            Negated(
-                                Sum(
-                                    Advice {
-                                        query_index: 10,
-                                        column_index: 9,
-                                        rotation: Rotation(
-                                            1,
-                                        ),
-                                    },
-                                    Negated(
-                                        Scaled(
-                                            Advice {
-                                                query_index: 9,
-                                                column_index: 9,
-                                                rotation: Rotation(
-                                                    0,
-                                                ),
-                                            },
-                                            0x0000000000000000000000000000000000000000000000000000000000000002,
-                                        ),
-                                    ),
-                                ),
-                            ),
-                        ),
-                        Sum(
-                            Advice {
-                                query_index: 0,
-                                column_index: 0,
-                                rotation: Rotation(
-                                    0,
-                                ),
-                            },
-                            Negated(
-                                Advice {
-                                    query_index: 15,
-                                    column_index: 0,
-                                    rotation: Rotation(
-                                        1,
-                                    ),
-                                },
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-            Product(
-                Product(
-                    Product(
-                        Product(
-                            Fixed {
-                                query_index: 22,
-                                column_index: 22,
-                                rotation: Rotation(
-                                    0,
-                                ),
-                            },
-                            Sum(
-                                Constant(
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
-                                ),
-                                Negated(
-                                    Fixed {
-                                        query_index: 22,
-                                        column_index: 22,
-                                        rotation: Rotation(
-                                            0,
-                                        ),
-                                    },
-                                ),
-                            ),
-                        ),
-                        Sum(
-                            Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000003,
-                            ),
-                            Negated(
-                                Fixed {
-                                    query_index: 22,
-                                    column_index: 22,
-                                    rotation: Rotation(
-                                        0,
-                                    ),
-                                },
-                            ),
-                        ),
-                    ),
-                    Sum(
-                        Constant(
-                            0x0000000000000000000000000000000000000000000000000000000000000004,
-                        ),
-                        Negated(
-                            Fixed {
-                                query_index: 22,
-                                column_index: 22,
-                                rotation: Rotation(
-                                    0,
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-                Sum(
-                    Product(
-                        Sum(
-                            Advice {
-                                query_index: 10,
-                                column_index: 9,
-                                rotation: Rotation(
-                                    1,
-                                ),
-                            },
-                            Negated(
-                                Scaled(
-                                    Advice {
-                                        query_index: 9,
-                                        column_index: 9,
-                                        rotation: Rotation(
-                                            0,
-                                        ),
-                                    },
-                                    0x0000000000000000000000000000000000000000000000000000000000000002,
-                                ),
-                            ),
-                        ),
-                        Advice {
-                            query_index: 1,
-                            column_index: 1,
-                            rotation: Rotation(
-                                0,
-                            ),
-                        },
-                    ),
-                    Product(
-                        Sum(
-                            Constant(
-                                0x0000000000000000000000000000000000000000000000000000000000000001,
-                            ),
-                            Negated(
-                                Sum(
-                                    Advice {
-                                        query_index: 10,
-                                        column_index: 9,
-                                        rotation: Rotation(
-                                            1,
-                                        ),
-                                    },
-                                    Negated(
-                                        Scaled(
-                                            Advice {
-                                                query_index: 9,
-                                                column_index: 9,
-                                                rotation: Rotation(
-                                                    0,
-                                                ),
-                                            },
-                                            0x0000000000000000000000000000000000000000000000000000000000000002,
-                                        ),
-                                    ),
-                                ),
-                            ),
-                        ),
-                        Sum(
-                            Advice {
-                                query_index: 1,
-                                column_index: 1,
-                                rotation: Rotation(
-                                    0,
-                                ),
-                            },
-                            Advice {
-                                query_index: 16,
-                                column_index: 1,
-                                rotation: Rotation(
-                                    1,
-                                ),
-                            },
-                        ),
-                    ),
-                ),
-            ),
-            Product(
-                Product(
-                    Product(
-                        Product(
                             Product(
                                 Product(
                                     Fixed {
@@ -3807,7 +3427,7 @@ PinnedVerificationKey {
                                         ),
                                     },
                                     Advice {
-                                        query_index: 17,
+                                        query_index: 15,
                                         column_index: 5,
                                         rotation: Rotation(
                                             1,
@@ -3853,7 +3473,7 @@ PinnedVerificationKey {
                                             ),
                                             Negated(
                                                 Advice {
-                                                    query_index: 15,
+                                                    query_index: 16,
                                                     column_index: 0,
                                                     rotation: Rotation(
                                                         1,
@@ -3967,7 +3587,7 @@ PinnedVerificationKey {
                     },
                     Negated(
                         Advice {
-                            query_index: 15,
+                            query_index: 16,
                             column_index: 0,
                             rotation: Rotation(
                                 1,
@@ -4074,7 +3694,7 @@ PinnedVerificationKey {
                     },
                     Negated(
                         Advice {
-                            query_index: 16,
+                            query_index: 17,
                             column_index: 1,
                             rotation: Rotation(
                                 1,
@@ -4826,7 +4446,7 @@ PinnedVerificationKey {
                                         ),
                                     },
                                     Advice {
-                                        query_index: 17,
+                                        query_index: 15,
                                         column_index: 5,
                                         rotation: Rotation(
                                             1,
@@ -4872,7 +4492,7 @@ PinnedVerificationKey {
                                             ),
                                             Negated(
                                                 Advice {
-                                                    query_index: 15,
+                                                    query_index: 16,
                                                     column_index: 0,
                                                     rotation: Rotation(
                                                         1,
@@ -5768,7 +5388,7 @@ PinnedVerificationKey {
                                             ),
                                             Negated(
                                                 Advice {
-                                                    query_index: 15,
+                                                    query_index: 16,
                                                     column_index: 0,
                                                     rotation: Rotation(
                                                         1,
@@ -5866,7 +5486,7 @@ PinnedVerificationKey {
                     },
                     Negated(
                         Advice {
-                            query_index: 15,
+                            query_index: 16,
                             column_index: 0,
                             rotation: Rotation(
                                 1,
@@ -5957,7 +5577,7 @@ PinnedVerificationKey {
                     },
                     Negated(
                         Advice {
-                            query_index: 16,
+                            query_index: 17,
                             column_index: 1,
                             rotation: Rotation(
                                 1,
@@ -6691,7 +6311,7 @@ PinnedVerificationKey {
                                             ),
                                             Negated(
                                                 Advice {
-                                                    query_index: 15,
+                                                    query_index: 16,
                                                     column_index: 0,
                                                     rotation: Rotation(
                                                         1,
@@ -8191,6 +7811,386 @@ PinnedVerificationKey {
                             1,
                         ),
                     },
+                ),
+            ),
+            Product(
+                Product(
+                    Product(
+                        Product(
+                            Fixed {
+                                query_index: 22,
+                                column_index: 22,
+                                rotation: Rotation(
+                                    0,
+                                ),
+                            },
+                            Sum(
+                                Constant(
+                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                ),
+                                Negated(
+                                    Fixed {
+                                        query_index: 22,
+                                        column_index: 22,
+                                        rotation: Rotation(
+                                            0,
+                                        ),
+                                    },
+                                ),
+                            ),
+                        ),
+                        Sum(
+                            Constant(
+                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                            ),
+                            Negated(
+                                Fixed {
+                                    query_index: 22,
+                                    column_index: 22,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                            ),
+                        ),
+                    ),
+                    Sum(
+                        Constant(
+                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                        ),
+                        Negated(
+                            Fixed {
+                                query_index: 22,
+                                column_index: 22,
+                                rotation: Rotation(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                Product(
+                    Sum(
+                        Advice {
+                            query_index: 10,
+                            column_index: 9,
+                            rotation: Rotation(
+                                1,
+                            ),
+                        },
+                        Negated(
+                            Scaled(
+                                Advice {
+                                    query_index: 9,
+                                    column_index: 9,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                                0x0000000000000000000000000000000000000000000000000000000000000002,
+                            ),
+                        ),
+                    ),
+                    Sum(
+                        Constant(
+                            0x0000000000000000000000000000000000000000000000000000000000000001,
+                        ),
+                        Negated(
+                            Sum(
+                                Advice {
+                                    query_index: 10,
+                                    column_index: 9,
+                                    rotation: Rotation(
+                                        1,
+                                    ),
+                                },
+                                Negated(
+                                    Scaled(
+                                        Advice {
+                                            query_index: 9,
+                                            column_index: 9,
+                                            rotation: Rotation(
+                                                0,
+                                            ),
+                                        },
+                                        0x0000000000000000000000000000000000000000000000000000000000000002,
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            Product(
+                Product(
+                    Product(
+                        Product(
+                            Fixed {
+                                query_index: 22,
+                                column_index: 22,
+                                rotation: Rotation(
+                                    0,
+                                ),
+                            },
+                            Sum(
+                                Constant(
+                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                ),
+                                Negated(
+                                    Fixed {
+                                        query_index: 22,
+                                        column_index: 22,
+                                        rotation: Rotation(
+                                            0,
+                                        ),
+                                    },
+                                ),
+                            ),
+                        ),
+                        Sum(
+                            Constant(
+                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                            ),
+                            Negated(
+                                Fixed {
+                                    query_index: 22,
+                                    column_index: 22,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                            ),
+                        ),
+                    ),
+                    Sum(
+                        Constant(
+                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                        ),
+                        Negated(
+                            Fixed {
+                                query_index: 22,
+                                column_index: 22,
+                                rotation: Rotation(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                Sum(
+                    Product(
+                        Sum(
+                            Advice {
+                                query_index: 10,
+                                column_index: 9,
+                                rotation: Rotation(
+                                    1,
+                                ),
+                            },
+                            Negated(
+                                Scaled(
+                                    Advice {
+                                        query_index: 9,
+                                        column_index: 9,
+                                        rotation: Rotation(
+                                            0,
+                                        ),
+                                    },
+                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                ),
+                            ),
+                        ),
+                        Advice {
+                            query_index: 0,
+                            column_index: 0,
+                            rotation: Rotation(
+                                0,
+                            ),
+                        },
+                    ),
+                    Product(
+                        Sum(
+                            Constant(
+                                0x0000000000000000000000000000000000000000000000000000000000000001,
+                            ),
+                            Negated(
+                                Sum(
+                                    Advice {
+                                        query_index: 10,
+                                        column_index: 9,
+                                        rotation: Rotation(
+                                            1,
+                                        ),
+                                    },
+                                    Negated(
+                                        Scaled(
+                                            Advice {
+                                                query_index: 9,
+                                                column_index: 9,
+                                                rotation: Rotation(
+                                                    0,
+                                                ),
+                                            },
+                                            0x0000000000000000000000000000000000000000000000000000000000000002,
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Sum(
+                            Advice {
+                                query_index: 0,
+                                column_index: 0,
+                                rotation: Rotation(
+                                    0,
+                                ),
+                            },
+                            Negated(
+                                Advice {
+                                    query_index: 16,
+                                    column_index: 0,
+                                    rotation: Rotation(
+                                        1,
+                                    ),
+                                },
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            Product(
+                Product(
+                    Product(
+                        Product(
+                            Fixed {
+                                query_index: 22,
+                                column_index: 22,
+                                rotation: Rotation(
+                                    0,
+                                ),
+                            },
+                            Sum(
+                                Constant(
+                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                ),
+                                Negated(
+                                    Fixed {
+                                        query_index: 22,
+                                        column_index: 22,
+                                        rotation: Rotation(
+                                            0,
+                                        ),
+                                    },
+                                ),
+                            ),
+                        ),
+                        Sum(
+                            Constant(
+                                0x0000000000000000000000000000000000000000000000000000000000000003,
+                            ),
+                            Negated(
+                                Fixed {
+                                    query_index: 22,
+                                    column_index: 22,
+                                    rotation: Rotation(
+                                        0,
+                                    ),
+                                },
+                            ),
+                        ),
+                    ),
+                    Sum(
+                        Constant(
+                            0x0000000000000000000000000000000000000000000000000000000000000004,
+                        ),
+                        Negated(
+                            Fixed {
+                                query_index: 22,
+                                column_index: 22,
+                                rotation: Rotation(
+                                    0,
+                                ),
+                            },
+                        ),
+                    ),
+                ),
+                Sum(
+                    Product(
+                        Sum(
+                            Advice {
+                                query_index: 10,
+                                column_index: 9,
+                                rotation: Rotation(
+                                    1,
+                                ),
+                            },
+                            Negated(
+                                Scaled(
+                                    Advice {
+                                        query_index: 9,
+                                        column_index: 9,
+                                        rotation: Rotation(
+                                            0,
+                                        ),
+                                    },
+                                    0x0000000000000000000000000000000000000000000000000000000000000002,
+                                ),
+                            ),
+                        ),
+                        Advice {
+                            query_index: 1,
+                            column_index: 1,
+                            rotation: Rotation(
+                                0,
+                            ),
+                        },
+                    ),
+                    Product(
+                        Sum(
+                            Constant(
+                                0x0000000000000000000000000000000000000000000000000000000000000001,
+                            ),
+                            Negated(
+                                Sum(
+                                    Advice {
+                                        query_index: 10,
+                                        column_index: 9,
+                                        rotation: Rotation(
+                                            1,
+                                        ),
+                                    },
+                                    Negated(
+                                        Scaled(
+                                            Advice {
+                                                query_index: 9,
+                                                column_index: 9,
+                                                rotation: Rotation(
+                                                    0,
+                                                ),
+                                            },
+                                            0x0000000000000000000000000000000000000000000000000000000000000002,
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Sum(
+                            Advice {
+                                query_index: 1,
+                                column_index: 1,
+                                rotation: Rotation(
+                                    0,
+                                ),
+                            },
+                            Advice {
+                                query_index: 17,
+                                column_index: 1,
+                                rotation: Rotation(
+                                    1,
+                                ),
+                            },
+                        ),
+                    ),
                 ),
             ),
             Product(
@@ -13093,7 +13093,7 @@ PinnedVerificationKey {
                         Sum(
                             Sum(
                                 Advice {
-                                    query_index: 15,
+                                    query_index: 16,
                                     column_index: 0,
                                     rotation: Rotation(
                                         1,
@@ -13179,7 +13179,7 @@ PinnedVerificationKey {
                             },
                             Negated(
                                 Advice {
-                                    query_index: 15,
+                                    query_index: 16,
                                     column_index: 0,
                                     rotation: Rotation(
                                         1,
@@ -13311,7 +13311,7 @@ PinnedVerificationKey {
                                         ),
                                         Sum(
                                             Advice {
-                                                query_index: 15,
+                                                query_index: 16,
                                                 column_index: 0,
                                                 rotation: Rotation(
                                                     1,
@@ -13338,7 +13338,7 @@ PinnedVerificationKey {
                                                         ),
                                                         Negated(
                                                             Advice {
-                                                                query_index: 15,
+                                                                query_index: 16,
                                                                 column_index: 0,
                                                                 rotation: Rotation(
                                                                     1,
@@ -13348,7 +13348,7 @@ PinnedVerificationKey {
                                                     ),
                                                     Negated(
                                                         Advice {
-                                                            query_index: 16,
+                                                            query_index: 17,
                                                             column_index: 1,
                                                             rotation: Rotation(
                                                                 1,
@@ -13798,7 +13798,7 @@ PinnedVerificationKey {
                         Negated(
                             Scaled(
                                 Advice {
-                                    query_index: 15,
+                                    query_index: 16,
                                     column_index: 0,
                                     rotation: Rotation(
                                         1,
@@ -13910,7 +13910,7 @@ PinnedVerificationKey {
                 Sum(
                     Sum(
                         Advice {
-                            query_index: 15,
+                            query_index: 16,
                             column_index: 0,
                             rotation: Rotation(
                                 1,
@@ -13929,7 +13929,7 @@ PinnedVerificationKey {
                                     Negated(
                                         Scaled(
                                             Advice {
-                                                query_index: 16,
+                                                query_index: 17,
                                                 column_index: 1,
                                                 rotation: Rotation(
                                                     1,
@@ -14173,7 +14173,7 @@ PinnedVerificationKey {
                 ),
                 Sum(
                     Advice {
-                        query_index: 16,
+                        query_index: 17,
                         column_index: 1,
                         rotation: Rotation(
                             1,
@@ -14401,7 +14401,7 @@ PinnedVerificationKey {
                         Sum(
                             Sum(
                                 Advice {
-                                    query_index: 17,
+                                    query_index: 15,
                                     column_index: 5,
                                     rotation: Rotation(
                                         1,
@@ -14487,7 +14487,7 @@ PinnedVerificationKey {
                             },
                             Negated(
                                 Advice {
-                                    query_index: 17,
+                                    query_index: 15,
                                     column_index: 5,
                                     rotation: Rotation(
                                         1,
@@ -14619,7 +14619,7 @@ PinnedVerificationKey {
                                         ),
                                         Sum(
                                             Advice {
-                                                query_index: 17,
+                                                query_index: 15,
                                                 column_index: 5,
                                                 rotation: Rotation(
                                                     1,
@@ -14646,7 +14646,7 @@ PinnedVerificationKey {
                                                         ),
                                                         Negated(
                                                             Advice {
-                                                                query_index: 17,
+                                                                query_index: 15,
                                                                 column_index: 5,
                                                                 rotation: Rotation(
                                                                     1,
@@ -15266,7 +15266,7 @@ PinnedVerificationKey {
                         Negated(
                             Scaled(
                                 Advice {
-                                    query_index: 17,
+                                    query_index: 15,
                                     column_index: 5,
                                     rotation: Rotation(
                                         1,
@@ -15394,7 +15394,7 @@ PinnedVerificationKey {
                 Sum(
                     Sum(
                         Advice {
-                            query_index: 17,
+                            query_index: 15,
                             column_index: 5,
                             rotation: Rotation(
                                 1,
@@ -16424,7 +16424,7 @@ PinnedVerificationKey {
                                 },
                                 Scaled(
                                     Advice {
-                                        query_index: 16,
+                                        query_index: 17,
                                         column_index: 1,
                                         rotation: Rotation(
                                             1,
@@ -16457,7 +16457,7 @@ PinnedVerificationKey {
                     ),
                     Negated(
                         Advice {
-                            query_index: 15,
+                            query_index: 16,
                             column_index: 0,
                             rotation: Rotation(
                                 1,
@@ -17211,7 +17211,7 @@ PinnedVerificationKey {
                                 },
                                 Scaled(
                                     Advice {
-                                        query_index: 16,
+                                        query_index: 17,
                                         column_index: 1,
                                         rotation: Rotation(
                                             1,
@@ -21504,7 +21504,7 @@ PinnedVerificationKey {
                 ),
                 Sum(
                     Advice {
-                        query_index: 17,
+                        query_index: 15,
                         column_index: 5,
                         rotation: Rotation(
                             1,
@@ -21661,7 +21661,7 @@ PinnedVerificationKey {
                         Sum(
                             Sum(
                                 Advice {
-                                    query_index: 17,
+                                    query_index: 15,
                                     column_index: 5,
                                     rotation: Rotation(
                                         1,
@@ -21800,7 +21800,7 @@ PinnedVerificationKey {
                     Sum(
                         Sum(
                             Advice {
-                                query_index: 17,
+                                query_index: 15,
                                 column_index: 5,
                                 rotation: Rotation(
                                     1,
@@ -26460,7 +26460,7 @@ PinnedVerificationKey {
                 ),
                 Sum(
                     Advice {
-                        query_index: 17,
+                        query_index: 15,
                         column_index: 5,
                         rotation: Rotation(
                             1,
@@ -26617,7 +26617,7 @@ PinnedVerificationKey {
                         Sum(
                             Sum(
                                 Advice {
-                                    query_index: 17,
+                                    query_index: 15,
                                     column_index: 5,
                                     rotation: Rotation(
                                         1,
@@ -26756,7 +26756,7 @@ PinnedVerificationKey {
                     Sum(
                         Sum(
                             Advice {
-                                query_index: 17,
+                                query_index: 15,
                                 column_index: 5,
                                 rotation: Rotation(
                                     1,
@@ -27285,6 +27285,15 @@ PinnedVerificationKey {
             ),
             (
                 Column {
+                    index: 5,
+                    column_type: Advice,
+                },
+                Rotation(
+                    1,
+                ),
+            ),
+            (
+                Column {
                     index: 0,
                     column_type: Advice,
                 },
@@ -27295,15 +27304,6 @@ PinnedVerificationKey {
             (
                 Column {
                     index: 1,
-                    column_type: Advice,
-                },
-                Rotation(
-                    1,
-                ),
-            ),
-            (
-                Column {
-                    index: 5,
                     column_type: Advice,
                 },
                 Rotation(


### PR DESCRIPTION
Closes #246. Based on #247. 

Review recommendation: commit-by-commit, with whitespace changes hidden.

This PR introduces a `configure()` method for each sub-config, refactoring away from the `impl From<EccConfig>` pattern. This allows each sub-config to enable equalities for the columns it needs.

This PR changes the order in which columns and gates are created; however, it DOES NOT change the number of columns.