### PR TITLE
Add `Clone` impls to various structs

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -367,7 +367,7 @@ pub trait InProgressSignatures {
 }
 
 /// Marker for a bundle in the process of being built.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct InProgress<P, S: InProgressSignatures> {
     proof: P,
     sigs: S,
@@ -380,7 +380,7 @@ impl<P, S: InProgressSignatures> Authorization for InProgress<P, S> {
 /// Marker for a bundle without a proof.
 ///
 /// This struct contains the private data needed to create a [`Proof`] for a [`Bundle`].
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Unproven {
     circuits: Vec<Circuit>,
 }
@@ -419,7 +419,7 @@ impl<S: InProgressSignatures, V> Bundle<InProgress<Unproven, S>, V> {
 }
 
 /// The parts needed to sign an [`Action`].
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SigningParts {
     /// The spend validating key for this action. Used to match spend authorizing keys to
     /// actions they can create signatures for.
@@ -429,7 +429,7 @@ pub struct SigningParts {
 }
 
 /// Marker for an unauthorized bundle with no signatures.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Unauthorized {
     bsk: redpallas::SigningKey<Binding>,
 }
@@ -439,7 +439,7 @@ impl InProgressSignatures for Unauthorized {
 }
 
 /// Container for metadata needed to sign an [`Action`].
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SigningMetadata {
     /// If this action is spending a dummy note, this field holds that note's spend
     /// authorizing key.

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -96,7 +96,7 @@ pub struct Config {
 }
 
 /// The Orchard Action circuit.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Circuit {
     pub(crate) path: Option<[MerkleHashOrchard; MERKLE_DEPTH_ORCHARD]>,
     pub(crate) pos: Option<u32>,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -101,7 +101,7 @@ impl SpendingKey {
 /// Defined in [Zcash Protocol Spec § 4.2.3: Orchard Key Components][orchardkeycomponents].
 ///
 /// [orchardkeycomponents]: https://zips.z.cash/protocol/nu5.pdf#orchardkeycomponents
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SpendAuthorizingKey(redpallas::SigningKey<SpendAuth>);
 
 impl SpendAuthorizingKey {

--- a/src/note/commitment.rs
+++ b/src/note/commitment.rs
@@ -12,7 +12,7 @@ use crate::{
     value::NoteValue,
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct NoteCommitTrapdoor(pub(super) pallas::Scalar);
 
 impl NoteCommitTrapdoor {

--- a/src/primitives/redpallas.rs
+++ b/src/primitives/redpallas.rs
@@ -23,7 +23,7 @@ pub type Binding = reddsa::orchard::Binding;
 impl SigType for Binding {}
 
 /// A RedPallas signing key.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SigningKey<T: SigType>(reddsa::SigningKey<T>);
 
 impl<T: SigType> From<SigningKey<T>> for [u8; 32] {


### PR DESCRIPTION
This enables `InProgress<Unproven, Unauthorized>: Clone`, which allows
the bundle returned by `Builder::build` to be cloned. In pure-Rust
wallets this should not be necessary, but it is required for `zcashd`
due to FFI-crossing.