### PR TITLE
Update `zcash_note_encryption` to remove unused arguments from `parse_note_plaintext_without_memo_ovk`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,5 +92,6 @@ debug = true
 debug = true
 
 [patch.crates-io]
+zcash_note_encryption = { git = "https://github.com/zcash/librustzcash.git", rev = "be89e81534a9108b6ecb79fc7509b9adc32d14d6" }
 bridgetree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "62f0c9039b0bee94c16c40c272e19c5922290664" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "62f0c9039b0bee94c16c40c272e19c5922290664" }

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -215,8 +215,6 @@ impl Domain for OrchardDomain {
     fn parse_note_plaintext_without_memo_ovk(
         &self,
         pk_d: &Self::DiversifiedTransmissionKey,
-        _esk: &Self::EphemeralSecretKey,
-        _ephemeral_key: &EphemeralKeyBytes,
         plaintext: &NotePlaintextBytes,
     ) -> Option<(Self::Note, Self::Recipient)> {
         orchard_parse_note_plaintext_without_memo(self, &plaintext.0, |_| *pk_d)


### PR DESCRIPTION
Requires https://github.com/zcash/librustzcash/pull/851