### PR TITLE
Clarify constraint descriptor for v_old and root == anchor to indicate inclusive OR

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -238,7 +238,7 @@ impl plonk::Circuit<pallas::Base> for Circuit {
                         v_old.clone() - v_new.clone() - magnitude * sign,
                     ),
                     (
-                        "Either v_old = 0, or root = anchor",
+                        "v_old = 0, or root = anchor",
                         v_old.clone() * (root - anchor),
                     ),
                     (


### PR DESCRIPTION
In [src/circuit.rs#L241](https://github.com/zcash/orchard/blob/main/src/circuit.rs#L241), the constraint is currently described as:

`"Either v_old = 0, or root = anchor"`

However, this phrasing can be read as an exclusive-or (XOR), suggesting that not both conditions can be true at once. 

To prevent confusion, the PR rephrased the comment/descriptor to

` "v_old = 0, or root = anchor"`

so it clearly indicates an inclusive-or rather than an exclusive-or. This will help auditors avoid misreading the condition as prohibiting both v_old == 0 and root == anchor from being true simultaneously.