### PR TITLE
Remove various usages of `FieldExt` methods

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -8,10 +8,7 @@ use halo2::{
     transcript::{Blake2bRead, Blake2bWrite},
 };
 use memuse::DynamicUsage;
-use pasta_curves::{
-    arithmetic::{CurveAffine, FieldExt},
-    pallas, vesta,
-};
+use pasta_curves::{arithmetic::CurveAffine, pallas, vesta};
 
 use crate::{
     constants::{
@@ -377,16 +374,14 @@ impl plonk::Circuit<pallas::Base> for Circuit {
             let v_old = self.load_private(
                 layouter.namespace(|| "witness v_old"),
                 config.advices[0],
-                self.v_old
-                    .map(|v_old| pallas::Base::from_u64(v_old.inner())),
+                self.v_old.map(|v_old| pallas::Base::from(v_old.inner())),
             )?;
 
             // Witness v_new.
             let v_new = self.load_private(
                 layouter.namespace(|| "witness v_new"),
                 config.advices[0],
-                self.v_new
-                    .map(|v_new| pallas::Base::from_u64(v_new.inner())),
+                self.v_new.map(|v_new| pallas::Base::from(v_new.inner())),
             )?;
 
             (psi_old, rho_old, cm_old, g_d_old, ak, nk, v_old, v_new)
@@ -415,12 +410,8 @@ impl plonk::Circuit<pallas::Base> for Circuit {
             let v_net = {
                 // v_old, v_new are guaranteed to be 64-bit values. Therefore, we can
                 // move them into the base field.
-                let v_old = self
-                    .v_old
-                    .map(|v_old| pallas::Base::from_u64(v_old.inner()));
-                let v_new = self
-                    .v_new
-                    .map(|v_new| pallas::Base::from_u64(v_new.inner()));
+                let v_old = self.v_old.map(|v_old| pallas::Base::from(v_old.inner()));
+                let v_new = self.v_new.map(|v_new| pallas::Base::from(v_new.inner()));
 
                 let magnitude_sign = v_old.zip(v_new).map(|(v_old, v_new)| {
                     let is_negative = v_old < v_new;
@@ -814,8 +805,8 @@ impl Instance {
         instance[RK_X] = *rk.x();
         instance[RK_Y] = *rk.y();
         instance[CMX] = self.cmx.inner();
-        instance[ENABLE_SPEND] = vesta::Scalar::from_u64(self.enable_spend.into());
-        instance[ENABLE_OUTPUT] = vesta::Scalar::from_u64(self.enable_output.into());
+        instance[ENABLE_SPEND] = vesta::Scalar::from(u64::from(self.enable_spend));
+        instance[ENABLE_OUTPUT] = vesta::Scalar::from(u64::from(self.enable_output));
 
         [instance]
     }

--- a/src/circuit/gadget/ecc/chip/add.rs
+++ b/src/circuit/gadget/ecc/chip/add.rs
@@ -121,8 +121,8 @@ impl Config {
 
             // Useful constants
             let one = Expression::Constant(pallas::Base::one());
-            let two = Expression::Constant(pallas::Base::from_u64(2));
-            let three = Expression::Constant(pallas::Base::from_u64(3));
+            let two = Expression::Constant(pallas::Base::from(2));
+            let three = Expression::Constant(pallas::Base::from(3));
 
             // (x_q − x_p)⋅((x_q − x_p)⋅λ − (y_q−y_p)) = 0
             let poly1 = {
@@ -302,7 +302,7 @@ impl Config {
                     } else {
                         if !y_p.is_zero_vartime() {
                             // 3(x_p)^2
-                            let three_x_p_sq = pallas::Base::from_u64(3) * x_p.square();
+                            let three_x_p_sq = pallas::Base::from(3) * x_p.square();
                             // 1 / 2(y_p)
                             let inv_two_y_p = y_p.invert().unwrap() * pallas::Base::TWO_INV;
                             // λ = 3(x_p)^2 / 2(y_p)

--- a/src/circuit/gadget/ecc/chip/mul.rs
+++ b/src/circuit/gadget/ecc/chip/mul.rs
@@ -258,7 +258,7 @@ impl Config {
                     let base = base.point();
                     let alpha = alpha
                         .value()
-                        .map(|alpha| pallas::Scalar::from_bytes(&alpha.to_bytes()).unwrap());
+                        .map(|alpha| pallas::Scalar::from_repr(alpha.to_repr()).unwrap());
                     let real_mul = base.zip(alpha).map(|(base, alpha)| base * alpha);
                     let result = result.point();
 
@@ -431,7 +431,7 @@ fn decompose_for_scalar_mul(scalar: Option<&pallas::Base>) -> Vec<Option<bool>> 
         // the scalar field `F_q = 2^254 + t_q`.
         // Note that the addition `scalar + t_q` is not reduced.
         //
-        let scalar = U256::from_little_endian(&scalar.to_bytes());
+        let scalar = U256::from_little_endian(&scalar.to_repr());
         let t_q = U256::from_little_endian(&T_Q.to_le_bytes());
         let k = scalar + t_q;
 
@@ -463,7 +463,7 @@ fn decompose_for_scalar_mul(scalar: Option<&pallas::Base>) -> Vec<Option<bool>> 
 
 #[cfg(test)]
 pub mod tests {
-    use group::Curve;
+    use group::{ff::PrimeField, Curve};
     use halo2::{
         circuit::{Chip, Layouter},
         plonk::Error,
@@ -497,7 +497,7 @@ pub mod tests {
         ) -> Result<(), Error> {
             // Move scalar from base field into scalar field (which always fits
             // for Pallas).
-            let scalar = pallas::Scalar::from_bytes(&scalar_val.to_bytes()).unwrap();
+            let scalar = pallas::Scalar::from_repr(scalar_val.to_repr()).unwrap();
             let expected = NonIdentityPoint::new(
                 chip,
                 layouter.namespace(|| "expected point"),

--- a/src/circuit/gadget/ecc/chip/mul.rs
+++ b/src/circuit/gadget/ecc/chip/mul.rs
@@ -143,7 +143,7 @@ impl Config {
 
             //    z_0 = 2 * z_1 + k_0
             // => k_0 = z_0 - 2 * z_1
-            let lsb = z_0 - z_1 * pallas::Base::from_u64(2);
+            let lsb = z_0 - z_1 * pallas::Base::from(2);
 
             let bool_check = bool_check(lsb.clone());
 
@@ -326,8 +326,8 @@ impl Config {
         // Assign z_0 = 2⋅z_1 + k_0
         let z_0 = {
             let z_0_val = z_1.value().zip(lsb).map(|(z_1, lsb)| {
-                let lsb = pallas::Base::from_u64(lsb as u64);
-                z_1 * pallas::Base::from_u64(2) + lsb
+                let lsb = pallas::Base::from(lsb as u64);
+                z_1 * pallas::Base::from(2) + lsb
             });
             let z_0_cell = region.assign_advice(
                 || "z_0",

--- a/src/circuit/gadget/ecc/chip/mul/complete.rs
+++ b/src/circuit/gadget/ecc/chip/mul/complete.rs
@@ -8,7 +8,7 @@ use halo2::{
     poly::Rotation,
 };
 
-use pasta_curves::{arithmetic::FieldExt, pallas};
+use pasta_curves::pallas;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Config {
@@ -59,7 +59,7 @@ impl Config {
                 let z_next = meta.query_advice(self.z_complete, Rotation::next());
 
                 // k_{i} = z_{i} - 2⋅z_{i+1}
-                let k = z_next - Expression::Constant(pallas::Base::from_u64(2)) * z_prev;
+                let k = z_next - Expression::Constant(pallas::Base::from(2)) * z_prev;
                 // (k_i) ⋅ (1 - k_i) = 0
                 let bool_check = bool_check(k.clone());
 
@@ -137,7 +137,7 @@ impl Config {
             z = {
                 // z_next = z_cur * 2 + k_next
                 let z_val = z.value().zip(k.as_ref()).map(|(z_val, k)| {
-                    pallas::Base::from_u64(2) * z_val + pallas::Base::from_u64(*k as u64)
+                    pallas::Base::from(2) * z_val + pallas::Base::from(*k as u64)
                 });
                 let z_cell = region.assign_advice(
                     || "z",

--- a/src/circuit/gadget/ecc/chip/mul/incomplete.rs
+++ b/src/circuit/gadget/ecc/chip/mul/incomplete.rs
@@ -103,13 +103,13 @@ impl<const NUM_BITS: usize> Config<NUM_BITS> {
             // The current bit in the scalar decomposition, k_i = z_i - 2⋅z_{i+1}.
             // Recall that we assigned the cumulative variable `z_i` in descending order,
             // i from n down to 0. So z_{i+1} corresponds to the `z_prev` query.
-            let k = z_cur - z_prev * pallas::Base::from_u64(2);
+            let k = z_cur - z_prev * pallas::Base::from(2);
             // Check booleanity of decomposition.
             let bool_check = bool_check(k.clone());
 
             // λ_{1,i}⋅(x_{A,i} − x_{P,i}) − y_{A,i} + (2k_i - 1) y_{P,i} = 0
             let gradient_1 = lambda1_cur * (x_a_cur.clone() - x_p_cur) - y_a_cur.clone()
-                + (k * pallas::Base::from_u64(2) - one) * y_p_cur;
+                + (k * pallas::Base::from(2) - one) * y_p_cur;
 
             // λ_{2,i}^2 − x_{A,i-1} − x_{R,i} − x_{A,i} = 0
             let secant_line = lambda2_cur.clone().square()
@@ -245,9 +245,10 @@ impl<const NUM_BITS: usize> Config<NUM_BITS> {
         // Incomplete addition
         for (row, k) in bits.iter().enumerate() {
             // z_{i} = 2 * z_{i+1} + k_i
-            let z_val = z.value().zip(k.as_ref()).map(|(z_val, k)| {
-                pallas::Base::from_u64(2) * z_val + pallas::Base::from_u64(*k as u64)
-            });
+            let z_val = z
+                .value()
+                .zip(k.as_ref())
+                .map(|(z_val, k)| pallas::Base::from(2) * z_val + pallas::Base::from(*k as u64));
             z = region.assign_advice(
                 || "z",
                 self.z,
@@ -301,7 +302,7 @@ impl<const NUM_BITS: usize> Config<NUM_BITS> {
                     .zip(x_a.value())
                     .zip(x_r)
                     .map(|(((lambda1, y_a), x_a), x_r)| {
-                        pallas::Base::from_u64(2) * y_a * (x_a - x_r).invert().unwrap() - lambda1
+                        pallas::Base::from(2) * y_a * (x_a - x_r).invert().unwrap() - lambda1
                     });
             region.assign_advice(
                 || "lambda2",

--- a/src/circuit/gadget/ecc/chip/mul_fixed.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed.rs
@@ -25,10 +25,10 @@ pub mod full_width;
 pub mod short;
 
 lazy_static! {
-    static ref TWO_SCALAR: pallas::Scalar = pallas::Scalar::from_u64(2);
+    static ref TWO_SCALAR: pallas::Scalar = pallas::Scalar::from(2);
     // H = 2^3 (3-bit window)
-    static ref H_SCALAR: pallas::Scalar = pallas::Scalar::from_u64(constants::H as u64);
-    static ref H_BASE: pallas::Base = pallas::Base::from_u64(constants::H as u64);
+    static ref H_SCALAR: pallas::Scalar = pallas::Scalar::from(constants::H as u64);
+    static ref H_BASE: pallas::Base = pallas::Base::from(constants::H as u64);
 }
 
 // A sum type for both full-width and short bases. This enables us to use the
@@ -182,7 +182,7 @@ impl Config {
 
             //    z_{i+1} = (z_i - a_i) / 2^3
             // => a_i = z_i - z_{i+1} * 2^3
-            let word = z_cur - z_next * pallas::Base::from_u64(constants::H as u64);
+            let word = z_cur - z_next * pallas::Base::from(constants::H as u64);
 
             self.coords_check(meta, q_mul_fixed_running_sum, word)
         });

--- a/src/circuit/gadget/ecc/chip/mul_fixed.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed.rs
@@ -8,7 +8,7 @@ use crate::constants::{
     load::{NullifierK, OrchardFixedBase, OrchardFixedBasesFull, ValueCommitV, WindowUs},
 };
 
-use group::Curve;
+use group::{ff::PrimeField, Curve};
 use halo2::{
     circuit::{AssignedCell, Region},
     plonk::{Advice, Column, ConstraintSystem, Error, Expression, Fixed, Selector, VirtualCells},
@@ -531,7 +531,7 @@ impl ScalarFixed {
                     let word = z_cur
                         .zip(z_next)
                         .map(|(z_cur, z_next)| z_cur - z_next * *H_BASE);
-                    word.map(|word| pallas::Scalar::from_bytes(&word.to_bytes()).unwrap())
+                    word.map(|word| pallas::Scalar::from_repr(word.to_repr()).unwrap())
                 })
                 .collect::<Vec<_>>()
         };
@@ -543,7 +543,7 @@ impl ScalarFixed {
                 .iter()
                 .map(|bits| {
                     bits.value()
-                        .map(|value| pallas::Scalar::from_bytes(&value.to_bytes()).unwrap())
+                        .map(|value| pallas::Scalar::from_repr(value.to_repr()).unwrap())
                 })
                 .collect::<Vec<_>>(),
         }

--- a/src/circuit/gadget/ecc/chip/mul_fixed/base_field_elem.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/base_field_elem.rs
@@ -89,7 +89,7 @@ impl Config {
                 let alpha_2_range_check = range_check(alpha_2.clone(), 1 << 1);
                 // Check that α_1 + 2^2 α_2 = z_84_alpha
                 let z_84_alpha_check = z_84_alpha.clone()
-                    - (alpha_1.clone() + alpha_2.clone() * pallas::Base::from_u64(1 << 2));
+                    - (alpha_1.clone() + alpha_2.clone() * pallas::Base::from(1 << 2));
 
                 std::iter::empty()
                     .chain(Some(("alpha_1_range_check", alpha_1_range_check)))
@@ -455,11 +455,11 @@ pub mod tests {
         // (There is another *non-canonical* sequence
         // 5333333333333333333333333333333333333333332711161673731021062440252244051273333333333 in octal.)
         {
-            let h = pallas::Base::from_u64(constants::H as u64);
+            let h = pallas::Base::from(constants::H as u64);
             let scalar_fixed = "1333333333333333333333333333333333333333333333333333333333333333333333333333333333334"
                         .chars()
                         .fold(pallas::Base::zero(), |acc, c| {
-                            acc * &h + &pallas::Base::from_u64(c.to_digit(8).unwrap().into())
+                            acc * &h + &pallas::Base::from(c.to_digit(8).unwrap() as u64)
                         });
             let result = {
                 let scalar_fixed = chip.load_private(

--- a/src/circuit/gadget/ecc/chip/mul_fixed/base_field_elem.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/base_field_elem.rs
@@ -214,13 +214,13 @@ impl Config {
         #[cfg(test)]
         // Check that the correct multiple is obtained.
         {
-            use group::Curve;
+            use group::{ff::PrimeField, Curve};
 
             let base: super::OrchardFixedBases = base.into();
             let scalar = &scalar
                 .base_field_elem()
                 .value()
-                .map(|scalar| pallas::Scalar::from_bytes(&scalar.to_bytes()).unwrap());
+                .map(|scalar| pallas::Scalar::from_repr(scalar.to_repr()).unwrap());
             let real_mul = scalar.map(|scalar| base.generator() * scalar);
             let result = result.point();
 
@@ -374,7 +374,7 @@ impl Config {
 
 #[cfg(test)]
 pub mod tests {
-    use group::Curve;
+    use group::{ff::PrimeField, Curve};
     use halo2::{
         circuit::{Chip, Layouter},
         plonk::Error,
@@ -421,7 +421,7 @@ pub mod tests {
             result: Point<pallas::Affine, EccChip>,
         ) -> Result<(), Error> {
             // Move scalar from base field into scalar field (which always fits for Pallas).
-            let scalar = pallas::Scalar::from_bytes(&scalar_val.to_bytes()).unwrap();
+            let scalar = pallas::Scalar::from_repr(scalar_val.to_repr()).unwrap();
             let expected = NonIdentityPoint::new(
                 chip,
                 layouter.namespace(|| "expected point"),

--- a/src/circuit/gadget/ecc/chip/mul_fixed/full_width.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/full_width.rs
@@ -10,7 +10,7 @@ use halo2::{
     plonk::{ConstraintSystem, Error, Selector},
     poly::Rotation,
 };
-use pasta_curves::{arithmetic::FieldExt, pallas};
+use pasta_curves::pallas;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Config {
@@ -99,7 +99,7 @@ impl Config {
             assert_eq!(windows.len(), NUM_WINDOWS);
             windows
                 .into_iter()
-                .map(|window| Some(pallas::Base::from_u64(window as u64)))
+                .map(|window| Some(pallas::Base::from(window as u64)))
                 .collect()
         } else {
             vec![None; NUM_WINDOWS]
@@ -272,11 +272,11 @@ pub mod tests {
         // (There is another *non-canonical* sequence
         // 5333333333333333333333333333333333333333332711161673731021062440252244051273333333333 in octal.)
         {
-            let h = pallas::Scalar::from_u64(constants::H as u64);
+            let h = pallas::Scalar::from(constants::H as u64);
             let scalar_fixed = "1333333333333333333333333333333333333333333333333333333333333333333333333333333333334"
                         .chars()
                         .fold(pallas::Scalar::zero(), |acc, c| {
-                            acc * &h + &pallas::Scalar::from_u64(c.to_digit(8).unwrap().into())
+                            acc * &h + &pallas::Scalar::from(c.to_digit(8).unwrap() as u64)
                         });
             let (result, _) =
                 base.mul(layouter.namespace(|| "mul with double"), Some(scalar_fixed))?;

--- a/src/circuit/gadget/ecc/chip/mul_fixed/short.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/short.rs
@@ -191,8 +191,7 @@ impl Config {
             use pasta_curves::arithmetic::FieldExt;
 
             if let (Some(magnitude), Some(sign)) = (scalar.magnitude.value(), scalar.sign.value()) {
-                let magnitude_is_valid =
-                    magnitude <= &pallas::Base::from_u64(0xFFFF_FFFF_FFFF_FFFFu64);
+                let magnitude_is_valid = magnitude <= &pallas::Base::from(0xFFFF_FFFF_FFFF_FFFFu64);
                 let sign_is_valid = sign * sign == pallas::Base::one();
                 if magnitude_is_valid && sign_is_valid {
                     let base: super::OrchardFixedBases = base.clone().into();
@@ -287,25 +286,21 @@ pub mod tests {
         }
 
         let magnitude_signs = [
-            (
-                "random [a]B",
-                pallas::Base::from_u64(rand::random::<u64>()),
-                {
-                    let mut random_sign = pallas::Base::one();
-                    if rand::random::<bool>() {
-                        random_sign = -random_sign;
-                    }
-                    random_sign
-                },
-            ),
+            ("random [a]B", pallas::Base::from(rand::random::<u64>()), {
+                let mut random_sign = pallas::Base::one();
+                if rand::random::<bool>() {
+                    random_sign = -random_sign;
+                }
+                random_sign
+            }),
             (
                 "[2^64 - 1]B",
-                pallas::Base::from_u64(0xFFFF_FFFF_FFFF_FFFFu64),
+                pallas::Base::from(0xFFFF_FFFF_FFFF_FFFFu64),
                 pallas::Base::one(),
             ),
             (
                 "-[2^64 - 1]B",
-                pallas::Base::from_u64(0xFFFF_FFFF_FFFF_FFFFu64),
+                pallas::Base::from(0xFFFF_FFFF_FFFF_FFFFu64),
                 -pallas::Base::one(),
             ),
             // There is a single canonical sequence of window values for which a doubling occurs on the last step:
@@ -313,12 +308,12 @@ pub mod tests {
             // [0xB6DB_6DB6_DB6D_B6DC] B
             (
                 "mul_with_double",
-                pallas::Base::from_u64(0xB6DB_6DB6_DB6D_B6DCu64),
+                pallas::Base::from(0xB6DB_6DB6_DB6D_B6DCu64),
                 pallas::Base::one(),
             ),
             (
                 "mul_with_double negative",
-                pallas::Base::from_u64(0xB6DB_6DB6_DB6D_B6DCu64),
+                pallas::Base::from(0xB6DB_6DB6_DB6D_B6DCu64),
                 -pallas::Base::one(),
             ),
         ];
@@ -561,7 +556,7 @@ pub mod tests {
         {
             let magnitude_u64 = rand::random::<u64>();
             let circuit = MyCircuit {
-                magnitude: Some(pallas::Base::from_u64(magnitude_u64)),
+                magnitude: Some(pallas::Base::from(magnitude_u64)),
                 sign: Some(pallas::Base::zero()),
                 magnitude_error: None,
             };

--- a/src/circuit/gadget/ecc/chip/mul_fixed/short.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/short.rs
@@ -187,8 +187,7 @@ impl Config {
         // Invalid values result in constraint failures which are
         // tested at the circuit-level.
         {
-            use group::Curve;
-            use pasta_curves::arithmetic::FieldExt;
+            use group::{ff::PrimeField, Curve};
 
             if let (Some(magnitude), Some(sign)) = (scalar.magnitude.value(), scalar.sign.value()) {
                 let magnitude_is_valid = magnitude <= &pallas::Base::from(0xFFFF_FFFF_FFFF_FFFFu64);
@@ -200,8 +199,7 @@ impl Config {
                         |(magnitude, sign)| {
                             // Move magnitude from base field into scalar field (which always fits
                             // for Pallas).
-                            let magnitude =
-                                pallas::Scalar::from_bytes(&magnitude.to_bytes()).unwrap();
+                            let magnitude = pallas::Scalar::from_repr(magnitude.to_repr()).unwrap();
 
                             let sign = if sign == &pallas::Base::one() {
                                 pallas::Scalar::one()
@@ -229,7 +227,7 @@ impl Config {
 
 #[cfg(test)]
 pub mod tests {
-    use group::Curve;
+    use group::{ff::PrimeField, Curve};
     use halo2::{
         arithmetic::CurveAffine,
         circuit::{AssignedCell, Chip, Layouter},
@@ -330,7 +328,7 @@ pub mod tests {
             };
             // Move from base field into scalar field
             let scalar = {
-                let magnitude = pallas::Scalar::from_bytes(&magnitude.to_bytes()).unwrap();
+                let magnitude = pallas::Scalar::from_repr(magnitude.to_repr()).unwrap();
                 let sign = if *sign == pallas::Base::one() {
                     pallas::Scalar::one()
                 } else {

--- a/src/circuit/gadget/poseidon/pow5.rs
+++ b/src/circuit/gadget/poseidon/pow5.rs
@@ -671,7 +671,7 @@ mod tests {
 
             // For the purpose of this test, compute the real final state inline.
             let mut expected_final_state = (0..WIDTH)
-                .map(|idx| Fp::from_u64(idx as u64))
+                .map(|idx| Fp::from(idx as u64))
                 .collect::<Vec<_>>()
                 .try_into()
                 .unwrap();

--- a/src/circuit/gadget/sinsemilla.rs
+++ b/src/circuit/gadget/sinsemilla.rs
@@ -196,7 +196,7 @@ where
         let to_base_field = |bits: &[Option<bool>]| -> Option<C::Base> {
             // To simplify the following logic, require that the all-ones bitstring is
             // canonical in the field, by not allowing a length of NUM_BITS.
-            assert!(bits.len() < C::Base::NUM_BITS as usize);
+            assert!(bits.len() <= C::Base::CAPACITY as usize);
 
             let bits: Option<Vec<bool>> = bits.iter().cloned().collect();
             bits.map(|bits| {

--- a/src/circuit/gadget/sinsemilla/chip.rs
+++ b/src/circuit/gadget/sinsemilla/chip.rs
@@ -145,7 +145,7 @@ impl SinsemillaChip {
         // Set up lookup argument
         GeneratorTableConfig::configure(meta, config.clone());
 
-        let two = pallas::Base::from_u64(2);
+        let two = pallas::Base::from(2);
 
         // Closures for expressions that are derived multiple times
         // x_r = lambda_1^2 - x_a - x_p
@@ -210,7 +210,7 @@ impl SinsemillaChip {
             //    - rhs = (2 * Y_A_cur + (2 - q_s3) * Y_A_next + 2 * q_s3 * y_a_final)
             let y_check = {
                 // lhs = 4 * lambda_2_cur * (x_a_cur - x_a_next)
-                let lhs = lambda_2_cur * pallas::Base::from_u64(4) * (x_a_cur - x_a_next);
+                let lhs = lambda_2_cur * pallas::Base::from(4) * (x_a_cur - x_a_next);
 
                 // rhs = 2 * Y_A_cur + (2 - q_s3) * Y_A_next + 2 * q_s3 * y_a_final
                 let rhs = {

--- a/src/circuit/gadget/sinsemilla/chip.rs
+++ b/src/circuit/gadget/sinsemilla/chip.rs
@@ -12,8 +12,9 @@ use crate::{
     },
 };
 
+use group::ff::PrimeField;
 use halo2::{
-    arithmetic::{CurveAffine, FieldExt},
+    arithmetic::CurveAffine,
     circuit::{AssignedCell, Chip, Layouter},
     plonk::{
         Advice, Column, ConstraintSystem, Error, Expression, Fixed, Selector, TableColumn,
@@ -305,18 +306,18 @@ impl HashDomains<pallas::Affine> for SinsemillaHashDomains {
     fn Q(&self) -> pallas::Affine {
         match self {
             SinsemillaHashDomains::CommitIvk => pallas::Affine::from_xy(
-                pallas::Base::from_bytes(&Q_COMMIT_IVK_M_GENERATOR.0).unwrap(),
-                pallas::Base::from_bytes(&Q_COMMIT_IVK_M_GENERATOR.1).unwrap(),
+                pallas::Base::from_repr(Q_COMMIT_IVK_M_GENERATOR.0).unwrap(),
+                pallas::Base::from_repr(Q_COMMIT_IVK_M_GENERATOR.1).unwrap(),
             )
             .unwrap(),
             SinsemillaHashDomains::NoteCommit => pallas::Affine::from_xy(
-                pallas::Base::from_bytes(&Q_NOTE_COMMITMENT_M_GENERATOR.0).unwrap(),
-                pallas::Base::from_bytes(&Q_NOTE_COMMITMENT_M_GENERATOR.1).unwrap(),
+                pallas::Base::from_repr(Q_NOTE_COMMITMENT_M_GENERATOR.0).unwrap(),
+                pallas::Base::from_repr(Q_NOTE_COMMITMENT_M_GENERATOR.1).unwrap(),
             )
             .unwrap(),
             SinsemillaHashDomains::MerkleCrh => pallas::Affine::from_xy(
-                pallas::Base::from_bytes(&Q_MERKLE_CRH.0).unwrap(),
-                pallas::Base::from_bytes(&Q_MERKLE_CRH.1).unwrap(),
+                pallas::Base::from_repr(Q_MERKLE_CRH.0).unwrap(),
+                pallas::Base::from_repr(Q_MERKLE_CRH.1).unwrap(),
             )
             .unwrap(),
         }

--- a/src/circuit/gadget/sinsemilla/chip/generator_table.rs
+++ b/src/circuit/gadget/sinsemilla/chip/generator_table.rs
@@ -42,7 +42,7 @@ impl GeneratorTableConfig {
             let word = {
                 let z_cur = meta.query_advice(config.bits, Rotation::cur());
                 let z_next = meta.query_advice(config.bits, Rotation::next());
-                z_cur - ((q_s2 - q_s3) * z_next * pallas::Base::from_u64(1 << sinsemilla::K))
+                z_cur - ((q_s2 - q_s3) * z_next * pallas::Base::from(1 << sinsemilla::K))
             };
 
             let x_p = meta.query_advice(config.x_p, Rotation::cur());
@@ -84,7 +84,7 @@ impl GeneratorTableConfig {
                         || "table_idx",
                         self.table_idx,
                         index,
-                        || Ok(pallas::Base::from_u64(index as u64)),
+                        || Ok(pallas::Base::from(index as u64)),
                     )?;
                     table.assign_cell(|| "table_x", self.table_x, index, || Ok(*x))?;
                     table.assign_cell(|| "table_y", self.table_y, index, || Ok(*y))?;

--- a/src/circuit/gadget/sinsemilla/chip/hash_to_point.rs
+++ b/src/circuit/gadget/sinsemilla/chip/hash_to_point.rs
@@ -224,7 +224,7 @@ impl SinsemillaChip {
                 offset + piece.num_words() - 1,
                 || {
                     Ok(if final_piece {
-                        pallas::Base::from_u64(2)
+                        pallas::Base::from(2)
                     } else {
                         pallas::Base::zero()
                     })
@@ -291,7 +291,7 @@ impl SinsemillaChip {
                 // z_{i + 1} = (z_i - m_{i + 1}) / 2^K
                 z = z
                     .zip(*word)
-                    .map(|(z, word)| (z - pallas::Base::from_u64(word as u64)) * inv_2_k);
+                    .map(|(z, word)| (z - pallas::Base::from(word as u64)) * inv_2_k);
                 let cell = region.assign_advice(
                     || format!("z_{:?}", idx + 1),
                     config.bits,
@@ -356,7 +356,7 @@ impl SinsemillaChip {
             let lambda_2 = {
                 let lambda_2 = x_a.value().zip(y_a.0).zip(x_r).zip(lambda_1).map(
                     |(((x_a, y_a), x_r), lambda_1)| {
-                        pallas::Base::from_u64(2) * y_a * (x_a - x_r).invert().unwrap() - lambda_1
+                        pallas::Base::from(2) * y_a * (x_a - x_r).invert().unwrap() - lambda_1
                     },
                 );
 

--- a/src/circuit/gadget/sinsemilla/chip/hash_to_point.rs
+++ b/src/circuit/gadget/sinsemilla/chip/hash_to_point.rs
@@ -7,7 +7,7 @@ use halo2::{
     plonk::Error,
 };
 
-use ff::{Field, PrimeFieldBits};
+use group::ff::{Field, PrimeField, PrimeFieldBits};
 use pasta_curves::{
     arithmetic::{CurveAffine, FieldExt},
     pallas,
@@ -284,7 +284,7 @@ impl SinsemillaChip {
             // We end up with z_n = 0. (z_n is not directly encoded as a cell value;
             // it is implicitly taken as 0 by adjusting the definition of m_{i+1}.)
             let mut z = piece.field_elem();
-            let inv_2_k = pallas::Base::from_bytes(&INV_TWO_POW_K).unwrap();
+            let inv_2_k = pallas::Base::from_repr(INV_TWO_POW_K).unwrap();
 
             // We do not assign the final z_n as it is constrained to be zero.
             for (idx, word) in words[0..(words.len() - 1)].iter().enumerate() {

--- a/src/circuit/gadget/sinsemilla/commit_ivk.rs
+++ b/src/circuit/gadget/sinsemilla/commit_ivk.rs
@@ -67,8 +67,8 @@ impl CommitIvkConfig {
             let q_commit_ivk = meta.query_selector(config.q_commit_ivk);
 
             // Useful constants
-            let two_pow_4 = pallas::Base::from_u64(1 << 4);
-            let two_pow_5 = pallas::Base::from_u64(1 << 5);
+            let two_pow_4 = pallas::Base::from(1 << 4);
+            let two_pow_5 = pallas::Base::from(1 << 5);
             let two_pow_9 = two_pow_4 * two_pow_5;
             let two_pow_250 = pallas::Base::from_u128(1 << 125).square();
             let two_pow_254 = two_pow_250 * two_pow_4;
@@ -119,7 +119,7 @@ impl CommitIvkConfig {
 
             // Check that nk = b_2 (5 bits) || c (240 bits) || d_0 (9 bits) || d_1 (1 bit)
             let nk_decomposition_check = {
-                let two_pow_245 = pallas::Base::from_u64(1 << 49).pow(&[5, 0, 0, 0]);
+                let two_pow_245 = pallas::Base::from(1 << 49).pow(&[5, 0, 0, 0]);
 
                 b_2.clone()
                     + c.clone() * two_pow_5
@@ -181,7 +181,7 @@ impl CommitIvkConfig {
                 // Check that b2_c_prime = b_2 + c * 2^5 + 2^140 - t_P.
                 // This is checked regardless of the value of d_1.
                 let b2_c_prime_check = {
-                    let two_pow_5 = pallas::Base::from_u64(1 << 5);
+                    let two_pow_5 = pallas::Base::from(1 << 5);
                     let two_pow_140 =
                         Expression::Constant(pallas::Base::from_u128(1 << 70).square());
                     let t_p = Expression::Constant(pallas::Base::from_u128(T_P));
@@ -257,8 +257,8 @@ impl CommitIvkConfig {
             let b_2 = nk.value().map(|value| bitrange_subset(value, 0..5));
 
             let b = b_0.zip(b_1).zip(b_2).map(|((b_0, b_1), b_2)| {
-                let b1_shifted = b_1 * pallas::Base::from_u64(1 << 4);
-                let b2_shifted = b_2 * pallas::Base::from_u64(1 << 5);
+                let b1_shifted = b_1 * pallas::Base::from(1 << 4);
+                let b2_shifted = b_2 * pallas::Base::from(1 << 5);
                 b_0 + b1_shifted + b2_shifted
             });
 
@@ -304,7 +304,7 @@ impl CommitIvkConfig {
 
             let d = d_0
                 .zip(d_1)
-                .map(|(d_0, d_1)| d_0 + d_1 * pallas::Base::from_u64(1 << 9));
+                .map(|(d_0, d_1)| d_0 + d_1 * pallas::Base::from(1 << 9));
 
             // Constrain d_0 to be 9 bits.
             let d_0 = self.sinsemilla_config.lookup_config.witness_short_check(
@@ -444,7 +444,7 @@ impl CommitIvkConfig {
         // Decompose the low 140 bits of b2_c_prime = b_2 + c * 2^5 + 2^140 - t_P, and output
         // the running sum at the end of it. If b2_c_prime < 2^140, the running sum will be 0.
         let b2_c_prime = b_2.value().zip(c.value()).map(|(b_2, c)| {
-            let two_pow_5 = pallas::Base::from_u64(1 << 5);
+            let two_pow_5 = pallas::Base::from(1 << 5);
             let two_pow_140 = pallas::Base::from_u128(1u128 << 70).square();
             let t_p = pallas::Base::from_u128(T_P);
             b_2 + c * two_pow_5 + two_pow_140 - t_p

--- a/src/circuit/gadget/sinsemilla/merkle.rs
+++ b/src/circuit/gadget/sinsemilla/merkle.rs
@@ -146,6 +146,7 @@ pub mod tests {
         tree,
     };
 
+    use group::ff::PrimeField;
     use halo2::{
         arithmetic::FieldExt,
         circuit::{Layouter, SimpleFloorPlanner},
@@ -260,8 +261,8 @@ pub mod tests {
                 // The expected final root
                 let final_root = {
                     let path = tree::MerklePath::new(leaf_pos, self.merkle_path.unwrap());
-                    let leaf = ExtractedNoteCommitment::from_bytes(&self.leaf.unwrap().to_bytes())
-                        .unwrap();
+                    let leaf =
+                        ExtractedNoteCommitment::from_bytes(&self.leaf.unwrap().to_repr()).unwrap();
                     path.root(leaf)
                 };
 

--- a/src/circuit/gadget/sinsemilla/merkle/chip.rs
+++ b/src/circuit/gadget/sinsemilla/merkle/chip.rs
@@ -82,7 +82,7 @@ impl MerkleChip {
             let q_decompose = meta.query_selector(q_decompose);
             let l_whole = meta.query_advice(advices[4], Rotation::next());
 
-            let two_pow_5 = pallas::Base::from_u64(1 << 5);
+            let two_pow_5 = pallas::Base::from(1 << 5);
             let two_pow_10 = two_pow_5.square();
 
             // a_whole is constrained by Sinsemilla to be 250 bits.
@@ -101,7 +101,7 @@ impl MerkleChip {
             let z1_a = meta.query_advice(advices[0], Rotation::next());
             let a_1 = z1_a;
             // a_0 = a - (a_1 * 2^10)
-            let a_0 = a_whole - a_1.clone() * pallas::Base::from_u64(1 << 10);
+            let a_0 = a_whole - a_1.clone() * pallas::Base::from(1 << 10);
             let l_check = a_0 - l_whole;
 
             // b = b_0||b_1||b_2
@@ -185,12 +185,12 @@ impl MerkleInstructions<pallas::Affine, MERKLE_DEPTH_ORCHARD, { sinsemilla::K },
         let a = {
             let a = {
                 // a_0 = l
-                let a_0 = bitrange_subset(&pallas::Base::from_u64(l as u64), 0..10);
+                let a_0 = bitrange_subset(&pallas::Base::from(l as u64), 0..10);
 
                 // a_1 = (bits 0..=239 of `left`)
                 let a_1 = left.value().map(|value| bitrange_subset(value, 0..240));
 
-                a_1.map(|a_1| a_0 + a_1 * pallas::Base::from_u64(1 << 10))
+                a_1.map(|a_1| a_0 + a_1 * pallas::Base::from(1 << 10))
             };
 
             self.witness_message_piece(layouter.namespace(|| "Witness a = a_0 || a_1"), a, 25)?
@@ -233,8 +233,7 @@ impl MerkleInstructions<pallas::Affine, MERKLE_DEPTH_ORCHARD, { sinsemilla::K },
                     .zip(b_1.value())
                     .zip(b_2.value())
                     .map(|((b_0, b_1), b_2)| {
-                        b_0 + b_1 * pallas::Base::from_u64(1 << 10)
-                            + b_2 * pallas::Base::from_u64(1 << 15)
+                        b_0 + b_1 * pallas::Base::from(1 << 10) + b_2 * pallas::Base::from(1 << 15)
                     });
                 self.witness_message_piece(
                     layouter.namespace(|| "Witness b = b_0 || b_1 || b_2"),
@@ -282,7 +281,7 @@ impl MerkleInstructions<pallas::Affine, MERKLE_DEPTH_ORCHARD, { sinsemilla::K },
                         || format!("l {}", l),
                         config.advices[4],
                         1,
-                        pallas::Base::from_u64(l as u64),
+                        pallas::Base::from(l as u64),
                     )?;
 
                     // Offset 0

--- a/src/circuit/gadget/sinsemilla/merkle/chip.rs
+++ b/src/circuit/gadget/sinsemilla/merkle/chip.rs
@@ -323,7 +323,7 @@ impl MerkleInstructions<pallas::Affine, MERKLE_DEPTH_ORCHARD, { sinsemilla::K },
                 constants::MERKLE_CRH_PERSONALIZATION, primitives::sinsemilla::HashDomain,
                 spec::i2lebsp,
             };
-            use ff::PrimeFieldBits;
+            use group::ff::{PrimeField, PrimeFieldBits};
 
             if let (Some(left), Some(right)) = (left.value(), right.value()) {
                 let l = i2lebsp::<10>(l as u64);
@@ -347,7 +347,7 @@ impl MerkleInstructions<pallas::Affine, MERKLE_DEPTH_ORCHARD, { sinsemilla::K },
 
                 let expected = merkle_crh.hash(message.into_iter()).unwrap();
 
-                assert_eq!(expected.to_bytes(), result.value().unwrap().to_bytes());
+                assert_eq!(expected.to_repr(), result.value().unwrap().to_repr());
             }
         }
 

--- a/src/circuit/gadget/sinsemilla/note_commit.rs
+++ b/src/circuit/gadget/sinsemilla/note_commit.rs
@@ -96,15 +96,15 @@ impl NoteCommitConfig {
         };
 
         // Useful constants
-        let two = pallas::Base::from_u64(2);
-        let two_pow_2 = pallas::Base::from_u64(1 << 2);
+        let two = pallas::Base::from(2);
+        let two_pow_2 = pallas::Base::from(1 << 2);
         let two_pow_4 = two_pow_2.square();
         let two_pow_5 = two_pow_4 * two;
         let two_pow_6 = two_pow_5 * two;
         let two_pow_8 = two_pow_4.square();
         let two_pow_9 = two_pow_8 * two;
         let two_pow_10 = two_pow_9 * two;
-        let two_pow_58 = pallas::Base::from_u64(1 << 58);
+        let two_pow_58 = pallas::Base::from(1 << 58);
         let two_pow_130 = Expression::Constant(pallas::Base::from_u128(1 << 65).square());
         let two_pow_140 = Expression::Constant(pallas::Base::from_u128(1 << 70).square());
         let two_pow_249 = pallas::Base::from_u128(1 << 124).square() * two;
@@ -579,9 +579,9 @@ impl NoteCommitConfig {
 
                 let b = b_0.value().zip(b_1).zip(b_2).zip(b_3.value()).map(
                     |(((b_0, b_1), b_2), b_3)| {
-                        let b1_shifted = b_1 * pallas::Base::from_u64(1 << 4);
-                        let b2_shifted = b_2 * pallas::Base::from_u64(1 << 5);
-                        let b3_shifted = b_3 * pallas::Base::from_u64(1 << 6);
+                        let b1_shifted = b_1 * pallas::Base::from(1 << 4);
+                        let b2_shifted = b_2 * pallas::Base::from(1 << 5);
+                        let b3_shifted = b_3 * pallas::Base::from(1 << 6);
                         b_0 + b1_shifted + b2_shifted + b3_shifted
                     },
                 );
@@ -621,9 +621,9 @@ impl NoteCommitConfig {
                 .zip(d_2.value())
                 .zip(d_3)
                 .map(|(((d_0, d_1), d_2), d_3)| {
-                    let d1_shifted = d_1 * pallas::Base::from_u64(2);
-                    let d2_shifted = d_2 * pallas::Base::from_u64(1 << 2);
-                    let d3_shifted = d_3 * pallas::Base::from_u64(1 << 10);
+                    let d1_shifted = d_1 * pallas::Base::from(2);
+                    let d2_shifted = d_2 * pallas::Base::from(1 << 2);
+                    let d3_shifted = d_3 * pallas::Base::from(1 << 10);
                     d_0 + d1_shifted + d2_shifted + d3_shifted
                 });
 
@@ -654,7 +654,7 @@ impl NoteCommitConfig {
             let e = e_0
                 .value()
                 .zip(e_1.value())
-                .map(|(e_0, e_1)| e_0 + e_1 * pallas::Base::from_u64(1 << 6));
+                .map(|(e_0, e_1)| e_0 + e_1 * pallas::Base::from(1 << 6));
             let e = MessagePiece::from_field_elem(chip.clone(), layouter.namespace(|| "e"), e, 1)?;
 
             (e_0, e_1, e)
@@ -684,8 +684,8 @@ impl NoteCommitConfig {
             // g_2 = z1_g from the SinsemillaHash(g) running sum output.
 
             let g = g_0.zip(g_1.value()).zip(g_2).map(|((g_0, g_1), g_2)| {
-                let g1_shifted = g_1 * pallas::Base::from_u64(2);
-                let g2_shifted = g_2 * pallas::Base::from_u64(1 << 10);
+                let g1_shifted = g_1 * pallas::Base::from(2);
+                let g2_shifted = g_2 * pallas::Base::from(1 << 10);
                 g_0 + g1_shifted + g2_shifted
             });
             let g = MessagePiece::from_field_elem(chip.clone(), layouter.namespace(|| "g"), g, 25)?;
@@ -711,7 +711,7 @@ impl NoteCommitConfig {
             let h = h_0
                 .value()
                 .zip(h_1)
-                .map(|(h_0, h_1)| h_0 + h_1 * pallas::Base::from_u64(1 << 5));
+                .map(|(h_0, h_1)| h_0 + h_1 * pallas::Base::from(1 << 5));
             let h = MessagePiece::from_field_elem(chip.clone(), layouter.namespace(|| "h"), h, 1)?;
 
             (h_0, h_1, h)
@@ -877,7 +877,7 @@ impl NoteCommitConfig {
         // and output the running sum at the end of it.
         // If b3_c_prime < 2^140, the running sum will be 0.
         let b3_c_prime = b_3.value().zip(c.value()).map(|(b_3, c)| {
-            let two_pow_4 = pallas::Base::from_u64(1u64 << 4);
+            let two_pow_4 = pallas::Base::from(1u64 << 4);
             let two_pow_140 = pallas::Base::from_u128(1u128 << 70).square();
             let t_p = pallas::Base::from_u128(T_P);
             b_3 + (two_pow_4 * c) + two_pow_140 - t_p
@@ -913,7 +913,7 @@ impl NoteCommitConfig {
         // - 0 ≤ e_1 + 2^4 f + 2^140 - t_P < 2^140 (14 ten-bit lookups)
 
         let e1_f_prime = e_1.value().zip(f.value()).map(|(e_1, f)| {
-            let two_pow_4 = pallas::Base::from_u64(1u64 << 4);
+            let two_pow_4 = pallas::Base::from(1u64 << 4);
             let two_pow_140 = pallas::Base::from_u128(1u128 << 70).square();
             let t_p = pallas::Base::from_u128(T_P);
             e_1 + (two_pow_4 * f) + two_pow_140 - t_p
@@ -953,7 +953,7 @@ impl NoteCommitConfig {
         // and output the running sum at the end of it.
         // If g1_g2_prime < 2^130, the running sum will be 0.
         let g1_g2_prime = g_1.value().zip(g_2.value()).map(|(g_1, g_2)| {
-            let two_pow_9 = pallas::Base::from_u64(1u64 << 9);
+            let two_pow_9 = pallas::Base::from(1u64 << 9);
             let two_pow_130 = pallas::Base::from_u128(1u128 << 65).square();
             let t_p = pallas::Base::from_u128(T_P);
             g_1 + (two_pow_9 * g_2) + two_pow_130 - t_p
@@ -1008,8 +1008,8 @@ impl NoteCommitConfig {
         // Decompose j = LSB + (2)k_0 + (2^10)k_1 using 25 ten-bit lookups.
         let (j, z1_j, z13_j) = {
             let j = lsb.zip(k_0.value()).zip(k_1).map(|((lsb, k_0), k_1)| {
-                let two = pallas::Base::from_u64(2);
-                let two_pow_10 = pallas::Base::from_u64(1 << 10);
+                let two = pallas::Base::from(2);
+                let two_pow_10 = pallas::Base::from(1 << 10);
                 lsb + two * k_0 + two_pow_10 * k_1
             });
             let zs = self.sinsemilla_config.lookup_config.witness_check(
@@ -1616,7 +1616,7 @@ mod tests {
                 // A note value cannot be negative.
                 let value = {
                     let mut rng = OsRng;
-                    pallas::Base::from_u64(rng.next_u64())
+                    pallas::Base::from(rng.next_u64())
                 };
                 let value_var = {
                     self.load_private(

--- a/src/circuit/gadget/utilities.rs
+++ b/src/circuit/gadget/utilities.rs
@@ -110,7 +110,7 @@ pub fn bitrange_subset<F: FieldExt + PrimeFieldBits>(field_elem: &F, bitrange: R
 /// i.e. 0 ≤ word < range.
 pub fn range_check<F: FieldExt>(word: Expression<F>, range: usize) -> Expression<F> {
     (1..range).fold(word.clone(), |acc, i| {
-        acc * (Expression::Constant(F::from_u64(i as u64)) - word.clone())
+        acc * (Expression::Constant(F::from(i as u64)) - word.clone())
     })
 }
 
@@ -176,7 +176,7 @@ mod tests {
                             || format!("witness {}", self.0),
                             config.advice,
                             0,
-                            || Ok(pallas::Base::from_u64(self.0.into())),
+                            || Ok(pallas::Base::from(self.0 as u64)),
                         )?;
 
                         Ok(())

--- a/src/circuit/gadget/utilities/cond_swap.rs
+++ b/src/circuit/gadget/utilities/cond_swap.rs
@@ -84,7 +84,7 @@ impl<F: FieldExt> CondSwapInstructions<F> for CondSwapChip<F> {
                 )?;
 
                 // Witness `swap` value
-                let swap_val = swap.map(|swap| F::from_u64(swap as u64));
+                let swap_val = swap.map(|swap| F::from(swap as u64));
                 region.assign_advice(
                     || "swap",
                     config.swap,

--- a/src/circuit/gadget/utilities/decompose_running_sum.rs
+++ b/src/circuit/gadget/utilities/decompose_running_sum.rs
@@ -84,7 +84,7 @@ impl<F: FieldExt + PrimeFieldBits, const WINDOW_NUM_BITS: usize>
             let z_next = meta.query_advice(config.z, Rotation::next());
             //    z_i = 2^{K}⋅z_{i + 1} + k_i
             // => k_i = z_i - 2^{K}⋅z_{i + 1}
-            let word = z_cur - z_next * F::from_u64(1 << WINDOW_NUM_BITS);
+            let word = z_cur - z_next * F::from(1 << WINDOW_NUM_BITS);
 
             vec![q_range_check * range_check(word, 1 << WINDOW_NUM_BITS)]
         });
@@ -182,11 +182,11 @@ impl<F: FieldExt + PrimeFieldBits, const WINDOW_NUM_BITS: usize>
         // Assign running sum `z_{i+1}` = (z_i - k_i) / (2^K) for i = 0..=n-1.
         // Outside of this helper, z_0 = alpha must have already been loaded into the
         // `z` column at `offset`.
-        let two_pow_k_inv = F::from_u64(1 << WINDOW_NUM_BITS as u64).invert().unwrap();
+        let two_pow_k_inv = F::from(1 << WINDOW_NUM_BITS as u64).invert().unwrap();
         for (i, word) in words.iter().enumerate() {
             // z_next = (z_cur - word) / (2^K)
             let z_next = {
-                let word = word.map(|word| F::from_u64(word as u64));
+                let word = word.map(|word| F::from(word as u64));
                 let z_next_val = z
                     .value()
                     .zip(word)
@@ -319,7 +319,7 @@ mod tests {
 
         // Random 64-bit word
         {
-            let alpha = pallas::Base::from_u64(rand::random());
+            let alpha = pallas::Base::from(rand::random::<u64>());
 
             // Strict full decomposition should pass.
             let circuit: MyCircuit<

--- a/src/circuit/gadget/utilities/lookup_range_check.rs
+++ b/src/circuit/gadget/utilities/lookup_range_check.rs
@@ -364,7 +364,7 @@ impl<F: FieldExt + PrimeFieldBits, const K: usize> LookupRangeCheckConfig<F, K> 
 mod tests {
     use super::LookupRangeCheckConfig;
 
-    use crate::primitives::sinsemilla::{INV_TWO_POW_K, K};
+    use crate::primitives::sinsemilla::K;
     use crate::spec::lebs2ip;
     use ff::{Field, PrimeFieldBits};
     use halo2::{
@@ -431,9 +431,7 @@ mod tests {
                             .collect::<Vec<_>>()
                     };
                     let expected_zs = {
-                        let mut repr = F::Repr::default();
-                        repr.as_mut().copy_from_slice(&INV_TWO_POW_K);
-                        let inv_two_pow_k = F::from_repr(repr).unwrap();
+                        let inv_two_pow_k = F::from(1 << K).invert().unwrap();
                         chunks.iter().fold(vec![element], |mut zs, a_i| {
                             // z_{i + 1} = (z_i - a_i) / 2^{K}
                             let z = (zs[zs.len() - 1] - a_i) * inv_two_pow_k;

--- a/src/circuit/gadget/utilities/lookup_range_check.rs
+++ b/src/circuit/gadget/utilities/lookup_range_check.rs
@@ -431,7 +431,9 @@ mod tests {
                             .collect::<Vec<_>>()
                     };
                     let expected_zs = {
-                        let inv_two_pow_k = F::from_bytes(&INV_TWO_POW_K).unwrap();
+                        let mut repr = F::Repr::default();
+                        repr.as_mut().copy_from_slice(&INV_TWO_POW_K);
+                        let inv_two_pow_k = F::from_repr(repr).unwrap();
                         chunks.iter().fold(vec![element], |mut zs, a_i| {
                             // z_{i + 1} = (z_i - a_i) / 2^{K}
                             let z = (zs[zs.len() - 1] - a_i) * inv_two_pow_k;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -254,7 +254,9 @@ fn test_zs_and_us<C: CurveAffine>(base: C, z: &[u64], u: &[[[u8; 32]; H]], num_w
     for ((u, z), window_points) in u.iter().zip(z.iter()).zip(window_table) {
         for (u, point) in u.iter().zip(window_points.iter()) {
             let y = *point.coordinates().unwrap().y();
-            let u = C::Base::from_bytes(u).unwrap();
+            let mut u_repr = <C::Base as PrimeField>::Repr::default();
+            u_repr.as_mut().copy_from_slice(u);
+            let u = C::Base::from_repr(u_repr).unwrap();
             assert_eq!(C::Base::from(*z) + y, u * u); // allow either square root
             assert!(bool::from((C::Base::from(*z) - y).sqrt().is_none()));
         }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -248,17 +248,15 @@ fn test_lagrange_coeffs<C: CurveAffine>(base: C, num_windows: usize) {
 //      1. z + y = u^2,
 //      2. z - y is not a square
 // for the y-coordinate of each fixed-base multiple in each window.
-fn test_zs_and_us<C: CurveAffine>(base: C, z: &[u64], u: &[[[u8; 32]; H]], num_windows: usize) {
+fn test_zs_and_us(base: pallas::Affine, z: &[u64], u: &[[[u8; 32]; H]], num_windows: usize) {
     let window_table = compute_window_table(base, num_windows);
 
     for ((u, z), window_points) in u.iter().zip(z.iter()).zip(window_table) {
         for (u, point) in u.iter().zip(window_points.iter()) {
             let y = *point.coordinates().unwrap().y();
-            let mut u_repr = <C::Base as PrimeField>::Repr::default();
-            u_repr.as_mut().copy_from_slice(u);
-            let u = C::Base::from_repr(u_repr).unwrap();
-            assert_eq!(C::Base::from(*z) + y, u * u); // allow either square root
-            assert!(bool::from((C::Base::from(*z) - y).sqrt().is_none()));
+            let u = pallas::Base::from_repr(*u).unwrap();
+            assert_eq!(pallas::Base::from(*z) + y, u * u); // allow either square root
+            assert!(bool::from((pallas::Base::from(*z) - y).sqrt().is_none()));
         }
     }
 }

--- a/src/constants/commit_ivk_r.rs
+++ b/src/constants/commit_ivk_r.rs
@@ -1,7 +1,5 @@
-use pasta_curves::{
-    arithmetic::{CurveAffine, FieldExt},
-    pallas,
-};
+use group::ff::PrimeField;
+use pasta_curves::{arithmetic::CurveAffine, pallas};
 
 /// Generator used in SinsemillaCommit randomness for IVK commitment
 pub const GENERATOR: ([u8; 32], [u8; 32]) = (
@@ -2922,8 +2920,8 @@ pub const U: [[[u8; 32]; super::H]; super::NUM_WINDOWS] = [
 
 pub fn generator() -> pallas::Affine {
     pallas::Affine::from_xy(
-        pallas::Base::from_bytes(&GENERATOR.0).unwrap(),
-        pallas::Base::from_bytes(&GENERATOR.1).unwrap(),
+        pallas::Base::from_repr(GENERATOR.0).unwrap(),
+        pallas::Base::from_repr(GENERATOR.1).unwrap(),
     )
     .unwrap()
 }
@@ -2936,10 +2934,7 @@ mod tests {
     use super::*;
     use crate::primitives::sinsemilla::CommitDomain;
     use group::Curve;
-    use pasta_curves::{
-        arithmetic::{CurveAffine, FieldExt},
-        pallas,
-    };
+    use pasta_curves::{arithmetic::CurveAffine, pallas};
 
     #[test]
     fn generator() {
@@ -2947,8 +2942,8 @@ mod tests {
         let point = domain.R();
         let coords = point.to_affine().coordinates().unwrap();
 
-        assert_eq!(*coords.x(), pallas::Base::from_bytes(&GENERATOR.0).unwrap());
-        assert_eq!(*coords.y(), pallas::Base::from_bytes(&GENERATOR.1).unwrap());
+        assert_eq!(*coords.x(), pallas::Base::from_repr(GENERATOR.0).unwrap());
+        assert_eq!(*coords.y(), pallas::Base::from_repr(GENERATOR.1).unwrap());
     }
 
     #[test]

--- a/src/constants/load.rs
+++ b/src/constants/load.rs
@@ -1,7 +1,8 @@
 use std::convert::TryInto;
 
 use crate::constants::{self, compute_lagrange_coeffs, H, NUM_WINDOWS, NUM_WINDOWS_SHORT};
-use pasta_curves::{arithmetic::FieldExt, pallas};
+use group::ff::PrimeField;
+use pasta_curves::pallas;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum OrchardFixedBasesFull {
@@ -212,7 +213,7 @@ impl From<&[[u8; 32]; H]> for WindowUs {
         Self(
             window_us
                 .iter()
-                .map(|u| pallas::Base::from_bytes(u).unwrap())
+                .map(|u| pallas::Base::from_repr(*u).unwrap())
                 .collect::<Vec<_>>()
                 .into_boxed_slice()
                 .try_into()

--- a/src/constants/load.rs
+++ b/src/constants/load.rs
@@ -177,7 +177,7 @@ impl From<[u64; NUM_WINDOWS]> for Z {
     fn from(zs: [u64; NUM_WINDOWS]) -> Self {
         Self(
             zs.iter()
-                .map(|z| pallas::Base::from_u64(*z))
+                .map(|z| pallas::Base::from(*z))
                 .collect::<Vec<_>>()
                 .into_boxed_slice()
                 .try_into()
@@ -194,7 +194,7 @@ impl From<[u64; NUM_WINDOWS_SHORT]> for ZShort {
     fn from(zs: [u64; NUM_WINDOWS_SHORT]) -> Self {
         Self(
             zs.iter()
-                .map(|z| pallas::Base::from_u64(*z))
+                .map(|z| pallas::Base::from(*z))
                 .collect::<Vec<_>>()
                 .into_boxed_slice()
                 .try_into()

--- a/src/constants/note_commit_r.rs
+++ b/src/constants/note_commit_r.rs
@@ -1,7 +1,5 @@
-use pasta_curves::{
-    arithmetic::{CurveAffine, FieldExt},
-    pallas,
-};
+use group::ff::PrimeField;
+use pasta_curves::{arithmetic::CurveAffine, pallas};
 
 /// Generator used in SinsemillaCommit randomness for note commitment
 pub const GENERATOR: ([u8; 32], [u8; 32]) = (
@@ -2922,8 +2920,8 @@ pub const U: [[[u8; 32]; super::H]; super::NUM_WINDOWS] = [
 
 pub fn generator() -> pallas::Affine {
     pallas::Affine::from_xy(
-        pallas::Base::from_bytes(&GENERATOR.0).unwrap(),
-        pallas::Base::from_bytes(&GENERATOR.1).unwrap(),
+        pallas::Base::from_repr(GENERATOR.0).unwrap(),
+        pallas::Base::from_repr(GENERATOR.1).unwrap(),
     )
     .unwrap()
 }
@@ -2936,10 +2934,7 @@ mod tests {
     use super::*;
     use crate::primitives::sinsemilla::CommitDomain;
     use group::Curve;
-    use pasta_curves::{
-        arithmetic::{CurveAffine, FieldExt},
-        pallas,
-    };
+    use pasta_curves::{arithmetic::CurveAffine, pallas};
 
     #[test]
     fn generator() {
@@ -2947,8 +2942,8 @@ mod tests {
         let point = domain.R();
         let coords = point.to_affine().coordinates().unwrap();
 
-        assert_eq!(*coords.x(), pallas::Base::from_bytes(&GENERATOR.0).unwrap());
-        assert_eq!(*coords.y(), pallas::Base::from_bytes(&GENERATOR.1).unwrap());
+        assert_eq!(*coords.x(), pallas::Base::from_repr(GENERATOR.0).unwrap());
+        assert_eq!(*coords.y(), pallas::Base::from_repr(GENERATOR.1).unwrap());
     }
 
     #[test]

--- a/src/constants/nullifier_k.rs
+++ b/src/constants/nullifier_k.rs
@@ -1,7 +1,5 @@
-use pasta_curves::{
-    arithmetic::{CurveAffine, FieldExt},
-    pallas,
-};
+use group::ff::PrimeField;
+use pasta_curves::{arithmetic::CurveAffine, pallas};
 
 pub const GENERATOR: ([u8; 32], [u8; 32]) = (
     [
@@ -2921,8 +2919,8 @@ pub const U: [[[u8; 32]; super::H]; super::NUM_WINDOWS] = [
 
 pub fn generator() -> pallas::Affine {
     pallas::Affine::from_xy(
-        pallas::Base::from_bytes(&GENERATOR.0).unwrap(),
-        pallas::Base::from_bytes(&GENERATOR.1).unwrap(),
+        pallas::Base::from_repr(GENERATOR.0).unwrap(),
+        pallas::Base::from_repr(GENERATOR.1).unwrap(),
     )
     .unwrap()
 }
@@ -2934,10 +2932,7 @@ mod tests {
     };
     use super::*;
     use group::Curve;
-    use pasta_curves::{
-        arithmetic::{CurveExt, FieldExt},
-        pallas,
-    };
+    use pasta_curves::{arithmetic::CurveExt, pallas};
 
     #[test]
     fn generator() {
@@ -2945,8 +2940,8 @@ mod tests {
         let point = hasher(b"K");
         let coords = point.to_affine().coordinates().unwrap();
 
-        assert_eq!(*coords.x(), pallas::Base::from_bytes(&GENERATOR.0).unwrap());
-        assert_eq!(*coords.y(), pallas::Base::from_bytes(&GENERATOR.1).unwrap());
+        assert_eq!(*coords.x(), pallas::Base::from_repr(GENERATOR.0).unwrap());
+        assert_eq!(*coords.y(), pallas::Base::from_repr(GENERATOR.1).unwrap());
     }
 
     #[test]

--- a/src/constants/spend_auth_g.rs
+++ b/src/constants/spend_auth_g.rs
@@ -1,7 +1,5 @@
-use pasta_curves::{
-    arithmetic::{CurveAffine, FieldExt},
-    pallas,
-};
+use group::ff::PrimeField;
+use pasta_curves::{arithmetic::CurveAffine, pallas};
 
 /// The value commitment is used to check balance between inputs and outputs. The value is
 /// placed over this generator.
@@ -2923,8 +2921,8 @@ pub const U: [[[u8; 32]; super::H]; super::NUM_WINDOWS] = [
 
 pub fn generator() -> pallas::Affine {
     pallas::Affine::from_xy(
-        pallas::Base::from_bytes(&GENERATOR.0).unwrap(),
-        pallas::Base::from_bytes(&GENERATOR.1).unwrap(),
+        pallas::Base::from_repr(GENERATOR.0).unwrap(),
+        pallas::Base::from_repr(GENERATOR.1).unwrap(),
     )
     .unwrap()
 }
@@ -2937,7 +2935,7 @@ mod tests {
     use super::*;
     use group::Curve;
     use pasta_curves::{
-        arithmetic::{CurveAffine, CurveExt, FieldExt},
+        arithmetic::{CurveAffine, CurveExt},
         pallas,
     };
 
@@ -2947,8 +2945,8 @@ mod tests {
         let point = hasher(b"G");
         let coords = point.to_affine().coordinates().unwrap();
 
-        assert_eq!(*coords.x(), pallas::Base::from_bytes(&GENERATOR.0).unwrap());
-        assert_eq!(*coords.y(), pallas::Base::from_bytes(&GENERATOR.1).unwrap());
+        assert_eq!(*coords.x(), pallas::Base::from_repr(GENERATOR.0).unwrap());
+        assert_eq!(*coords.y(), pallas::Base::from_repr(GENERATOR.1).unwrap());
     }
 
     #[test]

--- a/src/constants/util.rs
+++ b/src/constants/util.rs
@@ -1,5 +1,5 @@
 use ff::{Field, PrimeFieldBits};
-use halo2::arithmetic::{CurveAffine, FieldExt};
+use halo2::arithmetic::CurveAffine;
 
 /// Decompose a word `alpha` into `window_num_bits` bits (little-endian)
 /// For a window size of `w`, this returns [k_0, ..., k_n] where each `k_i`
@@ -33,7 +33,7 @@ pub fn decompose_word<F: PrimeFieldBits>(
 
 /// Evaluate y = f(x) given the coefficients of f(x)
 pub fn evaluate<C: CurveAffine>(x: u8, coeffs: &[C::Base]) -> C::Base {
-    let x = C::Base::from_u64(x as u64);
+    let x = C::Base::from(x as u64);
     coeffs
         .iter()
         .rev()

--- a/src/constants/util.rs
+++ b/src/constants/util.rs
@@ -102,7 +102,7 @@ mod tests {
             let bytes: Vec<u8> = bits.chunks_exact(8).map(|chunk| chunk.iter().rev().fold(0, |acc, b| (acc << 1) + (*b as u8))).collect();
 
             // Check that original scalar is recovered from decomposition
-            assert_eq!(scalar, pallas::Scalar::from_bytes(&bytes.try_into().unwrap()).unwrap());
+            assert_eq!(scalar, pallas::Scalar::from_repr(bytes.try_into().unwrap()).unwrap());
         }
     }
 }

--- a/src/constants/value_commit_r.rs
+++ b/src/constants/value_commit_r.rs
@@ -1,7 +1,5 @@
-use pasta_curves::{
-    arithmetic::{CurveAffine, FieldExt},
-    pallas,
-};
+use group::ff::PrimeField;
+use pasta_curves::{arithmetic::CurveAffine, pallas};
 
 /// The value commitment is used to check balance between inputs and outputs. The value is
 /// placed over this generator.
@@ -2923,8 +2921,8 @@ pub const U: [[[u8; 32]; super::H]; super::NUM_WINDOWS] = [
 
 pub fn generator() -> pallas::Affine {
     pallas::Affine::from_xy(
-        pallas::Base::from_bytes(&GENERATOR.0).unwrap(),
-        pallas::Base::from_bytes(&GENERATOR.1).unwrap(),
+        pallas::Base::from_repr(GENERATOR.0).unwrap(),
+        pallas::Base::from_repr(GENERATOR.1).unwrap(),
     )
     .unwrap()
 }
@@ -2937,7 +2935,7 @@ mod tests {
     use super::*;
     use group::Curve;
     use pasta_curves::{
-        arithmetic::{CurveAffine, CurveExt, FieldExt},
+        arithmetic::{CurveAffine, CurveExt},
         pallas,
     };
 
@@ -2947,8 +2945,8 @@ mod tests {
         let point = hasher(b"r");
         let coords = point.to_affine().coordinates().unwrap();
 
-        assert_eq!(*coords.x(), pallas::Base::from_bytes(&GENERATOR.0).unwrap());
-        assert_eq!(*coords.y(), pallas::Base::from_bytes(&GENERATOR.1).unwrap());
+        assert_eq!(*coords.x(), pallas::Base::from_repr(GENERATOR.0).unwrap());
+        assert_eq!(*coords.y(), pallas::Base::from_repr(GENERATOR.1).unwrap());
     }
 
     #[test]

--- a/src/constants/value_commit_v.rs
+++ b/src/constants/value_commit_v.rs
@@ -1,7 +1,5 @@
-use pasta_curves::{
-    arithmetic::{CurveAffine, FieldExt},
-    pallas,
-};
+use group::ff::PrimeField;
+use pasta_curves::{arithmetic::CurveAffine, pallas};
 
 /// The value commitment is used to check balance between inputs and outputs. The value is
 /// placed over this generator.
@@ -776,8 +774,8 @@ pub const U_SHORT: [[[u8; 32]; super::H]; super::NUM_WINDOWS_SHORT] = [
 
 pub fn generator() -> pallas::Affine {
     pallas::Affine::from_xy(
-        pallas::Base::from_bytes(&GENERATOR.0).unwrap(),
-        pallas::Base::from_bytes(&GENERATOR.1).unwrap(),
+        pallas::Base::from_repr(GENERATOR.0).unwrap(),
+        pallas::Base::from_repr(GENERATOR.1).unwrap(),
     )
     .unwrap()
 }
@@ -790,7 +788,7 @@ mod tests {
     use super::*;
     use group::Curve;
     use pasta_curves::{
-        arithmetic::{CurveAffine, CurveExt, FieldExt},
+        arithmetic::{CurveAffine, CurveExt},
         pallas,
     };
 
@@ -800,8 +798,8 @@ mod tests {
         let point = hasher(b"v");
         let coords = point.to_affine().coordinates().unwrap();
 
-        assert_eq!(*coords.x(), pallas::Base::from_bytes(&GENERATOR.0).unwrap());
-        assert_eq!(*coords.y(), pallas::Base::from_bytes(&GENERATOR.1).unwrap());
+        assert_eq!(*coords.x(), pallas::Base::from_repr(GENERATOR.0).unwrap());
+        assert_eq!(*coords.y(), pallas::Base::from_repr(GENERATOR.1).unwrap());
     }
 
     #[test]

--- a/src/note/commitment.rs
+++ b/src/note/commitment.rs
@@ -1,8 +1,8 @@
 use std::iter;
 
 use bitvec::{array::BitArray, order::Lsb0};
-use ff::PrimeFieldBits;
-use pasta_curves::{arithmetic::FieldExt, pallas};
+use group::ff::{PrimeField, PrimeFieldBits};
+use pasta_curves::pallas;
 use subtle::{ConstantTimeEq, CtOption};
 
 use crate::{
@@ -72,12 +72,12 @@ impl ExtractedNoteCommitment {
     ///
     /// [cmxcanon]: https://zips.z.cash/protocol/protocol.pdf#actionencodingandconsensus
     pub fn from_bytes(bytes: &[u8; 32]) -> CtOption<Self> {
-        pallas::Base::from_bytes(bytes).map(ExtractedNoteCommitment)
+        pallas::Base::from_repr(*bytes).map(ExtractedNoteCommitment)
     }
 
     /// Serialize the value commitment to its canonical byte representation.
     pub fn to_bytes(self) -> [u8; 32] {
-        self.0.to_bytes()
+        self.0.to_repr()
     }
 }
 

--- a/src/note/nullifier.rs
+++ b/src/note/nullifier.rs
@@ -1,6 +1,6 @@
-use group::Group;
+use group::{ff::PrimeField, Group};
 use halo2::arithmetic::CurveExt;
-use pasta_curves::{arithmetic::FieldExt, pallas};
+use pasta_curves::pallas;
 use rand::RngCore;
 use subtle::CtOption;
 
@@ -33,12 +33,12 @@ impl Nullifier {
 
     /// Deserialize the nullifier from a byte array.
     pub fn from_bytes(bytes: &[u8; 32]) -> CtOption<Self> {
-        pallas::Base::from_bytes(bytes).map(Nullifier)
+        pallas::Base::from_repr(*bytes).map(Nullifier)
     }
 
     /// Serialize the nullifier to its canonical byte representation.
     pub fn to_bytes(self) -> [u8; 32] {
-        self.0.to_bytes()
+        self.0.to_repr()
     }
 
     /// $DeriveNullifier$.

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -3,7 +3,7 @@
 use std::{convert::TryInto, fmt};
 
 use blake2b_simd::{Hash, Params};
-use halo2::arithmetic::FieldExt;
+use group::ff::PrimeField;
 use zcash_note_encryption::{
     BatchDomain, Domain, EphemeralKeyBytes, NotePlaintextBytes, NoteValidity, OutPlaintextBytes,
     OutgoingCipherKey, ShieldedOutput, COMPACT_NOTE_SIZE, NOTE_PLAINTEXT_SIZE, OUT_PLAINTEXT_SIZE,
@@ -170,7 +170,7 @@ impl Domain for OrchardDomain {
     ) -> OutPlaintextBytes {
         let mut op = [0; OUT_PLAINTEXT_SIZE];
         op[..32].copy_from_slice(&note.recipient().pk_d().to_bytes());
-        op[32..].copy_from_slice(&esk.0.to_bytes());
+        op[32..].copy_from_slice(&esk.0.to_repr());
         OutPlaintextBytes(op)
     }
 

--- a/src/primitives/poseidon.rs
+++ b/src/primitives/poseidon.rs
@@ -370,7 +370,7 @@ mod tests {
 
     #[test]
     fn orchard_spec_equivalence() {
-        let message = [pallas::Base::from_u64(6), pallas::Base::from_u64(42)];
+        let message = [pallas::Base::from(6), pallas::Base::from(42)];
 
         let (round_constants, mds, _) = OrchardNullifier::constants();
 

--- a/src/primitives/sinsemilla/constants.rs
+++ b/src/primitives/sinsemilla/constants.rs
@@ -66,8 +66,8 @@ mod tests {
     use crate::constants::{
         COMMIT_IVK_PERSONALIZATION, MERKLE_CRH_PERSONALIZATION, NOTE_COMMITMENT_PERSONALIZATION,
     };
-    use group::Curve;
-    use halo2::arithmetic::{CurveAffine, CurveExt, FieldExt};
+    use group::{ff::PrimeField, Curve};
+    use halo2::arithmetic::{CurveAffine, CurveExt};
     use halo2::pasta::pallas;
 
     #[test]
@@ -93,11 +93,11 @@ mod tests {
 
         assert_eq!(
             *coords.x(),
-            pallas::Base::from_bytes(&Q_NOTE_COMMITMENT_M_GENERATOR.0).unwrap()
+            pallas::Base::from_repr(Q_NOTE_COMMITMENT_M_GENERATOR.0).unwrap()
         );
         assert_eq!(
             *coords.y(),
-            pallas::Base::from_bytes(&Q_NOTE_COMMITMENT_M_GENERATOR.1).unwrap()
+            pallas::Base::from_repr(Q_NOTE_COMMITMENT_M_GENERATOR.1).unwrap()
         );
     }
 
@@ -109,11 +109,11 @@ mod tests {
 
         assert_eq!(
             *coords.x(),
-            pallas::Base::from_bytes(&Q_COMMIT_IVK_M_GENERATOR.0).unwrap()
+            pallas::Base::from_repr(Q_COMMIT_IVK_M_GENERATOR.0).unwrap()
         );
         assert_eq!(
             *coords.y(),
-            pallas::Base::from_bytes(&Q_COMMIT_IVK_M_GENERATOR.1).unwrap()
+            pallas::Base::from_repr(Q_COMMIT_IVK_M_GENERATOR.1).unwrap()
         );
     }
 
@@ -125,18 +125,18 @@ mod tests {
 
         assert_eq!(
             *coords.x(),
-            pallas::Base::from_bytes(&Q_MERKLE_CRH.0).unwrap()
+            pallas::Base::from_repr(Q_MERKLE_CRH.0).unwrap()
         );
         assert_eq!(
             *coords.y(),
-            pallas::Base::from_bytes(&Q_MERKLE_CRH.1).unwrap()
+            pallas::Base::from_repr(Q_MERKLE_CRH.1).unwrap()
         );
     }
 
     #[test]
     fn inv_two_pow_k() {
         let two_pow_k = pallas::Base::from(1u64 << K);
-        let inv_two_pow_k = pallas::Base::from_bytes(&INV_TWO_POW_K).unwrap();
+        let inv_two_pow_k = pallas::Base::from_repr(INV_TWO_POW_K).unwrap();
 
         assert_eq!(two_pow_k * inv_two_pow_k, pallas::Base::one());
     }

--- a/src/primitives/sinsemilla/constants.rs
+++ b/src/primitives/sinsemilla/constants.rs
@@ -135,7 +135,7 @@ mod tests {
 
     #[test]
     fn inv_two_pow_k() {
-        let two_pow_k = pallas::Base::from_u64(1u64 << K);
+        let two_pow_k = pallas::Base::from(1u64 << K);
         let inv_two_pow_k = pallas::Base::from_bytes(&INV_TWO_POW_K).unwrap();
 
         assert_eq!(two_pow_k * inv_two_pow_k, pallas::Base::one());

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -70,11 +70,11 @@ impl ConditionallySelectable for NonZeroPallasBase {
 
 impl NonZeroPallasBase {
     pub(crate) fn from_bytes(bytes: &[u8; 32]) -> CtOption<Self> {
-        pallas::Base::from_bytes(bytes).and_then(NonZeroPallasBase::from_base)
+        pallas::Base::from_repr(*bytes).and_then(NonZeroPallasBase::from_base)
     }
 
     pub(crate) fn to_bytes(&self) -> [u8; 32] {
-        self.0.to_bytes()
+        self.0.to_repr()
     }
 
     pub(crate) fn from_base(b: pallas::Base) -> CtOption<Self> {
@@ -116,7 +116,7 @@ impl ConditionallySelectable for NonZeroPallasScalar {
 
 impl NonZeroPallasScalar {
     pub(crate) fn from_bytes(bytes: &[u8; 32]) -> CtOption<Self> {
-        pallas::Scalar::from_bytes(bytes).and_then(NonZeroPallasScalar::from_scalar)
+        pallas::Scalar::from_repr(*bytes).and_then(NonZeroPallasScalar::from_scalar)
     }
 
     pub(crate) fn from_scalar(s: pallas::Scalar) -> CtOption<Self> {

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -251,8 +251,8 @@ pub(crate) fn extract_p_bottom(point: CtOption<pallas::Point>) -> CtOption<palla
 
 /// The field element representation of a u64 integer represented by
 /// an L-bit little-endian bitstring.
-pub fn lebs2ip_field<F: FieldExt, const L: usize>(bits: &[bool; L]) -> F {
-    F::from_u64(lebs2ip::<L>(bits))
+pub fn lebs2ip_field<F: PrimeField, const L: usize>(bits: &[bool; L]) -> F {
+    F::from(lebs2ip::<L>(bits))
 }
 
 /// The u64 integer represented by an L-bit little-endian bitstring.

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -9,7 +9,7 @@ use crate::{
     primitives::sinsemilla::{i2lebsp_k, HashDomain},
 };
 use incrementalmerkletree::{Altitude, Hashable};
-use pasta_curves::{arithmetic::FieldExt, pallas};
+use pasta_curves::pallas;
 
 use ff::{Field, PrimeField, PrimeFieldBits};
 use lazy_static::lazy_static;
@@ -172,7 +172,7 @@ impl MerkleHashOrchard {
 
     /// Convert this digest to its canonical byte representation.
     pub fn to_bytes(&self) -> [u8; 32] {
-        self.0.to_bytes()
+        self.0.to_repr()
     }
 
     /// Parses a incremental tree leaf digest from the bytes of
@@ -181,7 +181,7 @@ impl MerkleHashOrchard {
     /// Returns the empty `CtOption` if the provided bytes represent
     /// a non-canonical encoding.
     pub fn from_bytes(bytes: &[u8; 32]) -> CtOption<Self> {
-        pallas::Base::from_bytes(bytes).map(MerkleHashOrchard)
+        pallas::Base::from_repr(*bytes).map(MerkleHashOrchard)
     }
 }
 
@@ -199,7 +199,7 @@ impl std::cmp::Eq for MerkleHashOrchard {}
 impl std::hash::Hash for MerkleHashOrchard {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         <Option<pallas::Base>>::from(self.0)
-            .map(|b| b.to_bytes())
+            .map(|b| b.to_repr())
             .hash(state)
     }
 }
@@ -275,7 +275,9 @@ pub mod testing {
     #[cfg(test)]
     use crate::tree::{MerkleHashOrchard, EMPTY_ROOTS};
     #[cfg(test)]
-    use pasta_curves::{arithmetic::FieldExt, pallas};
+    use group::ff::PrimeField;
+    #[cfg(test)]
+    use pasta_curves::pallas;
     #[cfg(test)]
     use std::convert::TryInto;
 
@@ -296,7 +298,7 @@ pub mod testing {
             tree.append(&cmx);
             tree.witness();
 
-            assert_eq!(tree.root().0, pallas::Base::from_bytes(&tv.root).unwrap());
+            assert_eq!(tree.root().0, pallas::Base::from_repr(tv.root).unwrap());
 
             // Check paths for all leaves up to this point. The test vectors include paths
             // for not-yet-appended leaves (using UNCOMMITTED_ORCHARD as the leaf value),
@@ -327,7 +329,7 @@ pub mod testing {
             assert_eq!(
                 MerkleHashOrchard::empty_root(Altitude::from(altitude as u8))
                     .0
-                    .to_bytes(),
+                    .to_repr(),
                 *tv_root,
                 "Empty root mismatch at altitude {}",
                 altitude
@@ -378,12 +380,9 @@ pub mod testing {
 
         let mut frontier = BridgeFrontier::<MerkleHashOrchard, 32>::empty();
         for commitment in commitments.iter() {
-            let cmx = MerkleHashOrchard(pallas::Base::from_bytes(commitment).unwrap());
+            let cmx = MerkleHashOrchard(pallas::Base::from_repr(*commitment).unwrap());
             frontier.append(&cmx);
         }
-        assert_eq!(
-            frontier.root().0,
-            pallas::Base::from_bytes(&anchor).unwrap()
-        );
+        assert_eq!(frontier.root().0, pallas::Base::from_repr(anchor).unwrap());
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -23,7 +23,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 // The uncommitted leaf is defined as pallas::Base(2).
 // <https://zips.z.cash/protocol/protocol.pdf#thmuncommittedorchard>
 lazy_static! {
-    static ref UNCOMMITTED_ORCHARD: pallas::Base = pallas::Base::from_u64(2);
+    static ref UNCOMMITTED_ORCHARD: pallas::Base = pallas::Base::from(2);
     pub(crate) static ref EMPTY_ROOTS: Vec<MerkleHashOrchard> = {
         iter::empty()
             .chain(Some(MerkleHashOrchard::empty_leaf()))

--- a/src/value.rs
+++ b/src/value.rs
@@ -23,7 +23,7 @@ use bitvec::{array::BitArray, order::Lsb0};
 use ff::{Field, PrimeField};
 use group::{Curve, Group, GroupEncoding};
 use pasta_curves::{
-    arithmetic::{CurveAffine, CurveExt, FieldExt},
+    arithmetic::{CurveAffine, CurveExt},
     pallas,
 };
 use rand::RngCore;
@@ -252,9 +252,9 @@ impl ValueCommitment {
         let abs_value = u64::try_from(value.0.abs()).expect("value must be in valid range");
 
         let value = if value.0.is_negative() {
-            -pallas::Scalar::from_u64(abs_value)
+            -pallas::Scalar::from(abs_value)
         } else {
-            pallas::Scalar::from_u64(abs_value)
+            pallas::Scalar::from(abs_value)
         };
 
         ValueCommitment(V * value + R * rcv.0)


### PR DESCRIPTION
These methods are being removed in `pasta_curves 0.3.0`.