### PR TITLE
Migrate to `zcash_spec 0.2.1` and `zip32 0.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to Rust's notion of
 
 ### Changed
 - MSRV is now 1.70
-- Migrated to `nonempty 0.11`, `incrementalmerkletree 0.8`, `shardtree 0.6`, `zip32 0.1.3`.
+- Migrated to `nonempty 0.11`, `incrementalmerkletree 0.8`, `shardtree 0.6`, 
+  `zcash_spec 0.2`, `zip32 0.2`
 
 ## [0.10.1] - 2024-12-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2583,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_spec"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cede95491c2191d3e278cab76e097a44b17fde8d6ca0d4e3a22cf4807b2d857"
+checksum = "ded3f58b93486aa79b85acba1001f5298f27a46489859934954d262533ee2915"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2612,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "zip32"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9943793abf9060b68e1889012dafbd5523ab5b125c0fcc24802d69182f2ac9"
+checksum = "13ff9ea444cdbce820211f91e6aa3d3a56bde7202d3c0961b7c38f793abf5637"
 dependencies = [
  "blake2b_simd",
  "memuse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ sinsemilla = "0.1"
 subtle = { version = "2.3", default-features = false }
 zcash_note_encryption = "0.4"
 incrementalmerkletree = "0.8.1"
-zcash_spec = "0.1"
-zip32 = { version = "0.1.3", default-features = false }
+zcash_spec = "0.2.1"
+zip32 = { version = "0.2.0", default-features = false }
 visibility = "0.1.1"
 
 # Circuit

--- a/src/zip32.rs
+++ b/src/zip32.rs
@@ -209,6 +209,8 @@ impl ExtendedSpendingKey {
             self.chain_code.as_bytes(),
             self.sk.to_bytes(),
             &index.index().to_le_bytes(),
+            &[0],
+            &[],
         );
 
         // I_L is used as the child spending key sk_i.


### PR DESCRIPTION
Blocks on https://github.com/zcash/zcash_spec/pull/7 and https://github.com/zcash/zip32/pull/24.