### PR TITLE
Draft: update Orchard to use new backward-compatible version of Halo2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ dependencies = [
 [[package]]
 name = "halo2_gadgets"
 version = "0.3.0"
-source = "git+https://github.com/QED-it/halo2?branch=improve-backward-compatability-without-zsa-default-generic-arg#5414d9526c0e774b0d0597b3fcfea06b656f4ab3"
+source = "git+https://github.com/QED-it/halo2?branch=improve-backward-compatability-without-zsa#9ecbd6513163175efb4b699f9e80e0a14e70c1e6"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -988,7 +988,7 @@ checksum = "47716fe1ae67969c5e0b2ef826f32db8c3be72be325e1aa3c1951d06b5575ec5"
 [[package]]
 name = "halo2_proofs"
 version = "0.3.0"
-source = "git+https://github.com/QED-it/halo2?branch=improve-backward-compatability-without-zsa-default-generic-arg#5414d9526c0e774b0d0597b3fcfea06b656f4ab3"
+source = "git+https://github.com/QED-it/halo2?branch=improve-backward-compatability-without-zsa#9ecbd6513163175efb4b699f9e80e0a14e70c1e6"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,8 +964,7 @@ dependencies = [
 [[package]]
 name = "halo2_gadgets"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126a150072b0c38c7b573fe3eaf0af944a7fed09e154071bf2436d3f016f7230"
+source = "git+https://github.com/QED-it/halo2?branch=improve-backward-compatability-without-zsa-default-generic-arg#5414d9526c0e774b0d0597b3fcfea06b656f4ab3"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -989,8 +988,7 @@ checksum = "47716fe1ae67969c5e0b2ef826f32db8c3be72be325e1aa3c1951d06b5575ec5"
 [[package]]
 name = "halo2_proofs"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b867a8d9bbb85fca76fff60652b5cd19b853a1c4d0665cb89bee68b18d2caf0"
+source = "git+https://github.com/QED-it/halo2?branch=improve-backward-compatability-without-zsa-default-generic-arg#5414d9526c0e774b0d0597b3fcfea06b656f4ab3"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ blake2b_simd = "1"
 ff = "0.13"
 fpe = "0.6"
 group = { version = "0.13", features = ["wnaf-memuse"] }
-halo2_gadgets = { git = "https://github.com/QED-it/halo2", branch = "improve-backward-compatability-without-zsa-default-generic-arg" }
-halo2_proofs = { git = "https://github.com/QED-it/halo2", branch = "improve-backward-compatability-without-zsa-default-generic-arg", default-features = false, features = ["batch", "floor-planner-v1-legacy-pdqsort"] }
+halo2_gadgets = { git = "https://github.com/QED-it/halo2", branch = "improve-backward-compatability-without-zsa" }
+halo2_proofs = { git = "https://github.com/QED-it/halo2", branch = "improve-backward-compatability-without-zsa", default-features = false, features = ["batch", "floor-planner-v1-legacy-pdqsort"] }
 hex = "0.4"
 lazy_static = "1"
 memuse = { version = "0.2.1", features = ["nonempty"] }
@@ -56,7 +56,7 @@ plotters = { version = "0.3.0", optional = true }
 [dev-dependencies]
 bridgetree = "0.4"
 criterion = "0.4" # 0.5 depends on clap 4 which has MSRV 1.70
-halo2_gadgets = { git = "https://github.com/QED-it/halo2", branch = "improve-backward-compatability-without-zsa-default-generic-arg", features = ["test-dependencies"] }
+halo2_gadgets = { git = "https://github.com/QED-it/halo2", branch = "improve-backward-compatability-without-zsa", features = ["test-dependencies"] }
 hex = "0.4"
 proptest = "1.0.0"
 zcash_note_encryption = { version = "0.4", features = ["pre-zip-212"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ blake2b_simd = "1"
 ff = "0.13"
 fpe = "0.6"
 group = { version = "0.13", features = ["wnaf-memuse"] }
-halo2_gadgets = "0.3"
-halo2_proofs = { version = "0.3", default-features = false, features = ["batch", "floor-planner-v1-legacy-pdqsort"] }
+halo2_gadgets = { git = "https://github.com/QED-it/halo2", branch = "improve-backward-compatability-without-zsa-default-generic-arg" }
+halo2_proofs = { git = "https://github.com/QED-it/halo2", branch = "improve-backward-compatability-without-zsa-default-generic-arg", default-features = false, features = ["batch", "floor-planner-v1-legacy-pdqsort"] }
 hex = "0.4"
 lazy_static = "1"
 memuse = { version = "0.2.1", features = ["nonempty"] }
@@ -56,7 +56,7 @@ plotters = { version = "0.3.0", optional = true }
 [dev-dependencies]
 bridgetree = "0.4"
 criterion = "0.4" # 0.5 depends on clap 4 which has MSRV 1.70
-halo2_gadgets = { version = "0.3", features = ["test-dependencies"] }
+halo2_gadgets = { git = "https://github.com/QED-it/halo2", branch = "improve-backward-compatability-without-zsa-default-generic-arg", features = ["test-dependencies"] }
 hex = "0.4"
 proptest = "1.0.0"
 zcash_note_encryption = { version = "0.4", features = ["pre-zip-212"] }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -56,7 +56,7 @@ use halo2_gadgets::{
             MerklePath,
         },
     },
-    utilities::lookup_range_check::LookupRangeCheckConfig,
+    utilities::lookup_range_check::{LookupRangeCheck, LookupRangeCheckConfig},
 };
 
 mod commit_ivk;

--- a/src/circuit/commit_ivk.rs
+++ b/src/circuit/commit_ivk.rs
@@ -228,7 +228,10 @@ impl CommitIvkChip {
 }
 
 pub(in crate::circuit) mod gadgets {
-    use halo2_gadgets::utilities::{lookup_range_check::LookupRangeCheckConfig, RangeConstrained};
+    use halo2_gadgets::utilities::{
+        lookup_range_check::{LookupRangeCheck, LookupRangeCheckConfig},
+        RangeConstrained,
+    };
     use halo2_proofs::circuit::Chip;
 
     use super::*;
@@ -678,7 +681,10 @@ mod tests {
             chip::{SinsemillaChip, SinsemillaConfig},
             primitives::CommitDomain,
         },
-        utilities::{lookup_range_check::LookupRangeCheckConfig, UtilitiesInstructions},
+        utilities::{
+            lookup_range_check::{LookupRangeCheck, LookupRangeCheckConfig},
+            UtilitiesInstructions,
+        },
     };
     use halo2_proofs::{
         circuit::{AssignedCell, Layouter, SimpleFloorPlanner, Value},

--- a/src/circuit/note_commit.rs
+++ b/src/circuit/note_commit.rs
@@ -22,7 +22,9 @@ use halo2_gadgets::{
         CommitDomain, Message, MessagePiece,
     },
     utilities::{
-        bool_check, lookup_range_check::LookupRangeCheckConfig, FieldValue, RangeConstrained,
+        bool_check,
+        lookup_range_check::{LookupRangeCheck, LookupRangeCheckConfig},
+        FieldValue, RangeConstrained,
     },
 };
 
@@ -2034,7 +2036,7 @@ mod tests {
         },
         sinsemilla::chip::SinsemillaChip,
         sinsemilla::primitives::CommitDomain,
-        utilities::lookup_range_check::LookupRangeCheckConfig,
+        utilities::lookup_range_check::{LookupRangeCheck, LookupRangeCheckConfig},
     };
 
     use ff::{Field, PrimeField, PrimeFieldBits};


### PR DESCRIPTION
This PR updates the `orchard` crate to use a backward-compatible version of the `halo2` crate. It contains two key changes:

- Brings the `LookupRangeCheck` trait into scope (this maintains backward compatibility and allows existing code to function without additional modifications).
- Updates `Cargo.toml` to point to the `improve-backward-compatibility-without-zsa` branch of the `halo2` crate.

**Note:** This PR is a draft and is not intended to be merged. It is for review purposes only.
