### PR TITLE
Expose `Proof::add_to_batch` in public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `orchard::Proof::add_to_batch`
 
 ## [0.2.0] - 2022-06-24
 ### Added

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -866,11 +866,13 @@ impl Proof {
         plonk::verify_proof(&vk.params, &vk.vk, strategy, &instances, &mut transcript)
     }
 
-    pub(crate) fn add_to_batch(
-        &self,
-        batch: &mut BatchVerifier<vesta::Affine>,
-        instances: Vec<Instance>,
-    ) {
+    /// Adds this proof to the given batch for verification with the given instances.
+    ///
+    /// Use this API if you want more control over how proof batches are processed. If you
+    /// just want to batch-validate Orchard bundles, use [`bundle::BatchValidator`].
+    ///
+    /// [`bundle::BatchValidator`]: crate::bundle::BatchValidator
+    pub fn add_to_batch(&self, batch: &mut BatchVerifier<vesta::Affine>, instances: Vec<Instance>) {
         let instances = instances
             .iter()
             .map(|i| {


### PR DESCRIPTION
This supports downstream users that want more control over how proof batches are processed, instead of just batch validating Orchard bundles with `orchard::bundle::BatchValidator`.