### PR TITLE
Add no-std support via a default-enabled `std` feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- Migrated to `nonempty 0.11`.
+
 ## [0.10.1] - 2024-12-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,8 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "nonempty"
-version = "0.10.0"
-source = "git+https://github.com/nuttycom/nonempty.git?rev=38d37189faecb2a0e3d6adc05aa24e1b93c2483b#38d37189faecb2a0e3d6adc05aa24e1b93c2483b"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
 
 [[package]]
 name = "num-bigint"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,9 +1351,8 @@ dependencies = [
 
 [[package]]
 name = "nonempty"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+version = "0.10.0"
+source = "git+https://github.com/nuttycom/nonempty.git?rev=38d37189faecb2a0e3d6adc05aa24e1b93c2483b#38d37189faecb2a0e3d6adc05aa24e1b93c2483b"
 
 [[package]]
 name = "num-bigint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ pasta_curves = "0.5"
 proptest = { version = "1.0.0", optional = true }
 rand = { version = "0.8", default-features = false }
 reddsa = { version = "0.5", default-features = false }
-nonempty = { version = "0.10", default-features = false }
+nonempty = { version = "0.11", default-features = false }
 poseidon = { package = "halo2_poseidon", version = "0.1" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 sinsemilla = "0.1"
@@ -106,6 +106,3 @@ debug = true
 
 [profile.bench]
 debug = true
-
-[patch.crates-io]
-nonempty = { git = "https://github.com/nuttycom/nonempty.git", rev = "38d37189faecb2a0e3d6adc05aa24e1b93c2483b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ pasta_curves = "0.5"
 proptest = { version = "1.0.0", optional = true }
 rand = { version = "0.8", default-features = false }
 reddsa = { version = "0.5", default-features = false }
-nonempty = "0.7"
+nonempty = { version = "0.10", default-features = false }
 poseidon = { package = "halo2_poseidon", version = "0.1" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 sinsemilla = "0.1"
@@ -81,8 +81,9 @@ pprof = { version = "0.11", features = ["criterion", "flamegraph"] }
 bench = false
 
 [features]
-default = ["circuit", "multicore"]
-circuit = ["dep:halo2_gadgets", "dep:halo2_proofs", "core2/std", "group/wnaf-memuse", "reddsa/std"]
+default = ["circuit", "multicore", "std"]
+std = ["core2/std", "group/wnaf-memuse", "reddsa/std"]
+circuit = ["dep:halo2_gadgets", "dep:halo2_proofs", "std"]
 unstable-frost = []
 multicore = ["halo2_proofs?/multicore"]
 dev-graph = ["halo2_proofs?/dev-graph", "image", "plotters"]
@@ -105,3 +106,6 @@ debug = true
 
 [profile.bench]
 debug = true
+
+[patch.crates-io]
+nonempty = { git = "https://github.com/nuttycom/nonempty.git", rev = "38d37189faecb2a0e3d6adc05aa24e1b93c2483b" }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -163,6 +163,7 @@ impl fmt::Display for BuildError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for BuildError {}
 
 #[cfg(feature = "circuit")]
@@ -200,6 +201,7 @@ impl fmt::Display for SpendError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for SpendError {}
 
 /// The only error that can occur here is if outputs are disabled for this builder.
@@ -212,6 +214,7 @@ impl fmt::Display for OutputError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for OutputError {}
 
 /// Information about a specific note to be spent in an [`Action`].

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -12,9 +12,11 @@ pub use batch::BatchValidator;
 use core::fmt;
 
 use blake2b_simd::Hash as Blake2bHash;
-use memuse::DynamicUsage;
 use nonempty::NonEmpty;
 use zcash_note_encryption::{try_note_decryption, try_output_recovery_with_ovk};
+
+#[cfg(feature = "std")]
+use memuse::DynamicUsage;
 
 use crate::{
     action::Action,
@@ -474,6 +476,7 @@ impl<V> Bundle<Authorized, V> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<V: DynamicUsage> DynamicUsage for Bundle<Authorized, V> {
     fn dynamic_usage(&self) -> usize {
         self.actions.tail.dynamic_usage()

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -682,7 +682,7 @@ impl IncomingViewingKey {
 #[derive(Clone, Debug)]
 pub struct PreparedIncomingViewingKey(PreparedNonZeroScalar);
 
-#[cfg(feature = "circuit")]
+#[cfg(feature = "std")]
 impl memuse::DynamicUsage for PreparedIncomingViewingKey {
     fn dynamic_usage(&self) -> usize {
         self.0.dynamic_usage()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 #[macro_use]
 extern crate alloc;
 
+#[cfg(feature = "std")]
 extern crate std;
 
 use alloc::vec::Vec;

--- a/src/primitives/redpallas.rs
+++ b/src/primitives/redpallas.rs
@@ -5,7 +5,7 @@ use core::cmp::{Ord, Ordering, PartialOrd};
 use pasta_curves::pallas;
 use rand::{CryptoRng, RngCore};
 
-#[cfg(feature = "circuit")]
+#[cfg(feature = "std")]
 pub use reddsa::batch;
 
 #[cfg(test)]
@@ -127,7 +127,7 @@ impl VerificationKey<SpendAuth> {
     }
 
     /// Creates a batch validation item from a `SpendAuth` signature.
-    #[cfg(feature = "circuit")]
+    #[cfg(feature = "std")]
     pub fn create_batch_item<M: AsRef<[u8]>>(
         &self,
         sig: Signature<SpendAuth>,
@@ -137,7 +137,7 @@ impl VerificationKey<SpendAuth> {
     }
 }
 
-#[cfg(feature = "circuit")]
+#[cfg(feature = "std")]
 impl VerificationKey<Binding> {
     /// Creates a batch validation item from a `Binding` signature.
     pub fn create_batch_item<M: AsRef<[u8]>>(

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -7,7 +7,7 @@ use ff::{Field, FromUniformBytes, PrimeField, PrimeFieldBits};
 use group::{Curve, Group, GroupEncoding, WnafBase, WnafScalar};
 #[cfg(feature = "circuit")]
 use halo2_gadgets::{poseidon::primitives as poseidon, sinsemilla::primitives as sinsemilla};
-#[cfg(feature = "circuit")]
+#[cfg(feature = "std")]
 use memuse::DynamicUsage;
 use pasta_curves::{
     arithmetic::{CurveAffine, CurveExt},
@@ -157,7 +157,7 @@ impl PreparedNonIdentityBase {
 #[derive(Clone, Debug)]
 pub(crate) struct PreparedNonZeroScalar(WnafScalar<pallas::Scalar, PREPARED_WINDOW_SIZE>);
 
-#[cfg(feature = "circuit")]
+#[cfg(feature = "std")]
 impl DynamicUsage for PreparedNonZeroScalar {
     fn dynamic_usage(&self) -> usize {
         self.0.dynamic_usage()

--- a/src/value.rs
+++ b/src/value.rs
@@ -81,6 +81,7 @@ impl fmt::Display for OverflowError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for OverflowError {}
 
 /// The non-negative value of an individual Orchard note.


### PR DESCRIPTION
This cannot be merged until we have a `no_std` supporting `nonempty` release to depend upon.