### PR TITLE
Point patch directive at `zcash/librustzcash`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,5 +86,5 @@ debug = true
 debug = true
 
 [patch.crates-io]
-zcash_note_encryption = { git = "https://github.com/daira/librustzcash.git", rev = "515b0a40ec06eb640fffa65b745166511bf56ecc" }
+zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "515b0a40ec06eb640fffa65b745166511bf56ecc" }
 group = { git = "https://github.com/zkcrypto/group.git", rev = "a7f3ceb2373e9fe536996f7b4d55c797f3e667f0" }


### PR DESCRIPTION
zcash/orchard#357 pointed the patch at the PR branch's repository, which broke as soon as the PR branch was deleted from that repository.