### PR TITLE
Add spends/outputs getter fns to builders for use in change calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,9 @@ and this project adheres to Rust's notion of
   - `impl memuse::DynamicUsage for Nullifier`
 - `orchard::note_encryption`:
   - `impl memuse::DynamicUsage for OrchardDomain`
-- `orchard::builder::SpendInfo::new`
+- `orchard::builder`:
+  - `{SpendInfo::new, InputView, OutputView}`
+  - `Builder::{spends, outputs}`
 - `orchard::circuit::Circuit::from_action_context`
 - impls of `Eq` for:
   - `orchard::zip32::ChildIndex`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to Rust's notion of
 ## [Unreleased]
 ### Added
 - `orchard::builder`:
+  - `{SpendInfo::new, InputView, OutputView}`
+  - `Builder::{spends, outputs}`
   - `SpendError` 
   - `OutputError` 
 
@@ -33,9 +35,6 @@ and this project adheres to Rust's notion of
   - `impl memuse::DynamicUsage for Nullifier`
 - `orchard::note_encryption`:
   - `impl memuse::DynamicUsage for OrchardDomain`
-- `orchard::builder`:
-  - `{SpendInfo::new, InputView, OutputView}`
-  - `Builder::{spends, outputs}`
 - `orchard::circuit::Circuit::from_action_context`
 - impls of `Eq` for:
   - `orchard::zip32::ChildIndex`

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -345,6 +345,16 @@ impl Builder {
         Ok(())
     }
 
+    /// Returns the action spend components that will be produced by the transaction being constructed
+    pub fn spends(&self) -> &Vec<impl InputView<()>> {
+        &self.spends
+    }
+
+    /// Returns the action output components that will be produced by the transaction being constructed
+    pub fn outputs(&self) -> &Vec<impl OutputView> {
+        &self.recipients
+    }
+
     /// The net value of the bundle to be built. The value of all spends,
     /// minus the value of all outputs.
     ///
@@ -708,6 +718,39 @@ impl<V> Bundle<InProgress<Proof, PartiallyAuthorized>, V> {
                 ))
             },
         )
+    }
+}
+
+/// A trait that provides a minimized view of an Orchard input suitable for use in
+/// fee and change calculation.
+pub trait InputView<NoteRef> {
+    /// An identifier for the input being spent.
+    fn note_id(&self) -> &NoteRef;
+    /// The value of the input being spent.
+    fn value<V: From<u64>>(&self) -> V;
+}
+
+impl InputView<()> for SpendInfo {
+    fn note_id(&self) -> &() {
+        // The builder does not make use of note identifiers, so we can just return the unit value.
+        &()
+    }
+
+    fn value<V: From<u64>>(&self) -> V {
+        V::from(self.note.value().inner())
+    }
+}
+
+/// A trait that provides a minimized view of an Orchard output suitable for use in
+/// fee and change calculation.
+pub trait OutputView {
+    /// The value of the output being produced.
+    fn value<V: From<u64>>(&self) -> V;
+}
+
+impl OutputView for RecipientInfo {
+    fn value<V: From<u64>>(&self) -> V {
+        V::from(self.value.inner())
     }
 }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -345,7 +345,7 @@ impl Builder {
         Ok(())
     }
 
-    /// Returns the action spend components that will be produced by the 
+    /// Returns the action spend components that will be produced by the
     /// transaction being constructed
     pub fn spends(&self) -> &Vec<impl InputView<()>> {
         &self.spends

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -345,12 +345,14 @@ impl Builder {
         Ok(())
     }
 
-    /// Returns the action spend components that will be produced by the transaction being constructed
+    /// Returns the action spend components that will be produced by the 
+    /// transaction being constructed
     pub fn spends(&self) -> &Vec<impl InputView<()>> {
         &self.spends
     }
 
-    /// Returns the action output components that will be produced by the transaction being constructed
+    /// Returns the action output components that will be produced by the
+    /// transaction being constructed
     pub fn outputs(&self) -> &Vec<impl OutputView> {
         &self.recipients
     }


### PR DESCRIPTION
The `Input/OutputView` traits are nearly straight-copied from https://github.com/zcash/librustzcash/blob/main/zcash_primitives/src/transaction/components/sapling/fees.rs, I'm assuming that interface is the desired one to this kind of functionality. 