### PR TITLE
Update `halo2` revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+- pass in an additional `rng: impl RngCore` argument to `builder::InProgress::create_proof`, `builder::Bundle::create_proof`, `circuit::Proof::create`.
 ### Removed
 - `orchard::value::ValueSum::from_raw`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,4 +89,4 @@ debug = true
 debug = true
 
 [patch.crates-io]
-halo2 = { git = "https://github.com/zcash/halo2.git", rev = "afd7bc5469674cd08eae1634225fd02706a36a4f" }
+halo2 = { git = "https://github.com/zcash/halo2.git", rev = "f9b3ff2aef09a5a3cb5489d0e7e747e9523d2e6e" }

--- a/benches/circuit.rs
+++ b/benches/circuit.rs
@@ -57,7 +57,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 b.iter(|| {
                     bundle
                         .authorization()
-                        .create_proof(&pk, &instances)
+                        .create_proof(&pk, &instances, rng)
                         .unwrap()
                 });
             });
@@ -69,7 +69,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         for num_recipients in recipients_range {
             let (bundle, instances) = create_bundle(num_recipients);
             let bundle = bundle
-                .create_proof(&pk)
+                .create_proof(&pk, rng)
                 .unwrap()
                 .apply_signatures(rng, [0; 32], &[])
                 .unwrap();

--- a/benches/note_decryption.rs
+++ b/benches/note_decryption.rs
@@ -54,7 +54,7 @@ fn bench_note_decryption(c: &mut Criterion) {
             .unwrap();
         let bundle: Bundle<_, i64> = builder.build(rng).unwrap();
         bundle
-            .create_proof(&pk)
+            .create_proof(&pk, rng)
             .unwrap()
             .apply_signatures(rng, [0; 32], &[])
             .unwrap()

--- a/benches/poseidon.rs
+++ b/benches/poseidon.rs
@@ -203,7 +203,7 @@ fn bench_poseidon<S, const WIDTH: usize, const RATE: usize, const L: usize>(
     let prover_name = name.to_string() + "-prover";
     let verifier_name = name.to_string() + "-verifier";
 
-    let rng = OsRng;
+    let mut rng = OsRng;
     let message = (0..L)
         .map(|_| pallas::Base::random(rng))
         .collect::<Vec<_>>()
@@ -221,14 +221,14 @@ fn bench_poseidon<S, const WIDTH: usize, const RATE: usize, const L: usize>(
         b.iter(|| {
             // Create a proof
             let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
-            create_proof(&params, &pk, &[circuit], &[&[]], &mut transcript)
+            create_proof(&params, &pk, &[circuit], &[&[]], &mut rng, &mut transcript)
                 .expect("proof generation should not fail")
         })
     });
 
     // Create a proof
     let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
-    create_proof(&params, &pk, &[circuit], &[&[]], &mut transcript)
+    create_proof(&params, &pk, &[circuit], &[&[]], &mut rng, &mut transcript)
         .expect("proof generation should not fail");
     let proof = transcript.finalize();
 

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -198,11 +198,11 @@ impl plonk::Circuit<pallas::Base> for Circuit {
 
         // Instance column used for public inputs
         let primary = meta.instance_column();
-        meta.enable_equality(primary.into());
+        meta.enable_equality(primary);
 
         // Permutation over all advice columns.
         for advice in advices.iter() {
-            meta.enable_equality((*advice).into());
+            meta.enable_equality(*advice);
         }
 
         // Poseidon requires four advice columns, while ECC incomplete addition requires

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -9,6 +9,7 @@ use halo2::{
 };
 use memuse::DynamicUsage;
 use pasta_curves::{arithmetic::CurveAffine, pallas, vesta};
+use rand::RngCore;
 
 use crate::{
     constants::{
@@ -840,6 +841,7 @@ impl Proof {
         pk: &ProvingKey,
         circuits: &[Circuit],
         instances: &[Instance],
+        mut rng: impl RngCore,
     ) -> Result<Self, plonk::Error> {
         let instances: Vec<_> = instances.iter().map(|i| i.to_halo2_instance()).collect();
         let instances: Vec<Vec<_>> = instances
@@ -849,7 +851,14 @@ impl Proof {
         let instances: Vec<_> = instances.iter().map(|i| &i[..]).collect();
 
         let mut transcript = Blake2bWrite::<_, vesta::Affine, _>::init(vec![]);
-        plonk::create_proof(&pk.params, &pk.pk, circuits, &instances, &mut transcript)?;
+        plonk::create_proof(
+            &pk.params,
+            &pk.pk,
+            circuits,
+            &instances,
+            &mut rng,
+            &mut transcript,
+        )?;
         Ok(Proof(transcript.finalize()))
     }
 
@@ -998,7 +1007,7 @@ mod tests {
         }
 
         let pk = ProvingKey::build();
-        let proof = Proof::create(&pk, &circuits, &instances).unwrap();
+        let proof = Proof::create(&pk, &circuits, &instances, &mut rng).unwrap();
         assert!(proof.verify(&vk, &instances).is_ok());
         assert_eq!(proof.0.len(), expected_proof_size);
     }

--- a/src/circuit/gadget/ecc/chip/add.rs
+++ b/src/circuit/gadget/ecc/chip/add.rs
@@ -47,10 +47,10 @@ impl Config {
         gamma: Column<Advice>,
         delta: Column<Advice>,
     ) -> Self {
-        meta.enable_equality(x_p.into());
-        meta.enable_equality(y_p.into());
-        meta.enable_equality(x_qr.into());
-        meta.enable_equality(y_qr.into());
+        meta.enable_equality(x_p);
+        meta.enable_equality(y_p);
+        meta.enable_equality(x_qr);
+        meta.enable_equality(y_qr);
 
         let config = Self {
             q_add: meta.selector(),

--- a/src/circuit/gadget/ecc/chip/add_incomplete.rs
+++ b/src/circuit/gadget/ecc/chip/add_incomplete.rs
@@ -31,10 +31,10 @@ impl Config {
         x_qr: Column<Advice>,
         y_qr: Column<Advice>,
     ) -> Self {
-        meta.enable_equality(x_p.into());
-        meta.enable_equality(y_p.into());
-        meta.enable_equality(x_qr.into());
-        meta.enable_equality(y_qr.into());
+        meta.enable_equality(x_p);
+        meta.enable_equality(y_p);
+        meta.enable_equality(x_qr);
+        meta.enable_equality(y_qr);
 
         let config = Self {
             q_add_incomplete: meta.selector(),

--- a/src/circuit/gadget/ecc/chip/mul/complete.rs
+++ b/src/circuit/gadget/ecc/chip/mul/complete.rs
@@ -26,7 +26,7 @@ impl Config {
         z_complete: Column<Advice>,
         add_config: add::Config,
     ) -> Self {
-        meta.enable_equality(z_complete.into());
+        meta.enable_equality(z_complete);
 
         let config = Self {
             q_mul_decompose_var: meta.selector(),

--- a/src/circuit/gadget/ecc/chip/mul/incomplete.rs
+++ b/src/circuit/gadget/ecc/chip/mul/incomplete.rs
@@ -38,8 +38,8 @@ impl<const NUM_BITS: usize> Config<NUM_BITS> {
         lambda1: Column<Advice>,
         lambda2: Column<Advice>,
     ) -> Self {
-        meta.enable_equality(z.into());
-        meta.enable_equality(lambda1.into());
+        meta.enable_equality(z);
+        meta.enable_equality(lambda1);
 
         let config = Self {
             q_mul: (meta.selector(), meta.selector(), meta.selector()),

--- a/src/circuit/gadget/ecc/chip/mul/overflow.rs
+++ b/src/circuit/gadget/ecc/chip/mul/overflow.rs
@@ -32,7 +32,7 @@ impl Config {
         advices: [Column<Advice>; 3],
     ) -> Self {
         for advice in advices.iter() {
-            meta.enable_equality((*advice).into());
+            meta.enable_equality(*advice);
         }
 
         let config = Self {

--- a/src/circuit/gadget/ecc/chip/mul_fixed.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed.rs
@@ -110,8 +110,8 @@ impl Config {
         add_config: add::Config,
         add_incomplete_config: add_incomplete::Config,
     ) -> Self {
-        meta.enable_equality(window.into());
-        meta.enable_equality(u.into());
+        meta.enable_equality(window);
+        meta.enable_equality(u);
 
         let q_running_sum = meta.selector();
         let running_sum_config = RunningSumConfig::configure(meta, q_running_sum, window);

--- a/src/circuit/gadget/ecc/chip/mul_fixed/base_field_elem.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/base_field_elem.rs
@@ -34,7 +34,7 @@ impl Config {
         super_config: super::Config,
     ) -> Self {
         for advice in canon_advices.iter() {
-            meta.enable_equality((*advice).into());
+            meta.enable_equality(*advice);
         }
 
         let config = Self {

--- a/src/circuit/gadget/ecc/chip/mul_fixed/short.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/short.rs
@@ -373,7 +373,7 @@ pub mod tests {
         use crate::circuit::gadget::{ecc::chip::EccConfig, utilities::UtilitiesInstructions};
         use halo2::{
             circuit::{Layouter, SimpleFloorPlanner},
-            dev::{MockProver, VerifyFailure},
+            dev::{FailureLocation, MockProver, VerifyFailure},
             plonk::{Circuit, ConstraintSystem, Error},
         };
 
@@ -531,7 +531,10 @@ pub mod tests {
                                 "last_window_check"
                             )
                                 .into(),
-                            row: 26,
+                            location: FailureLocation::InRegion {
+                                region: (3, "Short fixed-base mul (most significant word)").into(),
+                                offset: 1,
+                            },
                             cell_values: vec![(
                                 ((Any::Advice, 5).into(), 0).into(),
                                 format_value(circuit.magnitude_error.unwrap()),
@@ -574,7 +577,10 @@ pub mod tests {
                     VerifyFailure::ConstraintNotSatisfied {
                         constraint: ((17, "Short fixed-base mul gate").into(), 1, "sign_check")
                             .into(),
-                        row: 26,
+                        location: FailureLocation::InRegion {
+                            region: (3, "Short fixed-base mul (most significant word)").into(),
+                            offset: 1,
+                        },
                         cell_values: vec![(((Any::Advice, 4).into(), 0).into(), "0".to_string())],
                     },
                     VerifyFailure::ConstraintNotSatisfied {
@@ -584,7 +590,10 @@ pub mod tests {
                             "negation_check"
                         )
                             .into(),
-                        row: 26,
+                        location: FailureLocation::InRegion {
+                            region: (3, "Short fixed-base mul (most significant word)").into(),
+                            offset: 1,
+                        },
                         cell_values: vec![
                             (
                                 ((Any::Advice, 1).into(), 0).into(),

--- a/src/circuit/gadget/poseidon/pow5.rs
+++ b/src/circuit/gadget/poseidon/pow5.rs
@@ -4,7 +4,7 @@ use std::iter;
 use halo2::{
     arithmetic::FieldExt,
     circuit::{AssignedCell, Cell, Chip, Layouter, Region},
-    plonk::{Advice, Column, ConstraintSystem, Error, Expression, Fixed, Selector},
+    plonk::{Advice, Any, Column, ConstraintSystem, Error, Expression, Fixed, Selector},
     poly::Rotation,
 };
 
@@ -75,8 +75,8 @@ impl<F: FieldExt, const WIDTH: usize, const RATE: usize> Pow5Chip<F, WIDTH, RATE
         // rounds, so we use rc_b as "scratch space" for fixed values (enabling potential
         // layouter optimisations).
         for column in iter::empty()
-            .chain(state.iter().cloned().map(|c| c.into()))
-            .chain(rc_b.iter().cloned().map(|c| c.into()))
+            .chain(state.iter().cloned().map(Column::<Any>::from))
+            .chain(rc_b.iter().cloned().map(Column::<Any>::from))
         {
             meta.enable_equality(column);
         }

--- a/src/circuit/gadget/sinsemilla/chip.rs
+++ b/src/circuit/gadget/sinsemilla/chip.rs
@@ -121,7 +121,7 @@ impl SinsemillaChip {
     ) -> <Self as Chip<pallas::Base>>::Config {
         // Enable equality on all advice columns
         for advice in advices.iter() {
-            meta.enable_equality((*advice).into())
+            meta.enable_equality(*advice);
         }
 
         let config = SinsemillaConfig {

--- a/src/circuit/gadget/sinsemilla/commit_ivk.rs
+++ b/src/circuit/gadget/sinsemilla/commit_ivk.rs
@@ -687,7 +687,7 @@ mod tests {
                 meta.enable_constant(constants);
 
                 for advice in advices.iter() {
-                    meta.enable_equality((*advice).into());
+                    meta.enable_equality(*advice);
                 }
 
                 let table_idx = meta.lookup_table_column();

--- a/src/circuit/gadget/sinsemilla/note_commit.rs
+++ b/src/circuit/gadget/sinsemilla/note_commit.rs
@@ -1522,7 +1522,7 @@ mod tests {
                 meta.enable_constant(constants);
 
                 for advice in advices.iter() {
-                    meta.enable_equality((*advice).into());
+                    meta.enable_equality(*advice);
                 }
 
                 let table_idx = meta.lookup_table_column();

--- a/src/circuit/gadget/utilities.rs
+++ b/src/circuit/gadget/utilities.rs
@@ -122,7 +122,7 @@ mod tests {
     use ff::PrimeField;
     use halo2::{
         circuit::{Layouter, SimpleFloorPlanner},
-        dev::{MockProver, VerifyFailure},
+        dev::{FailureLocation, MockProver, VerifyFailure},
         plonk::{Any, Circuit, ConstraintSystem, Error, Selector},
         poly::Rotation,
     };
@@ -199,7 +199,10 @@ mod tests {
                 prover.verify(),
                 Err(vec![VerifyFailure::ConstraintNotSatisfied {
                     constraint: ((0, "range check").into(), 0, "").into(),
-                    row: 0,
+                    location: FailureLocation::InRegion {
+                        region: (0, "range constrain").into(),
+                        offset: 0,
+                    },
                     cell_values: vec![(((Any::Advice, 0).into(), 0).into(), "0x8".to_string())],
                 }])
             );

--- a/src/circuit/gadget/utilities/cond_swap.rs
+++ b/src/circuit/gadget/utilities/cond_swap.rs
@@ -143,7 +143,7 @@ impl<F: FieldExt> CondSwapChip<F> {
     ) -> CondSwapConfig {
         let a = advices[0];
         // Only column a is used in an equality constraint directly by this chip.
-        meta.enable_equality(a.into());
+        meta.enable_equality(a);
 
         let q_swap = meta.selector();
 

--- a/src/circuit/gadget/utilities/decompose_running_sum.rs
+++ b/src/circuit/gadget/utilities/decompose_running_sum.rs
@@ -70,7 +70,7 @@ impl<F: FieldExt + PrimeFieldBits, const WINDOW_NUM_BITS: usize>
     ) -> Self {
         assert!(WINDOW_NUM_BITS <= 3);
 
-        meta.enable_equality(z.into());
+        meta.enable_equality(z);
 
         let config = Self {
             q_range_check,

--- a/src/circuit/gadget/utilities/lookup_range_check.rs
+++ b/src/circuit/gadget/utilities/lookup_range_check.rs
@@ -369,7 +369,7 @@ mod tests {
     use ff::{Field, PrimeFieldBits};
     use halo2::{
         circuit::{Layouter, SimpleFloorPlanner},
-        dev::{MockProver, VerifyFailure},
+        dev::{FailureLocation, MockProver, VerifyFailure},
         plonk::{Circuit, ConstraintSystem, Error},
     };
     use pasta_curves::{arithmetic::FieldExt, pallas};
@@ -562,7 +562,10 @@ mod tests {
                 prover.verify(),
                 Err(vec![VerifyFailure::Lookup {
                     lookup_index: 0,
-                    row: 1
+                    location: FailureLocation::InRegion {
+                        region: (1, "Range check 6 bits").into(),
+                        offset: 1,
+                    },
                 }])
             );
         }
@@ -579,11 +582,17 @@ mod tests {
                 Err(vec![
                     VerifyFailure::Lookup {
                         lookup_index: 0,
-                        row: 0
+                        location: FailureLocation::InRegion {
+                            region: (1, "Range check 6 bits").into(),
+                            offset: 0,
+                        },
                     },
                     VerifyFailure::Lookup {
                         lookup_index: 0,
-                        row: 1
+                        location: FailureLocation::InRegion {
+                            region: (1, "Range check 6 bits").into(),
+                            offset: 1,
+                        },
                     },
                 ])
             );
@@ -609,7 +618,10 @@ mod tests {
                 prover.verify(),
                 Err(vec![VerifyFailure::Lookup {
                     lookup_index: 0,
-                    row: 0
+                    location: FailureLocation::InRegion {
+                        region: (1, "Range check 6 bits").into(),
+                        offset: 0,
+                    },
                 }])
             );
         }

--- a/src/circuit/gadget/utilities/lookup_range_check.rs
+++ b/src/circuit/gadget/utilities/lookup_range_check.rs
@@ -50,7 +50,7 @@ impl<F: FieldExt + PrimeFieldBits, const K: usize> LookupRangeCheckConfig<F, K> 
         running_sum: Column<Advice>,
         table_idx: TableColumn,
     ) -> Self {
-        meta.enable_equality(running_sum.into());
+        meta.enable_equality(running_sum);
 
         let q_lookup = meta.complex_selector();
         let q_running = meta.complex_selector();


### PR DESCRIPTION
Updating to reflect API changes in `halo2`:

- we no longer need to call `.into()` on arguments to `enable_equality()`, as of https://github.com/zcash/halo2/pull/416;
- the `create_proof()` API now expects an `rng` argument, as of https://github.com/zcash/halo2/pull/444;
- `MockProver::FailureLocation` was introduced in https://github.com/zcash/halo2/pull/433.