### PR TITLE
Add support for `no-std` builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,29 +23,29 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "katex-header.html"]
 
 [dependencies]
-aes = "0.7"
-bitvec = "1"
-blake2b_simd = "1"
-ff = "0.12"
-fpe = "0.5"
-group = "0.12"
+aes = { version = "0.7", default-features = false }
+bitvec = { version = "1", default-features = false }
+blake2b_simd = { version = "1", default-features = false }
+ff = { version = "0.12", default-features = false, features = ["bits"] }
+fpe = { version = "0.5", default-features = false, features = ["alloc"] }
+group = { version = "0.12", default-features = false }
 halo2_gadgets = "0.2"
-halo2_proofs = "0.2"
-hex = "0.4"
-lazy_static = "1"
-memuse = { version = "0.2", features = ["nonempty"] }
-pasta_curves = "0.4"
+halo2_proofs = { version = "0.2", optional = true }
+hex = { version = "0.4", default-features = false }
+lazy_static = { version = "1", optional = true }
+memuse = { version = "0.2", optional = true, features = ["nonempty"] }
+pasta_curves = { version = "0.4", default-features = false, features = ["alloc", "bits"] }
 proptest = { version = "1.0.0", optional = true }
-rand = "0.8"
-reddsa = "0.3"
-nonempty = "0.7"
-serde = { version = "1.0", features = ["derive"] }
-subtle = "2.3"
-zcash_note_encryption = "0.1"
-incrementalmerkletree = "0.3"
+rand = { version = "0.8", default-features = false }
+reddsa = { version = "0.3", default-features = false }
+nonempty = { version = "0.7", optional = true }
+serde = { version = "1.0", optional = true, features = ["derive"] }
+subtle = { version = "2.3", default-features = false }
+zcash_note_encryption = { version = "0.1", default-features = false }
+incrementalmerkletree = { version = "0.3", optional = true }
 
 # Logging
-tracing = "0.1"
+tracing = { version = "0.1", optional = true }
 
 # Developer tooling dependencies
 plotters = { version = "0.3.0", optional = true }
@@ -64,8 +64,21 @@ pprof = { version = "0.9", features = ["criterion", "flamegraph"] } # MSRV 1.56
 bench = false
 
 [features]
-dev-graph = ["halo2_proofs/dev-graph", "plotters"]
-test-dependencies = ["proptest"]
+dev-graph = ["halo2_proofs/dev-graph", "plotters", "std"]
+test-dependencies = ["std", "proptest"]
+default = ["std"]
+std = [
+    "blake2b_simd/std", # to preserve some gpu optimizations
+    "lazy_static",
+    "memuse",
+    "reddsa/std",
+    "nonempty",
+    "serde",
+    "halo2_proofs",
+    "incrementalmerkletree",
+    "zcash_note_encryption/alloc",
+    "tracing",
+]
 
 [[bench]]
 name = "note_decryption"

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "std")]
 use memuse::DynamicUsage;
 
 use crate::{
@@ -105,6 +106,7 @@ impl<T> Action<T> {
     }
 }
 
