### PR TITLE
Remove 0xf6 empty memo convention.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to Rust's notion of
 - MSRV is now 1.70
 - Migrated to `nonempty 0.11`, `incrementalmerkletree 0.8`, `shardtree 0.6`, 
   `zcash_spec 0.2`, `zip32 0.2`
+- `orchard::builder::Builder::add_output` now takes a `[u8; 512]` for its
+  `memo` argument instead of an optional value.
 
 ## [0.10.1] - 2024-12-16
 

--- a/benches/circuit.rs
+++ b/benches/circuit.rs
@@ -28,7 +28,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let mut builder = Builder::new(BundleType::DEFAULT, Anchor::from_bytes([0; 32]).unwrap());
         for _ in 0..num_recipients {
             builder
-                .add_output(None, recipient, NoteValue::from_raw(10), None)
+                .add_output(None, recipient, NoteValue::from_raw(10), [0; 512])
                 .unwrap();
         }
         let bundle: Bundle<_, i64> = builder.build(rng).unwrap().unwrap().0;

--- a/benches/note_decryption.rs
+++ b/benches/note_decryption.rs
@@ -48,10 +48,10 @@ fn bench_note_decryption(c: &mut Criterion) {
         // The builder pads to two actions, and shuffles their order. Add two recipients
         // so the first action is always decryptable.
         builder
-            .add_output(None, recipient, NoteValue::from_raw(10), None)
+            .add_output(None, recipient, NoteValue::from_raw(10), [0; 512])
             .unwrap();
         builder
-            .add_output(None, recipient, NoteValue::from_raw(10), None)
+            .add_output(None, recipient, NoteValue::from_raw(10), [0; 512])
             .unwrap();
         let bundle: Bundle<_, i64> = builder.build(rng).unwrap().unwrap().0;
         bundle

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -334,17 +334,13 @@ impl OutputInfo {
         ovk: Option<OutgoingViewingKey>,
         recipient: Address,
         value: NoteValue,
-        memo: Option<[u8; 512]>,
+        memo: [u8; 512],
     ) -> Self {
         Self {
             ovk,
             recipient,
             value,
-            memo: memo.unwrap_or_else(|| {
-                let mut memo = [0; 512];
-                memo[0] = 0xf6;
-                memo
-            }),
+            memo,
         }
     }
 
@@ -355,7 +351,7 @@ impl OutputInfo {
         let fvk: FullViewingKey = (&SpendingKey::random(rng)).into();
         let recipient = fvk.address_at(0u32, Scope::External);
 
-        Self::new(None, recipient, NoteValue::zero(), None)
+        Self::new(None, recipient, NoteValue::zero(), [0u8; 512])
     }
 
     /// Builds the output half of an action.
@@ -594,7 +590,7 @@ impl Builder {
         ovk: Option<OutgoingViewingKey>,
         recipient: Address,
         value: NoteValue,
-        memo: Option<[u8; 512]>,
+        memo: [u8; 512],
     ) -> Result<(), OutputError> {
         let flags = self.bundle_type.flags();
         if !flags.outputs_enabled() {
@@ -1192,7 +1188,7 @@ pub mod testing {
                 let ovk = fvk.to_ovk(scope);
 
                 builder
-                    .add_output(Some(ovk.clone()), addr, value, None)
+                    .add_output(Some(ovk.clone()), addr, value, [0u8; 512])
                     .unwrap();
             }
 
@@ -1305,7 +1301,7 @@ mod tests {
         );
 
         builder
-            .add_output(None, recipient, NoteValue::from_raw(5000), None)
+            .add_output(None, recipient, NoteValue::from_raw(5000), [0u8; 512])
             .unwrap();
         let balance: i64 = builder.value_balance().unwrap();
         assert_eq!(balance, -5000);

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -365,7 +365,7 @@ mod tests {
             EMPTY_ROOTS[MERKLE_DEPTH_ORCHARD].into(),
         );
         builder
-            .add_output(None, recipient, NoteValue::from_raw(5000), None)
+            .add_output(None, recipient, NoteValue::from_raw(5000), [0u8; 512])
             .unwrap();
         let balance: i64 = builder.value_balance().unwrap();
         assert_eq!(balance, -5000);
@@ -442,14 +442,14 @@ mod tests {
             .add_spend(fvk.clone(), note, merkle_path.into())
             .unwrap();
         builder
-            .add_output(None, recipient, NoteValue::from_raw(10_000), None)
+            .add_output(None, recipient, NoteValue::from_raw(10_000), [0u8; 512])
             .unwrap();
         builder
             .add_output(
                 Some(fvk.to_ovk(Scope::Internal)),
                 fvk.address_at(0u32, Scope::Internal),
                 NoteValue::from_raw(5_000),
-                None,
+                [0u8; 512],
             )
             .unwrap();
         let balance: i64 = builder.value_balance().unwrap();

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -51,7 +51,7 @@ fn bundle_chain() {
         );
         let note_value = NoteValue::from_raw(5000);
         assert_eq!(
-            builder.add_output(None, recipient, note_value, None),
+            builder.add_output(None, recipient, note_value, [0u8; 512]),
             Ok(())
         );
         let (unauthorized, bundle_meta) = builder.build(&mut rng).unwrap().unwrap();
@@ -112,7 +112,7 @@ fn bundle_chain() {
         let mut builder = Builder::new(BundleType::DEFAULT, root.into());
         assert_eq!(builder.add_spend(fvk, note, merkle_path.into()), Ok(()));
         assert_eq!(
-            builder.add_output(None, recipient, NoteValue::from_raw(5000), None),
+            builder.add_output(None, recipient, NoteValue::from_raw(5000), [0u8; 512]),
             Ok(())
         );
         let (unauthorized, _) = builder.build(&mut rng).unwrap().unwrap();


### PR DESCRIPTION
This is a standard convention for Zcash memos, but it doesn't have any relevance to the general Orchard protocol and as such doesn't belong in this crate.