### PR TITLE
Add `ValueCommitTrapdoor::to_bytes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `orchard::value::ValueCommitTrapdoor::to_bytes`
+
 ## [0.10.0] - 2024-10-02
 
 ### Changed

--- a/src/value.rs
+++ b/src/value.rs
@@ -232,6 +232,16 @@ impl ValueCommitTrapdoor {
     pub fn from_bytes(bytes: [u8; 32]) -> CtOption<Self> {
         pallas::Scalar::from_repr(bytes).map(ValueCommitTrapdoor)
     }
+
+    /// Returns the byte encoding of this trapdoor.
+    ///
+    /// This is a low-level API, requiring a detailed understanding of the
+    /// [use of value commitment trapdoors][orchardbalance] in the Zcash protocol
+    /// to use correctly and securely. It is intended to be used in combination
+    /// with [`ValueCommitment::derive`], and PCZTs.
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.0.to_repr()
+    }
 }
 
 impl Add<&ValueCommitTrapdoor> for ValueCommitTrapdoor {


### PR DESCRIPTION
This is necessary to encode `bsk` into a PCZT.