### PR TITLE
circuit: Pin the proof size

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -1026,14 +1026,15 @@ mod tests {
         }
 
         // Test that the proof size is as expected.
-        {
+        let expected_proof_size = {
             let circuit_cost = halo2::dev::CircuitCost::<pasta_curves::vesta::Point, _>::measure(
                 K as usize,
                 &circuits[0],
             );
             assert_eq!(usize::from(circuit_cost.proof_size(1)), 4992);
             assert_eq!(usize::from(circuit_cost.proof_size(2)), 7264);
-        }
+            usize::from(circuit_cost.proof_size(instances.len()))
+        };
 
         for (circuit, instance) in circuits.iter().zip(instances.iter()) {
             assert_eq!(
@@ -1055,6 +1056,7 @@ mod tests {
         let pk = ProvingKey::build();
         let proof = Proof::create(&pk, &circuits, &instances).unwrap();
         assert!(proof.verify(&vk, &instances).is_ok());
+        assert_eq!(proof.0.len(), expected_proof_size);
     }
 
     #[cfg(feature = "dev-graph")]

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -1025,6 +1025,16 @@ mod tests {
             );
         }
 
+        // Test that the proof size is as expected.
+        {
+            let circuit_cost = halo2::dev::CircuitCost::<pasta_curves::vesta::Point, _>::measure(
+                K as usize,
+                &circuits[0],
+            );
+            assert_eq!(usize::from(circuit_cost.proof_size(1)), 4992);
+            assert_eq!(usize::from(circuit_cost.proof_size(2)), 7264);
+        }
+
         for (circuit, instance) in circuits.iter().zip(instances.iter()) {
             assert_eq!(
                 MockProver::run(


### PR DESCRIPTION
This is to ensure that if any future circuit changes are made, their effect on the proof size (if any) will be noticed.