### PR TITLE
Migrate tests from `FieldExt::rand` to `Field::random`

### DIFF
--- a/src/circuit/gadget/ecc/chip/mul.rs
+++ b/src/circuit/gadget/ecc/chip/mul.rs
@@ -463,12 +463,16 @@ fn decompose_for_scalar_mul(scalar: Option<&pallas::Base>) -> Vec<Option<bool>> 
 
 #[cfg(test)]
 pub mod tests {
-    use group::{ff::PrimeField, Curve};
+    use group::{
+        ff::{Field, PrimeField},
+        Curve,
+    };
     use halo2::{
         circuit::{Chip, Layouter},
         plonk::Error,
     };
-    use pasta_curves::{arithmetic::FieldExt, pallas};
+    use pasta_curves::pallas;
+    use rand::rngs::OsRng;
 
     use crate::circuit::gadget::{
         ecc::{
@@ -508,7 +512,7 @@ pub mod tests {
 
         // [a]B
         {
-            let scalar_val = pallas::Base::rand();
+            let scalar_val = pallas::Base::random(OsRng);
             let (result, _) = {
                 let scalar = chip.load_private(
                     layouter.namespace(|| "random scalar"),

--- a/src/circuit/gadget/ecc/chip/mul_fixed/base_field_elem.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/base_field_elem.rs
@@ -374,12 +374,16 @@ impl Config {
 
 #[cfg(test)]
 pub mod tests {
-    use group::{ff::PrimeField, Curve};
+    use group::{
+        ff::{Field, PrimeField},
+        Curve,
+    };
     use halo2::{
         circuit::{Chip, Layouter},
         plonk::Error,
     };
-    use pasta_curves::{arithmetic::FieldExt, pallas};
+    use pasta_curves::pallas;
+    use rand::rngs::OsRng;
 
     use crate::circuit::gadget::{
         ecc::{
@@ -411,6 +415,8 @@ pub mod tests {
         base: FixedPointBaseField<pallas::Affine, EccChip>,
         base_val: pallas::Affine,
     ) -> Result<(), Error> {
+        let rng = OsRng;
+
         let column = chip.config().advices[0];
 
         fn constrain_equal_non_id(
@@ -432,7 +438,7 @@ pub mod tests {
 
         // [a]B
         {
-            let scalar_fixed = pallas::Base::rand();
+            let scalar_fixed = pallas::Base::random(rng);
             let result = {
                 let scalar_fixed = chip.load_private(
                     layouter.namespace(|| "random base field element"),

--- a/src/circuit/gadget/ecc/chip/mul_fixed/full_width.rs
+++ b/src/circuit/gadget/ecc/chip/mul_fixed/full_width.rs
@@ -178,9 +178,10 @@ impl Config {
 
 #[cfg(test)]
 pub mod tests {
-    use group::Curve;
+    use group::{ff::Field, Curve};
     use halo2::{circuit::Layouter, plonk::Error};
-    use pasta_curves::{arithmetic::FieldExt, pallas};
+    use pasta_curves::pallas;
+    use rand::rngs::OsRng;
 
     use crate::circuit::gadget::ecc::{
         chip::{EccChip, OrchardFixedBasesFull},
@@ -255,7 +256,7 @@ pub mod tests {
 
         // [a]B
         {
-            let scalar_fixed = pallas::Scalar::rand();
+            let scalar_fixed = pallas::Scalar::random(OsRng);
 
             let (result, _) = base.mul(layouter.namespace(|| "random [a]B"), Some(scalar_fixed))?;
             constrain_equal_non_id(

--- a/src/circuit/gadget/poseidon/pow5.rs
+++ b/src/circuit/gadget/poseidon/pow5.rs
@@ -595,15 +595,15 @@ impl<F: FieldExt, const WIDTH: usize> Pow5State<F, WIDTH> {
 
 #[cfg(test)]
 mod tests {
-    use ff::PrimeField;
+    use group::ff::{Field, PrimeField};
     use halo2::{
-        arithmetic::FieldExt,
         circuit::{Layouter, SimpleFloorPlanner},
         dev::MockProver,
         pasta::Fp,
         plonk::{Circuit, ConstraintSystem, Error},
     };
     use pasta_curves::pallas;
+    use rand::rngs::OsRng;
 
     use super::{PoseidonInstructions, Pow5Chip, Pow5Config, StateWord};
     use crate::{
@@ -812,7 +812,9 @@ mod tests {
 
     #[test]
     fn poseidon_hash() {
-        let message = [Fp::rand(), Fp::rand()];
+        let rng = OsRng;
+
+        let message = [Fp::random(rng), Fp::random(rng)];
         let output =
             poseidon::Hash::<_, OrchardNullifier, ConstantLength<2>, 3, 2>::init().hash(message);
 
@@ -828,7 +830,9 @@ mod tests {
 
     #[test]
     fn poseidon_hash_longer_input() {
-        let message = [Fp::rand(), Fp::rand(), Fp::rand()];
+        let rng = OsRng;
+
+        let message = [Fp::random(rng), Fp::random(rng), Fp::random(rng)];
         let output =
             poseidon::Hash::<_, OrchardNullifier, ConstantLength<3>, 3, 2>::init().hash(message);
 

--- a/src/circuit/gadget/sinsemilla.rs
+++ b/src/circuit/gadget/sinsemilla.rs
@@ -411,6 +411,7 @@ mod tests {
         dev::MockProver,
         plonk::{Circuit, ConstraintSystem, Error},
     };
+    use rand::rngs::OsRng;
 
     use super::{
         chip::{SinsemillaChip, SinsemillaCommitDomains, SinsemillaConfig, SinsemillaHashDomains},
@@ -429,8 +430,8 @@ mod tests {
         primitives::sinsemilla::{self, K},
     };
 
-    use group::Curve;
-    use pasta_curves::{arithmetic::FieldExt, pallas};
+    use group::{ff::Field, Curve};
+    use pasta_curves::pallas;
 
     use std::convert::TryInto;
 
@@ -510,6 +511,8 @@ mod tests {
             config: Self::Config,
             mut layouter: impl Layouter<pallas::Base>,
         ) -> Result<(), Error> {
+            let rng = OsRng;
+
             let ecc_chip = EccChip::construct(config.0);
 
             // The two `SinsemillaChip`s share the same lookup table.
@@ -601,7 +604,7 @@ mod tests {
                     ecc_chip.clone(),
                     &SinsemillaCommitDomains::CommitIvk,
                 );
-                let r_val = pallas::Scalar::rand();
+                let r_val = pallas::Scalar::random(rng);
                 let message: Vec<Option<bool>> =
                     (0..500).map(|_| Some(rand::random::<bool>())).collect();
 

--- a/src/circuit/gadget/sinsemilla/commit_ivk.rs
+++ b/src/circuit/gadget/sinsemilla/commit_ivk.rs
@@ -639,13 +639,14 @@ mod tests {
         constants::{COMMIT_IVK_PERSONALIZATION, L_ORCHARD_BASE, T_Q},
         primitives::sinsemilla::CommitDomain,
     };
-    use ff::PrimeFieldBits;
+    use group::ff::{Field, PrimeFieldBits};
     use halo2::{
         circuit::{AssignedCell, Layouter, SimpleFloorPlanner},
         dev::MockProver,
         plonk::{Circuit, ConstraintSystem, Error},
     };
     use pasta_curves::{arithmetic::FieldExt, pallas};
+    use rand::rngs::OsRng;
 
     use std::convert::TryInto;
 
@@ -757,7 +758,7 @@ mod tests {
                 )?;
 
                 // Use a random scalar for rivk
-                let rivk = pallas::Scalar::rand();
+                let rivk = pallas::Scalar::random(OsRng);
 
                 let ivk = commit_ivk_config.assign_region(
                     sinsemilla_chip,

--- a/src/circuit/gadget/sinsemilla/merkle.rs
+++ b/src/circuit/gadget/sinsemilla/merkle.rs
@@ -146,16 +146,15 @@ pub mod tests {
         tree,
     };
 
-    use group::ff::PrimeField;
+    use group::ff::{Field, PrimeField};
     use halo2::{
-        arithmetic::FieldExt,
         circuit::{Layouter, SimpleFloorPlanner},
         dev::MockProver,
         pasta::pallas,
         plonk::{Circuit, ConstraintSystem, Error},
     };
 
-    use rand::random;
+    use rand::{rngs::OsRng, RngCore};
     use std::convert::TryInto;
 
     #[derive(Default)]
@@ -276,13 +275,15 @@ pub mod tests {
 
     #[test]
     fn merkle_chip() {
+        let mut rng = OsRng;
+
         // Choose a random leaf and position
-        let leaf = pallas::Base::rand();
-        let pos = random::<u32>();
+        let leaf = pallas::Base::random(rng);
+        let pos = rng.next_u32();
 
         // Choose a path of random inner nodes
         let path: Vec<_> = (0..(MERKLE_DEPTH_ORCHARD))
-            .map(|_| pallas::Base::rand())
+            .map(|_| pallas::Base::random(rng))
             .collect();
 
         // The root is provided as a public input in the Orchard circuit.

--- a/src/circuit/gadget/sinsemilla/note_commit.rs
+++ b/src/circuit/gadget/sinsemilla/note_commit.rs
@@ -1640,7 +1640,7 @@ mod tests {
                     self.psi,
                 )?;
 
-                let rcm = pallas::Scalar::rand();
+                let rcm = pallas::Scalar::random(OsRng);
 
                 let cm = note_commit_config.assign_region(
                     layouter.namespace(|| "Hash NoteCommit pieces"),

--- a/src/circuit/gadget/utilities.rs
+++ b/src/circuit/gadget/utilities.rs
@@ -119,7 +119,7 @@ pub fn range_check<F: FieldExt>(word: Expression<F>, range: usize) -> Expression
 mod tests {
     use super::*;
     use bigint::U256;
-    use ff::PrimeField;
+    use group::ff::{Field, PrimeField};
     use halo2::{
         circuit::{Layouter, SimpleFloorPlanner},
         dev::{FailureLocation, MockProver, VerifyFailure},
@@ -127,6 +127,7 @@ mod tests {
         poly::Rotation,
     };
     use pasta_curves::pallas;
+    use rand::rngs::OsRng;
 
     #[test]
     fn test_range_check() {
@@ -211,9 +212,11 @@ mod tests {
 
     #[test]
     fn test_bitrange_subset() {
+        let rng = OsRng;
+
         // Subset full range.
         {
-            let field_elem = pallas::Base::rand();
+            let field_elem = pallas::Base::random(rng);
             let bitrange = 0..(pallas::Base::NUM_BITS as usize);
             let subset = bitrange_subset(&field_elem, bitrange);
             assert_eq!(field_elem, subset);
@@ -221,7 +224,7 @@ mod tests {
 
         // Subset zero bits
         {
-            let field_elem = pallas::Base::rand();
+            let field_elem = pallas::Base::random(rng);
             let bitrange = 0..0;
             let subset = bitrange_subset(&field_elem, bitrange);
             assert_eq!(pallas::Base::zero(), subset);
@@ -270,13 +273,13 @@ mod tests {
             assert_eq!(field_elem, sum);
         };
 
-        decompose(pallas::Base::rand(), &[0..255]);
-        decompose(pallas::Base::rand(), &[0..1, 1..255]);
-        decompose(pallas::Base::rand(), &[0..254, 254..255]);
-        decompose(pallas::Base::rand(), &[0..127, 127..255]);
-        decompose(pallas::Base::rand(), &[0..128, 128..255]);
+        decompose(pallas::Base::random(rng), &[0..255]);
+        decompose(pallas::Base::random(rng), &[0..1, 1..255]);
+        decompose(pallas::Base::random(rng), &[0..254, 254..255]);
+        decompose(pallas::Base::random(rng), &[0..127, 127..255]);
+        decompose(pallas::Base::random(rng), &[0..128, 128..255]);
         decompose(
-            pallas::Base::rand(),
+            pallas::Base::random(rng),
             &[0..50, 50..100, 100..150, 150..200, 200..255],
         );
     }

--- a/src/circuit/gadget/utilities/cond_swap.rs
+++ b/src/circuit/gadget/utilities/cond_swap.rs
@@ -197,12 +197,14 @@ impl<F: FieldExt> CondSwapChip<F> {
 mod tests {
     use super::super::UtilitiesInstructions;
     use super::{CondSwapChip, CondSwapConfig, CondSwapInstructions};
+    use group::ff::Field;
     use halo2::{
         circuit::{Layouter, SimpleFloorPlanner},
         dev::MockProver,
         plonk::{Circuit, ConstraintSystem, Error},
     };
     use pasta_curves::{arithmetic::FieldExt, pallas::Base};
+    use rand::rngs::OsRng;
 
     #[test]
     fn cond_swap() {
@@ -265,11 +267,13 @@ mod tests {
             }
         }
 
+        let rng = OsRng;
+
         // Test swap case
         {
             let circuit: MyCircuit<Base> = MyCircuit {
-                a: Some(Base::rand()),
-                b: Some(Base::rand()),
+                a: Some(Base::random(rng)),
+                b: Some(Base::random(rng)),
                 swap: Some(true),
             };
             let prover = MockProver::<Base>::run(3, &circuit, vec![]).unwrap();
@@ -279,8 +283,8 @@ mod tests {
         // Test non-swap case
         {
             let circuit: MyCircuit<Base> = MyCircuit {
-                a: Some(Base::rand()),
-                b: Some(Base::rand()),
+                a: Some(Base::random(rng)),
+                b: Some(Base::random(rng)),
                 swap: Some(false),
             };
             let prover = MockProver::<Base>::run(3, &circuit, vec![]).unwrap();

--- a/src/circuit/gadget/utilities/decompose_running_sum.rs
+++ b/src/circuit/gadget/utilities/decompose_running_sum.rs
@@ -218,12 +218,14 @@ impl<F: FieldExt + PrimeFieldBits, const WINDOW_NUM_BITS: usize>
 mod tests {
     use super::*;
     use crate::constants::{self, FIXED_BASE_WINDOW_SIZE, L_ORCHARD_BASE, L_VALUE};
+    use group::ff::Field;
     use halo2::{
         circuit::{Layouter, SimpleFloorPlanner},
         dev::{MockProver, VerifyFailure},
         plonk::{Any, Circuit, ConstraintSystem, Error},
     };
     use pasta_curves::{arithmetic::FieldExt, pallas};
+    use rand::rngs::OsRng;
 
     #[test]
     fn test_running_sum() {
@@ -301,7 +303,7 @@ mod tests {
 
         // Random base field element
         {
-            let alpha = pallas::Base::rand();
+            let alpha = pallas::Base::random(OsRng);
 
             // Strict full decomposition should pass.
             let circuit: MyCircuit<


### PR DESCRIPTION
These were missed in zcash/orchard#254.