### PR TITLE
Add missing `Debug` trait bounds for `Builder` components

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,6 +1,7 @@
 //! Logic for building Orchard components of transactions.
 
 use std::convert::TryFrom;
+use std::fmt;
 use std::iter;
 
 use ff::Field;
@@ -361,9 +362,9 @@ impl Builder {
 }
 
 /// Marker trait representing bundle signatures in the process of being created.
-pub trait InProgressSignatures {
+pub trait InProgressSignatures: fmt::Debug {
     /// The authorization type of an Orchard action in the process of being authorized.
-    type SpendAuth;
+    type SpendAuth: fmt::Debug;
 }
 
 /// Marker for a bundle in the process of being built.
@@ -373,7 +374,7 @@ pub struct InProgress<P, S: InProgressSignatures> {
     sigs: S,
 }
 
-impl<P, S: InProgressSignatures> Authorization for InProgress<P, S> {
+impl<P: fmt::Debug, S: InProgressSignatures> Authorization for InProgress<P, S> {
     type SpendAuth = S::SpendAuth;
 }
 
@@ -481,7 +482,7 @@ impl MaybeSigned {
     }
 }
 
-impl<P, V> Bundle<InProgress<P, Unauthorized>, V> {
+impl<P: fmt::Debug, V> Bundle<InProgress<P, Unauthorized>, V> {
     /// Loads the sighash into this bundle, preparing it for signing.
     ///
     /// This API ensures that all signatures are created over the same sighash.
@@ -527,7 +528,7 @@ impl<V> Bundle<InProgress<Proof, Unauthorized>, V> {
     }
 }
 
-impl<P, V> Bundle<InProgress<P, PartiallyAuthorized>, V> {
+impl<P: fmt::Debug, V> Bundle<InProgress<P, PartiallyAuthorized>, V> {
     /// Signs this bundle with the given [`SpendAuthorizingKey`].
     ///
     /// This will apply signatures for all notes controlled by this spending key.

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -3,6 +3,7 @@
 pub mod commitments;
 
 use std::convert::TryInto;
+use std::fmt;
 use std::io;
 
 use blake2b_simd::Hash as Blake2bHash;
@@ -230,9 +231,9 @@ impl Flags {
 }
 
 /// Defines the authorization type of an Orchard bundle.
-pub trait Authorization {
+pub trait Authorization: fmt::Debug {
     /// The authorization type of an Orchard action.
-    type SpendAuth;
+    type SpendAuth: fmt::Debug;
 }
 
 /// A bundle of actions to be applied to the ledger.


### PR DESCRIPTION
All relevant types have `Debug` impls, but some of the trait and method impls were lacking `Debug` bounds on their generic types. This prevented `Debug` impls being used on the overall partially-constructed `Bundle` types.