### PR TITLE
Move some changelog entries from 0.3.0 to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,15 @@ and this project adheres to Rust's notion of
   - `Builder::{spends, outputs}`
   - `SpendError`
   - `OutputError`
+- `orchard::keys`:
+  - `PreparedEphemeralPublicKey`
+  - `PreparedIncomingViewingKey`
+- impls of `memuse::DynamicUsage` for:
+  - `orchard::note::nullifier::Nullifier`
+  - `orchard::note_encryption::OrchardDomain`
+- impls of `Eq` for:
+  - `orchard::zip32::ChildIndex`
+  - `orchard::value::ValueSum`
 
 ### Changed
 - MSRV is now 1.60.0.
@@ -77,20 +86,11 @@ and this project adheres to Rust's notion of
 ### Added
 - `orchard::Proof::add_to_batch`
 - `orchard::address::Address::diversifier`
-- `orchard::keys:`:
-  - `Diversifier::from_bytes`
-  - `PreparedEphemeralPublicKey`
-  - `PreparedIncomingViewingKey`
+- `orchard::keys::Diversifier::from_bytes`
 - `orchard::note`:
   - `RandomSeed`
   - `Note::{from_parts, rseed}`
-  - `impl memuse::DynamicUsage for Nullifier`
-- `orchard::note_encryption`:
-  - `impl memuse::DynamicUsage for OrchardDomain`
 - `orchard::circuit::Circuit::from_action_context`
-- impls of `Eq` for:
-  - `orchard::zip32::ChildIndex`
-  - `orchard::value::ValueSum`
 
 ### Changed
 - Migrated to `zcash_note_encryption 0.2`.


### PR DESCRIPTION
The changelog changes in #362 had a non-merge conflict with #363, because #362 was implemented as if it would be part of the 0.3.0 release but was in fact merged just afterwards.

fixes #391