### PR TITLE
Make note decryption benchmark reliable

### DIFF
--- a/benches/note_decryption.rs
+++ b/benches/note_decryption.rs
@@ -48,6 +48,11 @@ fn bench_note_decryption(c: &mut Criterion) {
             Flags::from_parts(true, true),
             Anchor::from_bytes([0; 32]).unwrap(),
         );
+        // The builder pads to two actions, and shuffles their order. Add two recipients
+        // so the first action is always decryptable.
+        builder
+            .add_recipient(None, recipient, NoteValue::from_raw(10), None)
+            .unwrap();
         builder
             .add_recipient(None, recipient, NoteValue::from_raw(10), None)
             .unwrap();


### PR DESCRIPTION
The benchmark assumed that the first action in the bundle was for the
recipient it had added, but we've started shuffling recipients within
actions, and the builder pads to a minimum of two actions. This meant
that 50% of benchmark runs would fail to start, but would proceed fine
if they did start (as the bundle is cached for the entire test).

We now add two recipients, to cancel out the effect of the padding and
shuffle.