### PR TITLE
Allow SpendValidatingKey to be constructed from bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### added
+- Added [Visibility crate](https://crates.io/crates/visibility) to modify
+visibility of methods and struct for the `unstable-frost` feature.
+- Added `SpendValidatingKey` serialization and deserialization from bytes
+visibility under the `unstable-frost` feature
+  - `orchard::keys::SpendValidatingKey`
 
 ## [0.8.0] - 2024-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### added
-- Added [Visibility crate](https://crates.io/crates/visibility) to modify
-visibility of methods and struct for the `unstable-frost` feature.
-- Added `SpendValidatingKey` serialization and deserialization from bytes
-visibility under the `unstable-frost` feature
-  - `orchard::keys::SpendValidatingKey`
+### Added
+- `orchard::keys::SpendValidatingKey::{from_bytes, to_bytes}` behind the
+  `unstable-frost` feature flag. These are temporary APIs exposed for development
+  purposes, and will be replaced by type-safe FROST APIs once ZIP 312 key
+  generation is specified (https://github.com/zcash/zips/pull/883).
 
 ## [0.8.0] - 2024-03-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,6 +1440,7 @@ dependencies = [
  "serde",
  "subtle",
  "tracing",
+ "visibility",
  "zcash_note_encryption",
  "zcash_spec",
  "zip32",
@@ -2250,6 +2251,17 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "visibility"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3fd98999db9227cf28e59d83e1f120f42bc233d4b152e8fab9bc87d5bb1e0f8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.31",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ zcash_note_encryption = "0.4"
 incrementalmerkletree = "0.5"
 zcash_spec = "0.1"
 zip32 = "0.1"
+visibility = "0.1.0"
 
 # Logging
 tracing = "0.1"
@@ -71,6 +72,7 @@ bench = false
 
 [features]
 default = ["multicore"]
+unstable-frost = []
 multicore = ["halo2_proofs/multicore"]
 dev-graph = ["halo2_proofs/dev-graph", "image", "plotters"]
 test-dependencies = ["proptest"]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -186,12 +186,17 @@ impl SpendValidatingKey {
 
     /// Converts this spend validating key to its serialized form,
     /// I2LEOSP_256(ak).
+    #[cfg_attr(feature = "unstable-frost", visibility::make(pub))]
     pub(crate) fn to_bytes(&self) -> [u8; 32] {
         // This is correct because the wrapped point must have ỹ = 0, and
         // so the point repr is the same as I2LEOSP of its x-coordinate.
         <[u8; 32]>::from(&self.0)
     }
 
+    /// Attempts to convert these bytes into a spend validating key
+    /// from its serialized form, I2LEOSP_256(ak). Returns None if
+    /// it can't be created.
+    #[cfg_attr(feature = "unstable-frost", visibility::make(pub))]
     pub(crate) fn from_bytes(bytes: &[u8]) -> Option<Self> {
         <[u8; 32]>::try_from(bytes)
             .ok()

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -190,12 +190,14 @@ impl SpendValidatingKey {
     pub(crate) fn to_bytes(&self) -> [u8; 32] {
         // This is correct because the wrapped point must have ỹ = 0, and
         // so the point repr is the same as I2LEOSP of its x-coordinate.
-        <[u8; 32]>::from(&self.0)
+        let b = <[u8; 32]>::from(&self.0);
+        assert!(b[31] & 0x80 == 0);
+        b
     }
 
-    /// Attempts to convert these bytes into a spend validating key
-    /// from its serialized form, I2LEOSP_256(ak). Returns None if
-    /// it can't be created.
+    /// Attempts to parse a byte slice as a spend validating key, `I2LEOSP_256(ak)`.
+    ///
+    /// Returns `None` if the given slice does not contain a valid spend validating key.
     #[cfg_attr(feature = "unstable-frost", visibility::make(pub))]
     pub(crate) fn from_bytes(bytes: &[u8]) -> Option<Self> {
         <[u8; 32]>::try_from(bytes)


### PR DESCRIPTION
According to the [FROST book](https://frost.zfnd.org/zcash/technical-details.html) the ASK is split using FROST and its verifying key is the ak that should be used to generate the Orchard Full Viewing Key.

Allow SpendValidatingKey to be constructed from bytes

closes #427

As we agreed with @daira at Z|ECC, this adds a FROST feature flag so that public interface of the 
crate is not altered in its meaning for non-FROST applications.

Key derivation is intended to be done on a specific way for usual
applications. Interface changes introduce by FROST can pose a risk
for the rest of the use cases that don't involve the assumptions
of the FROST signature scheme protocol. we don't want non-FROST
cases to make use the helper functions FROST needs to derive the 
needed key elements.

There are other changes pending to make FROST work with Orchard.
Those changes will also be under this same feature flag