### PR TITLE
Return bundle metadata from bundle building.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to Rust's notion of
 
 ### Added
 - `orchard::builder::bundle`
+- `orchard::builder::BundleMetadata`
 - `orchard::builder::BundleType`
 - `orchard::builder::OutputInfo`
 - `orchard::bundle::Flags::{ENABLED, SPENDS_DISABLED, OUTPUTS_DISABLED}`
@@ -29,7 +30,7 @@ and this project adheres to Rust's notion of
   sent to the same recipient.
 - `orchard::builder::Builder::build` now takes an additional `BundleType` argument
   that specifies how actions should be padded, instead of using hardcoded padding.
-  It also now returns a `Result<Option<Bundle<...>>, ...>` instead of a 
+  It also now returns a `Result<Option<(Bundle<...>, BundleMetadata)>, ...>` instead of a 
   `Result<Bundle<...>, ...>`.
 - `orchard::builder::BuildError` has additional variants:
   - `SpendsDisabled`

--- a/benches/circuit.rs
+++ b/benches/circuit.rs
@@ -31,7 +31,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 .add_output(None, recipient, NoteValue::from_raw(10), None)
                 .unwrap();
         }
-        let bundle: Bundle<_, i64> = builder.build(rng).unwrap().unwrap();
+        let bundle: Bundle<_, i64> = builder.build(rng).unwrap().unwrap().0;
 
         let instances: Vec<_> = bundle
             .actions()

--- a/benches/note_decryption.rs
+++ b/benches/note_decryption.rs
@@ -53,7 +53,7 @@ fn bench_note_decryption(c: &mut Criterion) {
         builder
             .add_output(None, recipient, NoteValue::from_raw(10), None)
             .unwrap();
-        let bundle: Bundle<_, i64> = builder.build(rng).unwrap().unwrap();
+        let bundle: Bundle<_, i64> = builder.build(rng).unwrap().unwrap().0;
         bundle
             .create_proof(&pk, rng)
             .unwrap()

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -373,8 +373,12 @@ impl ActionInfo {
 /// This is returned by [`Builder::build`].
 pub type UnauthorizedBundle<V> = Bundle<InProgress<Unproven, Unauthorized>, V>;
 
-/// Metadata about a how a transaction created by a [`bundle`] ordered actions relative to the
-/// order in which spends and outputs were provided
+/// Metadata about a bundle created by [`bundle`] or [`Builder::build`] that is not
+/// necessarily recoverable from the bundle itself.
+///
+/// This includes information about how [`Action`]s within the bundle are ordered (after
+/// padding and randomization) relative to the order in which spends and outputs were
+/// provided (to [`bundle`]), or the order in which [`Builder`] mutations were performed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BundleMetadata {
     spend_indices: Vec<usize>,
@@ -389,29 +393,31 @@ impl BundleMetadata {
         }
     }
 
-    /// Returns a new empty [`BundleMetadata`].
+    /// Returns the metadata for a [`Bundle`] that contains only dummy actions, if any.
     pub fn empty() -> Self {
         Self::new(0, 0)
     }
 
-    /// Returns the index within the transaction of the [`Action`] corresponding to the `n`-th
-    /// spend specified in bundle construction. If a [`Builder`] was used, this refers to the spend
-    /// added by the `n`-th call to [`Builder::add_spend`].
+    /// Returns the index within the bundle of the [`Action`] corresponding to the `n`-th
+    /// spend specified in bundle construction. If a [`Builder`] was used, this refers to
+    /// the spend added by the `n`-th call to [`Builder::add_spend`].
     ///
-    /// Note positions are randomized when building transactions for indistinguishability.
-    /// This means that the transaction consumer cannot assume that e.g. the first spend
-    /// they added corresponds to the first [`Action`] in the transaction.
+    /// For the purpose of improving indistinguishability, actions are padded and note
+    /// positions are randomized when building bundles. This means that the bundle
+    /// consumer cannot assume that e.g. the first spend they added corresponds to the
+    /// first action in the bundle.
     pub fn spend_action_index(&self, n: usize) -> Option<usize> {
         self.spend_indices.get(n).copied()
     }
 
-    /// Returns the index within the transaction of the [`Action`] corresponding to the `n`-th
-    /// output specified in bundle construction. If a [`Builder`] was used, this refers to the
-    /// output added by the `n`-th call to [`Builder::add_output`].
+    /// Returns the index within the bundle of the [`Action`] corresponding to the `n`-th
+    /// output specified in bundle construction. If a [`Builder`] was used, this refers to
+    /// the output added by the `n`-th call to [`Builder::add_output`].
     ///
-    /// Note positions are randomized when building transactions for indistinguishability.
-    /// This means that the transaction consumer cannot assume that e.g. the first output
-    /// they added corresponds to the first [`Action`] in the transaction.
+    /// For the purpose of improving indistinguishability, actions are padded and note
+    /// positions are randomized when building bundles. This means that the bundle
+    /// consumer cannot assume that e.g. the first output they added corresponds to the
+    /// first action in the bundle.
     pub fn output_action_index(&self, n: usize) -> Option<usize> {
         self.output_indices.get(n).copied()
     }


### PR DESCRIPTION
In order to be able to associate requested spends and outputs with the indices of the actions that execute these operations, it is necessary to track the randomization of inputs and outputs and return the mappings that resulted from that shuffling.