### PR TITLE
pczt: Add output field for storing the user-facing address

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -390,6 +390,7 @@ impl OutputInfo {
             // Signers can check `out_ciphertext`.
             ock: None,
             zip32_derivation: None,
+            user_address: None,
             proprietary: BTreeMap::new(),
         }
     }

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -260,6 +260,13 @@ pub struct Output {
     /// The ZIP 32 derivation path at which the spending key can be found for the output.
     pub(crate) zip32_derivation: Option<Zip32Derivation>,
 
+    /// The user-facing address to which this output is being sent, if any.
+    ///
+    /// - This is set by an Updater.
+    /// - Signers must parse this address (if present) and confirm that it contains
+    ///   `recipient` (either directly, or e.g. as a receiver within a Unified Address).
+    pub(crate) user_address: Option<String>,
+
     /// Proprietary fields related to the note being created.
     pub(crate) proprietary: BTreeMap<String, Vec<u8>>,
 }
@@ -273,6 +280,7 @@ impl fmt::Debug for Output {
             .field("value", &self.value)
             .field("rseed", &self.rseed)
             .field("zip32_derivation", &self.zip32_derivation)
+            .field("user_address", &self.user_address)
             .field("proprietary", &self.proprietary)
             .finish_non_exhaustive()
     }

--- a/src/pczt/parse.rs
+++ b/src/pczt/parse.rs
@@ -216,6 +216,7 @@ impl Output {
         rseed: Option<[u8; 32]>,
         ock: Option<[u8; 32]>,
         zip32_derivation: Option<Zip32Derivation>,
+        user_address: Option<String>,
         proprietary: BTreeMap<String, Vec<u8>>,
     ) -> Result<Self, ParseError> {
         let cmx = ExtractedNoteCommitment::from_bytes(&cmx)
@@ -264,6 +265,7 @@ impl Output {
             rseed,
             ock,
             zip32_derivation,
+            user_address,
             proprietary,
         })
     }

--- a/src/pczt/updater.rs
+++ b/src/pczt/updater.rs
@@ -55,6 +55,11 @@ impl<'a> ActionUpdater<'a> {
         self.0.output.zip32_derivation = Some(derivation);
     }
 
+    /// Sets the user-facing address that the new note is being sent to.
+    pub fn set_output_user_address(&mut self, user_address: String) {
+        self.0.output.user_address = Some(user_address);
+    }
+
     /// Stores the given output-specific proprietary value at the given key.
     pub fn set_output_proprietary(&mut self, key: String, value: Vec<u8>) {
         self.0.output.proprietary.insert(key, value);


### PR DESCRIPTION
This is necessary in order for Signers to display the address encoding that a user is expecting to confirm.