### PR TITLE
Replace `PartialEq, PartialOrd` with `ConstantTimeEq` on `{Extended}SpendingKey`

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -35,6 +35,12 @@ const ZIP32_PURPOSE: u32 = 32;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SpendingKey([u8; 32]);
 
+impl ConstantTimeEq for SpendingKey {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.to_bytes().ct_eq(other.to_bytes())
+    }
+}
+
 impl SpendingKey {
     /// Generates a random spending key.
     ///

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -32,7 +32,7 @@ const ZIP32_PURPOSE: u32 = 32;
 /// Defined in [Zcash Protocol Spec § 4.2.3: Orchard Key Components][orchardkeycomponents].
 ///
 /// [orchardkeycomponents]: https://zips.z.cash/protocol/nu5.pdf#orchardkeycomponents
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone)]
 pub struct SpendingKey([u8; 32]);
 
 impl ConstantTimeEq for SpendingKey {

--- a/src/zip32.rs
+++ b/src/zip32.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use blake2b_simd::Params as Blake2bParams;
+use subtle::{Choice, ConstantTimeEq};
 
 use crate::{
     keys::{FullViewingKey, SpendingKey},
@@ -99,6 +100,16 @@ pub(crate) struct ExtendedSpendingKey {
     child_index: ChildIndex,
     chain_code: ChainCode,
     sk: SpendingKey,
+}
+
+impl ConstantTimeEq for ExtendedSpendingKey {
+    fn ct_eq(&self, rhs: &Self) -> Choice {
+        self.depth.ct_eq(&rhs.depth)
+            & self.parent_fvk_tag.0.ct_eq(&rhs.parent_fvk_tag.0)
+            & self.child_index.0.ct_eq(&rhs.child_index.0)
+            & self.chain_code.0.ct_eq(&rhs.chain_code.0)
+            & self.sk.ct_eq(&rhs.sk)
+    }
 }
 
 impl std::cmp::PartialEq for ExtendedSpendingKey {

--- a/src/zip32.rs
+++ b/src/zip32.rs
@@ -112,16 +112,6 @@ impl ConstantTimeEq for ExtendedSpendingKey {
     }
 }
 
-impl std::cmp::PartialEq for ExtendedSpendingKey {
-    fn eq(&self, rhs: &ExtendedSpendingKey) -> bool {
-        self.depth == rhs.depth
-            && self.parent_fvk_tag == rhs.parent_fvk_tag
-            && self.child_index == rhs.child_index
-            && self.chain_code == rhs.chain_code
-            && self.sk == rhs.sk
-    }
-}
-
 #[allow(non_snake_case)]
 impl ExtendedSpendingKey {
     /// Returns the spending key of the child key corresponding to
@@ -240,16 +230,17 @@ mod tests {
         let xsk_m = ExtendedSpendingKey::master(&seed).unwrap();
 
         let xsk_5h = xsk_m.derive_child(5.try_into().unwrap()).unwrap();
-        assert_eq!(
-            ExtendedSpendingKey::from_path(&seed, &[5.try_into().unwrap()]).unwrap(),
-            xsk_5h
-        );
+        assert!(bool::from(
+            ExtendedSpendingKey::from_path(&seed, &[5.try_into().unwrap()])
+                .unwrap()
+                .ct_eq(&xsk_5h)
+        ));
 
         let xsk_5h_7 = xsk_5h.derive_child(7.try_into().unwrap()).unwrap();
-        assert_eq!(
+        assert!(bool::from(
             ExtendedSpendingKey::from_path(&seed, &[5.try_into().unwrap(), 7.try_into().unwrap()])
-                .unwrap(),
-            xsk_5h_7
-        );
+                .unwrap()
+                .ct_eq(&xsk_5h_7)
+        ));
     }
 }


### PR DESCRIPTION
Closes #241.