### PR TITLE
Allow creating notes from serialized parts

### DIFF
--- a/src/note.rs
+++ b/src/note.rs
@@ -21,7 +21,7 @@ pub use self::nullifier::Nullifier;
 
 /// The ZIP 212 seed randomness for a note.
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct RandomSeed([u8; 32]);
+pub struct RandomSeed([u8; 32]);
 
 impl RandomSeed {
     pub(crate) fn random(rng: &mut impl RngCore, rho: &Nullifier) -> Self {
@@ -35,13 +35,15 @@ impl RandomSeed {
         }
     }
 
-    pub(crate) fn from_bytes(rseed: [u8; 32], rho: &Nullifier) -> CtOption<Self> {
+    /// Create RandomSeed from previously serialized bytes
+    pub fn from_bytes(rseed: [u8; 32], rho: &Nullifier) -> CtOption<Self> {
         let rseed = RandomSeed(rseed);
         let esk = rseed.esk_inner(rho);
         CtOption::new(rseed, esk.is_some())
     }
 
-    pub(crate) fn as_bytes(&self) -> &[u8; 32] {
+    /// Serialize randomness into bytes
+    pub fn as_bytes(&self) -> &[u8; 32] {
         &self.0
     }
 
@@ -108,7 +110,8 @@ impl PartialEq for Note {
 impl Eq for Note {}
 
 impl Note {
-    pub(crate) fn from_parts(
+    /// Construct note from its component parts
+    pub fn from_parts(
         recipient: Address,
         value: NoteValue,
         rho: Nullifier,


### PR DESCRIPTION
Allow creating an Orchard `Note` from serialized parts. 

When lightclients parse Orchard actions, they need to serialize the notes into the wallet to be able to spend them at a later time. Right now, the Note's constructors are all `pub(crate)`. This PR allows constructing a `Note` from it's components. 

It is possible I'm misunderstanding how Notes are managed, so if there's another way a lightwallet is supposed to store/load/serialize Orchard notes, please let me know. 