### PR TITLE
CI and dependency fixes for `no_std`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Verify working directory is clean (excluding lockfile)
         run: git diff --exit-code ':!Cargo.lock'
 
-  build-nodefault:
-    name: Build target ${{ matrix.target }}
+  build-nostd:
+    name: Build no_std for target ${{ matrix.target }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -51,7 +51,7 @@ jobs:
       # We use a synthetic crate to ensure no dev-dependencies are enabled, which can
       # be incompatible with some of these targets.
       - name: Create synthetic crate for testing
-        run: cargo init --lib ci-build
+        run: cargo init --edition 2021 --lib ci-build
       - name: Copy Rust version into synthetic crate
         run: cp crate_root/rust-toolchain.toml ci-build/
       - name: Copy patch directives into synthetic crate
@@ -61,16 +61,22 @@ jobs:
       - name: Add no_std pragma to lib.rs
         run: |
           echo "#![no_std]" > ./ci-build/src/lib.rs
-      - name: Add sapling-crypto as a dependency of the synthetic crate
+      - name: Add dependencies of the synthetic crate (e.g. sapling-crypto)
         working-directory: ./ci-build
         run: cargo add --no-default-features --path ../crate_root
       - name: Add lazy_static with the spin_no_std feature
         working-directory: ./ci-build
-        run: cargo add lazy_static --features "spin_no_std"
+        run: cargo add lazy_static --no-default-features --features "spin_no_std"
+      - name: Add typenum with the no_std feature
+        working-directory: ./ci-build
+        run: cargo add typenum --no-default-features --features "no_std"
+      - name: Show Cargo.toml for the synthetic crate
+        working-directory: ./ci-build
+        run: cat Cargo.toml
       - name: Add target
         working-directory: ./ci-build
         run: rustup target add ${{ matrix.target }}
-      - name: Build for target
+      - name: Build no_std for target
         working-directory: ./ci-build
         run: cargo build --verbose --target ${{ matrix.target }}
 

--- a/.github/workflows/lints-stable.yml
+++ b/.github/workflows/lints-stable.yml
@@ -16,3 +16,46 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: ${{ inputs.target }}
           deny: warnings
+
+  clippy-nostd:
+    name: Clippy (MSRV) no_std for ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - wasm32-wasi
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: crate_root
+      # We use a synthetic crate to ensure no dev-dependencies are enabled, which can
+      # be incompatible with some of these targets.
+      - name: Create synthetic crate for testing
+        run: cargo init --edition 2021 --lib ci-build
+      - name: Copy Rust version into synthetic crate
+        run: cp crate_root/rust-toolchain.toml ci-build/
+      - name: Copy patch directives into synthetic crate
+        run: |
+          echo "[patch.crates-io]" >> ./ci-build/Cargo.toml
+          cat ./crate_root/Cargo.toml | sed "0,/.\+\(patch.crates.\+\)/d" >> ./ci-build/Cargo.toml
+      - name: Add no_std pragma to lib.rs
+        run: |
+          echo "#![no_std]" > ./ci-build/src/lib.rs
+      - name: Add dependencies of the synthetic crate (e.g. sapling-crypto)
+        working-directory: ./ci-build
+        run: cargo add --no-default-features --path ../crate_root
+      - name: Add lazy_static with the spin_no_std feature
+        working-directory: ./ci-build
+        run: cargo add lazy_static --no-default-features --features "spin_no_std"
+      - name: Add typenum with the no_std feature
+        working-directory: ./ci-build
+        run: cargo add typenum --no-default-features --features "no_std"
+      - name: Show Cargo.toml for the synthetic crate
+        working-directory: ./ci-build
+        run: cat Cargo.toml
+      - name: Add target
+        working-directory: ./ci-build
+        run: rustup target add ${{ matrix.target }}
+      - name: Clippy no_std for target
+        working-directory: ./ci-build
+        run: cargo clippy --verbose --target ${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ zip32 = { version = "0.2.0", default-features = false }
 visibility = "0.1.1"
 
 # Circuit
-halo2_gadgets = { version = "0.3", optional = true }
+halo2_gadgets = { version = "0.3", optional = true, default-features = false }
 halo2_proofs = { version = "0.3", optional = true, default-features = false, features = ["batch", "floor-planner-v1-legacy-pdqsort"] }
 
 # Boilerplate
@@ -87,7 +87,7 @@ circuit = ["dep:halo2_gadgets", "dep:halo2_proofs", "std"]
 unstable-frost = []
 multicore = ["halo2_proofs?/multicore"]
 dev-graph = ["halo2_proofs?/dev-graph", "image", "plotters"]
-test-dependencies = ["proptest"]
+test-dependencies = ["proptest", "rand/std"]
 
 [[bench]]
 name = "note_decryption"

--- a/README.md
+++ b/README.md
@@ -9,10 +9,14 @@ Requires Rust 1.66+.
 
 ## `no_std` compatibility
 
-Downstream users of this crate must enable the `spin_no_std` feature of the
-`lazy_static` crate in order to take advantage of `no_std` builds; this is due
-to the fact that `--no-default-features` builds of `lazy_static` still rely on
-`std`.
+In order to take advantage of `no_std` builds, downstream users of this crate
+must enable:
+
+* the `spin_no_std` feature of the `lazy_static` crate; and
+* the `no_std` feature of the `typenum` crate.
+
+This is needed because the `--no-default-features` builds of these crates still
+rely on `std`.
 
 ## License
 


### PR DESCRIPTION
* Document needing the `no_std` feature of `typenum` for no_std builds.
* CI: Fixes to `build-nodefault` (renamed to `build-nostd`).
* CI: Add a clippy lint for no_std on `wasm32-wasi`.
* Depend on `halo2_gadgets` with default-features = false.

This fixes the CI steps for `no_std` builds.