+#[cfg(feature = "std")]
 impl DynamicUsage for Action<redpallas::Signature<SpendAuth>> {
     #[inline(always)]
     fn dynamic_usage(&self) -> usize {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -3,7 +3,9 @@ pub mod fixed_bases;
 pub mod sinsemilla;
 pub mod util;
 
+#[cfg(feature = "std")]
 pub use fixed_bases::{NullifierK, OrchardFixedBases, OrchardFixedBasesFull, ValueCommitV, H};
+#[cfg(feature = "std")]
 pub use sinsemilla::{OrchardCommitDomains, OrchardHashDomains};
 
 /// $\mathsf{MerkleDepth^{Orchard}}$

--- a/src/constants/fixed_bases.rs
+++ b/src/constants/fixed_bases.rs
@@ -1,21 +1,31 @@
 //! Orchard fixed bases.
+#[cfg(feature = "std")]
 use super::{L_ORCHARD_SCALAR, L_VALUE};
+#[cfg(feature = "std")]
 use halo2_gadgets::ecc::{
     chip::{BaseFieldElem, FixedPoint, FullScalar, ShortScalar},
     FixedPoints,
 };
 
+#[cfg(feature = "std")]
 use pasta_curves::pallas;
 
+#[cfg(feature = "std")]
 pub mod commit_ivk_r;
+#[cfg(feature = "std")]
 pub mod note_commit_r;
+#[cfg(feature = "std")]
 pub mod nullifier_k;
+#[cfg(feature = "std")]
 pub mod spend_auth_g;
+#[cfg(feature = "std")]
 pub mod value_commit_r;
+#[cfg(feature = "std")]
 pub mod value_commit_v;
 
 /// SWU hash-to-curve personalization for the spending key base point and
 /// the nullifier base point K^Orchard
+#[cfg(feature = "std")]
 pub const ORCHARD_PERSONALIZATION: &str = "z.cash:Orchard";
 
 /// SWU hash-to-curve personalization for the value commitment generator
@@ -34,40 +44,48 @@ pub const NOTE_COMMITMENT_PERSONALIZATION: &str = "z.cash:Orchard-NoteCommit";
 pub const COMMIT_IVK_PERSONALIZATION: &str = "z.cash:Orchard-CommitIvk";
 
 /// Window size for fixed-base scalar multiplication
+#[cfg(feature = "std")]
 pub const FIXED_BASE_WINDOW_SIZE: usize = 3;
 
 /// $2^{`FIXED_BASE_WINDOW_SIZE`}$
+#[cfg(feature = "std")]
 pub const H: usize = 1 << FIXED_BASE_WINDOW_SIZE;
 
 /// Number of windows for a full-width scalar
+#[cfg(feature = "std")]
 pub const NUM_WINDOWS: usize =
     (L_ORCHARD_SCALAR + FIXED_BASE_WINDOW_SIZE - 1) / FIXED_BASE_WINDOW_SIZE;
 
 /// Number of windows for a short signed scalar
+#[cfg(feature = "std")]
 pub const NUM_WINDOWS_SHORT: usize =
     (L_VALUE + FIXED_BASE_WINDOW_SIZE - 1) / FIXED_BASE_WINDOW_SIZE;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 // A sum type for both full-width and short bases. This enables us to use the
 // shared functionality of full-width and short fixed-base scalar multiplication.
+#[cfg(feature = "std")]
 pub enum OrchardFixedBases {
     Full(OrchardFixedBasesFull),
     NullifierK,
     ValueCommitV,
 }
 
+#[cfg(feature = "std")]
 impl From<OrchardFixedBasesFull> for OrchardFixedBases {
     fn from(full_width_base: OrchardFixedBasesFull) -> Self {
         Self::Full(full_width_base)
     }
 }
 
+#[cfg(feature = "std")]
 impl From<ValueCommitV> for OrchardFixedBases {
     fn from(_value_commit_v: ValueCommitV) -> Self {
         Self::ValueCommitV
     }
 }
 
+#[cfg(feature = "std")]
 impl From<NullifierK> for OrchardFixedBases {
     fn from(_nullifier_k: NullifierK) -> Self {
         Self::NullifierK
@@ -75,6 +93,7 @@ impl From<NullifierK> for OrchardFixedBases {
 }
 
 /// The Orchard fixed bases used in scalar mul with full-width scalars.
+#[cfg(feature = "std")]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum OrchardFixedBasesFull {
     CommitIvkR,
@@ -91,12 +110,14 @@ pub struct NullifierK;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct ValueCommitV;
 
+#[cfg(feature = "std")]
 impl FixedPoints<pallas::Affine> for OrchardFixedBases {
     type FullScalar = OrchardFixedBasesFull;
     type Base = NullifierK;
     type ShortScalar = ValueCommitV;
 }
 
+#[cfg(feature = "std")]
 impl FixedPoint<pallas::Affine> for OrchardFixedBasesFull {
     type FixedScalarKind = FullScalar;
 
@@ -128,6 +149,7 @@ impl FixedPoint<pallas::Affine> for OrchardFixedBasesFull {
     }
 }
 
+#[cfg(feature = "std")]
 impl FixedPoint<pallas::Affine> for NullifierK {
     type FixedScalarKind = BaseFieldElem;
 
@@ -144,6 +166,7 @@ impl FixedPoint<pallas::Affine> for NullifierK {
     }
 }
 
+#[cfg(feature = "std")]
 impl FixedPoint<pallas::Affine> for ValueCommitV {
     type FixedScalarKind = ShortScalar;
 

--- a/src/constants/sinsemilla.rs
+++ b/src/constants/sinsemilla.rs
@@ -1,9 +1,13 @@
 //! Sinsemilla generators
+#[cfg(feature = "std")]
 use super::{OrchardFixedBases, OrchardFixedBasesFull};
 use crate::spec::i2lebsp;
+#[cfg(feature = "std")]
 use halo2_gadgets::sinsemilla::{CommitDomains, HashDomains};
 
+#[cfg(feature = "std")]
 use group::ff::PrimeField;
+#[cfg(feature = "std")]
 use pasta_curves::{arithmetic::CurveAffine, pallas};
 
 /// Number of bits of each message piece in $\mathsf{SinsemillaHashToPoint}$
@@ -75,6 +79,7 @@ pub(crate) fn i2lebsp_k(int: usize) -> [bool; K] {
     i2lebsp(int as u64)
 }
 
+#[cfg(feature = "std")]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum OrchardHashDomains {
     NoteCommit,
@@ -82,6 +87,7 @@ pub enum OrchardHashDomains {
     MerkleCrh,
 }
 
+#[cfg(feature = "std")]
 #[allow(non_snake_case)]
 impl HashDomains<pallas::Affine> for OrchardHashDomains {
     fn Q(&self) -> pallas::Affine {
@@ -111,6 +117,7 @@ pub enum OrchardCommitDomains {
     CommitIvk,
 }
 
+#[cfg(feature = "std")]
 impl CommitDomains<pallas::Affine, OrchardFixedBases, OrchardHashDomains> for OrchardCommitDomains {
     fn r(&self) -> OrchardFixedBasesFull {
         match self {
@@ -136,8 +143,8 @@ mod tests {
     };
     use group::{ff::PrimeField, Curve};
     use halo2_gadgets::sinsemilla::primitives::{CommitDomain, HashDomain};
-    use halo2_proofs::arithmetic::CurveAffine;
-    use halo2_proofs::pasta::pallas;
+    use pasta_curves::arithmetic::CurveAffine;
+    use pasta_curves::pallas;
     use rand::{self, rngs::OsRng, Rng};
 
     #[test]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,14 +1,16 @@
 //! Key structures for Orchard.
 
 use core::mem;
+#[cfg(feature = "std")]
 use std::io::{self, Read, Write};
 
 use aes::Aes256;
 use blake2b_simd::{Hash as Blake2bHash, Params};
 use fpe::ff1::{BinaryNumeralString, FF1};
+#[cfg(feature = "std")]
+use group::prime::PrimeCurveAffine;
 use group::{
     ff::{Field, PrimeField},
-    prime::PrimeCurveAffine,
     Curve, GroupEncoding,
 };
 use pasta_curves::pallas;
@@ -395,6 +397,7 @@ impl FullViewingKey {
     /// Serializes the full viewing key as specified in [Zcash Protocol Spec § 5.6.4.4: Orchard Raw Full Viewing Keys][orchardrawfullviewingkeys]
     ///
     /// [orchardrawfullviewingkeys]: https://zips.z.cash/protocol/protocol.pdf#orchardfullviewingkeyencoding
+    #[cfg(feature = "std")]
     pub fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
         writer.write_all(&self.to_bytes())
     }
@@ -402,6 +405,7 @@ impl FullViewingKey {
     /// Parses a full viewing key from its "raw" encoding as specified in [Zcash Protocol Spec § 5.6.4.4: Orchard Raw Full Viewing Keys][orchardrawfullviewingkeys]
     ///
     /// [orchardrawfullviewingkeys]: https://zips.z.cash/protocol/protocol.pdf#orchardfullviewingkeyencoding
+    #[cfg(feature = "std")]
     pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let mut data = [0u8; 96];
         reader.read_exact(&mut data)?;
@@ -856,6 +860,7 @@ impl SharedSecret {
     }
 
     /// Only for use in batched note encryption.
+    #[cfg(feature = "std")]
     pub(crate) fn batch_to_affine(
         shared_secrets: Vec<Option<Self>>,
     ) -> impl Iterator<Item = Option<pallas::Affine>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //! implicitly mean it is an Orchard payment address (as opposed to e.g. a Sapling payment
 //! address, which is also shielded).
 
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 // Temporary until we have more of the crate implemented.
 #![allow(dead_code)]
@@ -18,8 +19,11 @@
 
 mod action;
 mod address;
+#[cfg(feature = "std")]
 pub mod builder;
+#[cfg(feature = "std")]
 pub mod bundle;
+#[cfg(feature = "std")]
 pub mod circuit;
 mod constants;
 pub mod keys;
@@ -27,6 +31,7 @@ pub mod note;
 pub mod note_encryption;
 pub mod primitives;
 mod spec;
+#[cfg(feature = "std")]
 pub mod tree;
 pub mod value;
 pub mod zip32;
@@ -36,7 +41,10 @@ mod test_vectors;
 
 pub use action::Action;
 pub use address::Address;
+#[cfg(feature = "std")]
 pub use bundle::Bundle;
+#[cfg(feature = "std")]
 pub use circuit::Proof;
 pub use note::Note;
+#[cfg(feature = "std")]
 pub use tree::Anchor;

--- a/src/note/nullifier.rs
+++ b/src/note/nullifier.rs
@@ -1,6 +1,5 @@
 use group::{ff::PrimeField, Group};
-use halo2_proofs::arithmetic::CurveExt;
-use pasta_curves::pallas;
+use pasta_curves::{arithmetic::CurveExt, pallas};
 use rand::RngCore;
 use subtle::CtOption;
 

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -4,9 +4,11 @@ use core::fmt;
 
 use blake2b_simd::{Hash, Params};
 use group::ff::PrimeField;
+#[cfg(feature = "std")]
+use zcash_note_encryption::BatchDomain;
 use zcash_note_encryption::{
-    BatchDomain, Domain, EphemeralKeyBytes, NotePlaintextBytes, OutPlaintextBytes,
-    OutgoingCipherKey, ShieldedOutput, COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE, NOTE_PLAINTEXT_SIZE,
+    Domain, EphemeralKeyBytes, NotePlaintextBytes, OutPlaintextBytes, OutgoingCipherKey,
+    ShieldedOutput, COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE, NOTE_PLAINTEXT_SIZE,
     OUT_PLAINTEXT_SIZE,
 };
 
@@ -239,6 +241,7 @@ impl Domain for OrchardDomain {
     }
 }
 
+#[cfg(feature = "std")]
 impl BatchDomain for OrchardDomain {
     fn batch_kdf<'a>(
         items: impl Iterator<Item = (Option<Self::SharedSecret>, &'a EphemeralKeyBytes)>,

--- a/src/primitives/redpallas.rs
+++ b/src/primitives/redpallas.rs
@@ -5,6 +5,7 @@ use core::cmp::{Ord, Ordering, PartialOrd};
 use pasta_curves::pallas;
 use rand::{CryptoRng, RngCore};
 
+#[cfg(feature = "std")]
 pub use reddsa::batch;
 
 #[cfg(test)]
@@ -126,6 +127,7 @@ impl VerificationKey<SpendAuth> {
     }
 
     /// Creates a batch validation item from a `SpendAuth` signature.
+    #[cfg(feature = "std")]
     pub fn create_batch_item<M: AsRef<[u8]>>(
         &self,
         sig: Signature<SpendAuth>,
@@ -135,6 +137,7 @@ impl VerificationKey<SpendAuth> {
     }
 }
 
+#[cfg(feature = "std")]
 impl VerificationKey<Binding> {
     /// Creates a batch validation item from a `Binding` signature.
     pub fn create_batch_item<M: AsRef<[u8]>>(

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -6,9 +6,12 @@ use core::ops::Deref;
 use ff::{Field, PrimeField, PrimeFieldBits};
 use group::GroupEncoding;
 use group::{Curve, Group};
+
 use halo2_gadgets::{poseidon::primitives as poseidon, sinsemilla::primitives as sinsemilla};
-use halo2_proofs::arithmetic::{CurveAffine, CurveExt, FieldExt};
-use pasta_curves::pallas;
+use pasta_curves::{
+    arithmetic::{CurveAffine, CurveExt, FieldExt},
+    pallas,
+};
 use subtle::{ConditionallySelectable, CtOption};
 
 use crate::constants::{
@@ -273,8 +276,7 @@ mod tests {
     use super::{i2lebsp, lebs2ip};
 
     use group::Group;
-    use halo2_proofs::arithmetic::CurveExt;
-    use pasta_curves::pallas;
+    use pasta_curves::{arithmetic::CurveExt, pallas};
     use rand::{rngs::OsRng, RngCore};
 
     #[test]

--- a/src/value.rs
+++ b/src/value.rs
@@ -42,6 +42,7 @@ use core::ops::{Add, RangeInclusive, Sub};
 use bitvec::{array::BitArray, order::Lsb0};
 use ff::{Field, PrimeField};
 use group::{Curve, Group, GroupEncoding};
+#[cfg(feature = "std")]
 use halo2_proofs::plonk::Assigned;
 use pasta_curves::{
     arithmetic::{CurveAffine, CurveExt},
@@ -78,6 +79,7 @@ impl fmt::Display for OverflowError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for OverflowError {}
 
 /// The non-negative value of an individual Orchard note.
@@ -116,6 +118,7 @@ impl NoteValue {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<&NoteValue> for Assigned<pallas::Base> {
     fn from(v: &NoteValue) -> Self {
         pallas::Base::from(v.inner()).into()


### PR DESCRIPTION
Closes #211.

Curve arithmetic is now imported directly from `pasta_curves` instead of `halo2_proofs`.

`no-std` support for `halo2_gadgets::{sinsemilla, poseidon}` can be added later.