### PR TITLE
Shuffle spends and recipients before pairing them into Actions

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -12,7 +12,7 @@ use group::{
     prime::PrimeCurveAffine,
     Curve, GroupEncoding,
 };
-use pasta_curves::{arithmetic::FieldExt, pallas};
+use pasta_curves::pallas;
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use zcash_note_encryption::EphemeralKeyBytes;
@@ -324,7 +324,7 @@ impl FullViewingKey {
     }
 
     pub(crate) fn rivk_internal(&self) -> CommitIvkRandomness {
-        let k = self.rivk.0.to_bytes();
+        let k = self.rivk.0.to_repr();
         let ak = self.ak.to_bytes();
         let nk = self.nk.to_bytes();
         CommitIvkRandomness(to_scalar(


### PR DESCRIPTION
Callers cannot assume that any specific output corresponds to a specific
Orchard recipient, and must trial-decrypt all outputs to find the ones
belonging to them. This is consistent with higher-layer semantics like
having Unified Addresses as recipients (where the mapping from recipient
to a specific output would become much more complex).

Closes zcash/orchard#203.

Co-authored-by: Daira Hopwood <daira@jacaranda.org>