### PR TITLE
Add `ValueSum::commit`

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -174,6 +174,15 @@ impl ValueSum {
             sign,
         )
     }
+
+    /// Commits this value with the corresponding trapdoor `rcv` by $ValueCommit^Orchard$
+    ///
+    /// Defined in [Zcash Protocol Spec § 5.4.8.3: Homomorphic Pedersen commitments (Sapling and Orchard)][concretehomomorphiccommit].
+    ///
+    /// [concretehomomorphiccommit]: https://zips.z.cash/protocol/nu5.pdf#concretehomomorphiccommit
+    pub fn commit(self, rcv: ValueCommitTrapdoor) -> ValueCommitment {
+        ValueCommitment::derive(self, rcv)
+    }
 }
 
 impl Add for ValueSum {


### PR DESCRIPTION
This PR adds API for creating `ValueCommitment`s.

It enables us serialize less data when passing proof witness from HWW to a Prover.