### PR TITLE
Dummy implementation of Domain API change for prepared ivk and epk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,3 +84,7 @@ debug = true
 
 [profile.bench]
 debug = true
+
+[patch.crates-io]
+zcash_note_encryption = { git = "https://github.com/daira/librustzcash.git", rev = "515b0a40ec06eb640fffa65b745166511bf56ecc" }
+group = { git = "https://github.com/zkcrypto/group.git", rev = "a7f3ceb2373e9fe536996f7b4d55c797f3e667f0" }

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -102,6 +102,7 @@ impl OrchardDomain {
 impl Domain for OrchardDomain {
     type EphemeralSecretKey = EphemeralSecretKey;
     type EphemeralPublicKey = EphemeralPublicKey;
+    type PreparedEphemeralPublicKey = EphemeralPublicKey;
     type SharedSecret = SharedSecret;
     type SymmetricKey = Hash;
     type Note = Note;
@@ -122,6 +123,10 @@ impl Domain for OrchardDomain {
         *note.recipient().pk_d()
     }
 
+    fn prepare_epk(epk: Self::EphemeralPublicKey) -> Self::PreparedEphemeralPublicKey {
+        epk
+    }
+
     fn ka_derive_public(
         note: &Self::Note,
         esk: &Self::EphemeralSecretKey,
@@ -138,7 +143,7 @@ impl Domain for OrchardDomain {
 
     fn ka_agree_dec(
         ivk: &Self::IncomingViewingKey,
-        epk: &Self::EphemeralPublicKey,
+        epk: &Self::PreparedEphemeralPublicKey,
     ) -> Self::SharedSecret {
         epk.agree(ivk)
     }


### PR DESCRIPTION
This adapts to API changes in https://github.com/zcash/librustzcash/pull/633 without changing the behaviour for Orchard.