### PR TITLE
Rename `Bundle::{try_}authorize` to `Bundle::{try_}map_authorization`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 ### Changed
-- `orchard::bundle::Action` has been moved to `orchard::Action`.
-- `orchard::bundle::Flags::from_byte` now returns `Option<Flags>` instead of
-  `io::Result<Flags>`.
+- `orchard::bundle`:
+  - `Action` has been moved to `orchard::Action`.
+  - `Bundle::{try_}authorize` have been renamed to
+    `Bundle::{try_}map_authorization`.
+  - `Flags::from_byte` now returns `Option<Flags>` instead of
+    `io::Result<Flags>`.
 
 ## [0.1.0-beta.3] - 2022-04-06
 ### Added

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -423,7 +423,7 @@ impl<S: InProgressSignatures, V> Bundle<InProgress<Unproven, S>, V> {
             .iter()
             .map(|a| a.to_instance(*self.flags(), *self.anchor()))
             .collect();
-        self.try_authorize(
+        self.try_map_authorization(
             &mut (),
             |_, _, a| Ok(a),
             |_, auth| {
@@ -509,7 +509,7 @@ impl<P: fmt::Debug, V> Bundle<InProgress<P, Unauthorized>, V> {
         mut rng: R,
         sighash: [u8; 32],
     ) -> Bundle<InProgress<P, PartiallyAuthorized>, V> {
-        self.authorize(
+        self.map_authorization(
             &mut rng,
             |rng, _, SigningMetadata { dummy_ask, parts }| {
                 // We can create signatures for dummy spends immediately.
@@ -552,7 +552,7 @@ impl<P: fmt::Debug, V> Bundle<InProgress<P, PartiallyAuthorized>, V> {
     /// This will apply signatures for all notes controlled by this spending key.
     pub fn sign<R: RngCore + CryptoRng>(self, mut rng: R, ask: &SpendAuthorizingKey) -> Self {
         let expected_ak = ask.into();
-        self.authorize(
+        self.map_authorization(
             &mut rng,
             |rng, partial, maybe| match maybe {
                 MaybeSigned::SigningMetadata(parts) if parts.ak == expected_ak => {
@@ -572,7 +572,7 @@ impl<V> Bundle<InProgress<Proof, PartiallyAuthorized>, V> {
     ///
     /// Returns an error if any signatures are missing.
     pub fn finalize(self) -> Result<Bundle<Authorized, V>, Error> {
-        self.try_authorize(
+        self.try_map_authorization(
             &mut (),
             |_, _, maybe| maybe.finalize(),
             |_, partial| {

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -225,7 +225,7 @@ impl<T: Authorization, V> Bundle<T, V> {
     }
 
     /// Transitions this bundle from one authorization state to another.
-    pub fn authorize<R, U: Authorization>(
+    pub fn map_authorization<R, U: Authorization>(
         self,
         context: &mut R,
         mut spend_auth: impl FnMut(&mut R, &T, T::SpendAuth) -> U::SpendAuth,
@@ -244,7 +244,7 @@ impl<T: Authorization, V> Bundle<T, V> {
     }
 
     /// Transitions this bundle from one authorization state to another.
-    pub fn try_authorize<R, U: Authorization, E>(
+    pub fn try_map_authorization<R, U: Authorization, E>(
         self,
         context: &mut R,
         mut spend_auth: impl FnMut(&mut R, &T, T::SpendAuth) -> Result<U::SpendAuth, E>,


### PR DESCRIPTION
Closes zcash/orchard#71.