### PR TITLE
Migrate to zcash_note_encryption 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to Rust's notion of
   - `Error` has been renamed to `BuildError` to differentiate from new error
     types.
   - `BuildError` now implements `std::error::Error` and `std::fmt::Display`.
+- Migrate to `zcash_note_encryption 0.3.0` 
 
 ## [0.3.0] - 2022-10-19
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ reddsa = "0.5"
 nonempty = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 subtle = "2.3"
-zcash_note_encryption = "0.2"
+zcash_note_encryption = "0.3"
 incrementalmerkletree = "0.3"
 
 # Logging
@@ -56,7 +56,7 @@ criterion = "0.3"
 halo2_gadgets = { version = "0.2", features = ["test-dependencies"] }
 hex = "0.4"
 proptest = "1.0.0"
-zcash_note_encryption = { version = "0.2", features = ["pre-zip-212"] }
+zcash_note_encryption = { version = "0.3", features = ["pre-zip-212"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 inferno = ">= 0.11, < 0.11.15"
@@ -92,3 +92,4 @@ debug = true
 [patch.crates-io]
 halo2_gadgets = { git = "https://github.com/zcash/halo2.git", rev = "642924d614305d882cc122739c59144109f4bd3f" }
 halo2_proofs = { git = "https://github.com/zcash/halo2.git", rev = "642924d614305d882cc122739c59144109f4bd3f" }
+zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "169782c672abaa0c94940a3b2c2c6561933743c3" }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -226,7 +226,6 @@ impl ActionInfo {
         let encryptor = OrchardNoteEncryption::new(
             self.output.ovk,
             note,
-            self.output.recipient,
             self.output.memo.unwrap_or_else(|| {
                 let mut memo = [0; 512];
                 memo[0] = 0xf6;

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -162,11 +162,7 @@ impl Domain for OrchardDomain {
         secret.kdf_orchard(ephemeral_key)
     }
 
-    fn note_plaintext_bytes(
-        note: &Self::Note,
-        _: &Self::Recipient,
-        memo: &Self::Memo,
-    ) -> NotePlaintextBytes {
+    fn note_plaintext_bytes(note: &Self::Note, memo: &Self::Memo) -> NotePlaintextBytes {
         let mut np = [0; NOTE_PLAINTEXT_SIZE];
         np[0] = 0x02;
         np[1..12].copy_from_slice(note.recipient().diversifier().as_array());
@@ -468,7 +464,7 @@ mod tests {
             // Test encryption
             //
 
-            let ne = OrchardNoteEncryption::new_with_esk(esk, Some(ovk), note, recipient, tv.memo);
+            let ne = OrchardNoteEncryption::new_with_esk(esk, Some(ovk), note, tv.memo);
 
             assert_eq!(ne.encrypt_note_plaintext().as_ref(), &tv.c_enc[..]);
             assert_eq!(


### PR DESCRIPTION
This can be merged prior to a `zcash_note_encryption 0.3.0` release, though it will need to be updated to upgrade to such a release prior to `orchard 0.4.0`.