### PR TITLE
Add `FullViewingKey::derive_internal`

### DIFF
--- a/src/spec/prf_expand.rs
+++ b/src/spec/prf_expand.rs
@@ -12,6 +12,7 @@ pub(crate) enum PrfExpand {
     Psi,
     OrchardZip32Child,
     OrchardDkOvk,
+    OrchardRivkInternal,
 }
 
 impl PrfExpand {
@@ -25,6 +26,7 @@ impl PrfExpand {
             Self::Psi => 0x09,
             Self::OrchardZip32Child => 0x81,
             Self::OrchardDkOvk => 0x82,
+            Self::OrchardRivkInternal => 0x83,
         }
     }
 


### PR DESCRIPTION
This is identical to the changes introduced in zcash/orchard#270, except that the output is non-optional (since the derivation is non-fallible). This PR is needed because that PR was not based on non-circuit changes, but we need it before bringing the circuit changes into `zcashd`.