### PR TITLE
Disallow identity `rk` in Orchard proof verification.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to Rust's notion of
 - `orchard::pczt::Bundle::extract` now takes its `self` argument by
   reference instead of by value.
 - `orchard::zip32::Error` has added variant `MaxDerivationDepth`
+- `orchard::keys::SpendValidatingKey::randomize` now returns
+  `Option<redpallas::VerificationKey<SpendAuth>>`, yielding `None` when
+  randomization would produce the identity `pallas::Point`.
+- `orchard::primitives::redpallas::VerificationKey<SpendAuth>::randomize`
+  now returns `Option<Self>`, returning None when the randomized verification
+  key corresponds to the identity `pallas::Point`.
+- The blanket `impl<T: SigType> TryFrom<[u8; 32]> for
+  orchard::primitives::redpallas::VerificationKey<T>` has been replaced
+  with distinct implementations for `VerificationKey<SpendAuth>` and
+  `VerificationKey<Binding>`. The `SpendAuth` implementation rejects byte
+  encodings of the identity `pallas::Point`.
 
 ## [0.12.0] - 2025-12-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,12 +60,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,16 +265,15 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.30"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -343,25 +336,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
-name = "const-cstr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d0b5ff30645a68f35ece8cea4556ca14ef8a1651455f789a099a0513532a6"
 
 [[package]]
 name = "constant_time_eq"
@@ -371,9 +349,9 @@ checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -381,15 +359,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
-version = "0.22.3"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -400,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "core-graphics-types"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb142d41022986c1d8ff29103a1411c8a3dfad3552f87a4f8dc50d61d4f4e33"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -411,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "core-text"
-version = "19.2.0"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d74ada66e07c1cefa18f8abfba765b486f250de2e4a999e5727fc0dd4b4a25"
+checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
 dependencies = [
  "core-foundation",
  "core-graphics",
@@ -632,24 +610,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
+name = "dirs"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "cfg-if",
- "dirs-sys-next",
+ "dirs-sys",
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
+name = "dirs-sys"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -663,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "dwrote"
-version = "0.11.0"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b"
+checksum = "9e1b35532432acc8b19ceed096e35dfa088d3ea037fe4f3c085f1f97f33b4d02"
 dependencies = [
  "lazy_static",
  "libc",
@@ -687,7 +665,7 @@ checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -766,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "float-ord"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bad48618fdb549078c333a7a8528acb57af271d0433bdecd523eb620628364e"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "flume"
@@ -791,19 +769,19 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "font-kit"
-version = "0.11.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21fe28504d371085fae9ac7a3450f0b289ab71e07c8e57baa3fb68b9e57d6ce5"
+checksum = "2c7e611d49285d4c4b2e1727b72cf05353558885cc5252f93707b845dfcaf3d3"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "byteorder",
  "core-foundation",
  "core-graphics",
  "core-text",
- "dirs-next",
+ "dirs",
  "dwrote",
  "float-ord",
- "freetype",
+ "freetype-sys",
  "lazy_static",
  "libc",
  "log",
@@ -816,18 +794,30 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
+ "foreign-types-macros",
  "foreign-types-shared",
 ]
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
+name = "foreign-types-macros"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "fpe"
@@ -844,22 +834,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "freetype"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee38378a9e3db1cc693b4f88d166ae375338a0ff75cb8263e1c601d51f35dc6"
-dependencies = [
- "freetype-sys",
- "libc",
-]
-
-[[package]]
 name = "freetype-sys"
-version = "0.13.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37d4011c0cc628dfa766fcc195454f4b068d7afdc2adfd28861191d866e731a"
+checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
 dependencies = [
- "cmake",
+ "cc",
  "libc",
  "pkg-config",
 ]
@@ -914,7 +894,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1188,10 +1168,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1237,7 +1218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1245,6 +1226,15 @@ name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1434,6 +1424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orchard"
 version = "0.12.0"
 dependencies = [
@@ -1509,7 +1505,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "smallvec",
  "windows-targets",
 ]
@@ -1541,22 +1537,11 @@ dependencies = [
 
 [[package]]
 name = "pathfinder_simd"
-version = "0.5.1"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39fe46acc5503595e5949c17b818714d26fdf9b4920eacf3b2947f0199f4a6ff"
+checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
 dependencies = [
  "rustc_version",
-]
-
-[[package]]
-name = "pest"
-version = "2.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33"
-dependencies = [
- "memchr",
- "thiserror",
- "ucd-trie",
 ]
 
 [[package]]
@@ -1576,7 +1561,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1593,9 +1578,9 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "plotters"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "chrono",
  "font-kit",
@@ -1613,15 +1598,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-bitmap"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cebbe1f70205299abc69e8b295035bb52a6a70ee35474ad10011f0a4efb8543"
+checksum = "72ce181e3f6bf82d6c1dc569103ca7b1bd964c60ba03d7e6cdfbb3e3eb7f7405"
 dependencies = [
  "gif 0.12.0",
  "image",
@@ -1630,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
@@ -1680,7 +1665,7 @@ dependencies = [
  "smallvec",
  "symbolic-demangle",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.48",
 ]
 
 [[package]]
@@ -1708,14 +1693,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1757,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1845,17 +1830,8 @@ dependencies = [
  "pasta_curves",
  "rand_core",
  "serde",
- "thiserror",
+ "thiserror 1.0.48",
  "zeroize",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1869,13 +1845,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom",
- "redox_syscall 0.2.16",
- "thiserror",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1930,9 +1906,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -1947,8 +1923,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -1991,21 +1973,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2024,7 +1994,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2154,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.31"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2188,9 +2158,9 @@ checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2205,7 +2175,16 @@ version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.48",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2216,7 +2195,18 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2260,7 +2250,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2274,21 +2264,15 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.17.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375812fa44dab6df41c195cd2f7fecb488f6c09fbaafb62807488cefab642bff"
+checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "uint"
@@ -2344,7 +2328,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2374,34 +2358,22 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
-dependencies = [
- "bumpalo",
- "log",
  "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.31",
+ "rustversion",
+ "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2409,28 +2381,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
- "wasm-bindgen-backend",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2483,12 +2458,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2568,11 +2558,10 @@ dependencies = [
 
 [[package]]
 name = "yeslogic-fontconfig-sys"
-version = "3.2.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bbd69036d397ebbff671b1b8e4d918610c181c5a16073b96f984a38d08c386"
+checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
 dependencies = [
- "const-cstr",
  "dlib",
  "once_cell",
  "pkg-config",
@@ -2617,7 +2606,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -302,7 +302,9 @@ impl SpendInfo {
         let nf_old = self.note.nullifier(&self.fvk);
         let ak: SpendValidatingKey = self.fvk.clone().into();
         let alpha = pallas::Scalar::random(&mut rng);
-        let rk = ak.randomize(&alpha);
+        let rk = ak
+            .randomize(&alpha)
+            .expect("alpha was generated randomly, so the identity is vanishingly unlikely");
 
         (nf_old, ak, alpha, rk)
     }
@@ -921,6 +923,8 @@ pub struct SigningParts {
     /// actions they can create signatures for.
     ak: SpendValidatingKey,
     /// The randomization needed to derive the actual signing key for this note.
+    ///
+    /// This is guaranteed (internally) to be derived from randomness.
     alpha: pallas::Scalar,
 }
 
@@ -1068,7 +1072,7 @@ impl<P: fmt::Debug, V> Bundle<InProgress<P, PartiallyAuthorized>, V> {
             &mut signature_valid_for,
             |valid_for, partial, maybe| match maybe {
                 MaybeSigned::SigningMetadata(parts) => {
-                    let rk = parts.ak.randomize(&parts.alpha);
+                    let rk = parts.ak.randomize(&parts.alpha).expect("SigningParts is constructed only with random alpha, so the identity is vanishingly unlikely.");
                     if rk.verify(&partial.sigs.sighash[..], signature).is_ok() {
                         *valid_for += 1;
                         MaybeSigned::Signature(signature.clone())

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -995,7 +995,11 @@ impl<P: fmt::Debug, V> Bundle<InProgress<P, Unauthorized>, V> {
             |rng, _, SigningMetadata { dummy_ask, parts }| {
                 // We can create signatures for dummy spends immediately.
                 dummy_ask
-                    .map(|ask| ask.randomize(&parts.alpha).sign(rng, &sighash))
+                    .map(|ask| {
+                        ask.randomize(&parts.alpha)
+                            .expect("alpha was generated randomly, so a zero randomized signing key is vanishingly unlikely")
+                            .sign(rng, &sighash)
+                    })
                     .map(MaybeSigned::Signature)
                     .unwrap_or(MaybeSigned::SigningMetadata(parts))
             },
@@ -1041,7 +1045,9 @@ impl<P: fmt::Debug, V> Bundle<InProgress<P, PartiallyAuthorized>, V> {
             |rng, partial, maybe| match maybe {
                 MaybeSigned::SigningMetadata(parts) if parts.ak == expected_ak => {
                     MaybeSigned::Signature(
-                        ask.randomize(&parts.alpha).sign(rng, &partial.sigs.sighash),
+                        ask.randomize(&parts.alpha)
+                            .expect("alpha was generated randomly, so a zero randomized signing key is vanishingly unlikely")
+                            .sign(rng, &partial.sigs.sighash),
                     )
                 }
                 s => s,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -844,10 +844,8 @@ impl Instance {
         instance[NF_OLD] = self.nf_old.0;
 
         let rk = pallas::Point::from_bytes(&self.rk.clone().into())
-            .unwrap()
-            .to_affine()
-            .coordinates()
-            .unwrap();
+            .and_then(|ep| ep.to_affine().coordinates())
+            .expect("The identity VerificationKey for SpendAuth is disallowed by construction.");
 
         instance[RK_X] = *rk.x();
         instance[RK_Y] = *rk.y();
@@ -949,7 +947,9 @@ mod tests {
         let rho = Rho::from_nf_old(nf_old);
         let ak: SpendValidatingKey = fvk.into();
         let alpha = pallas::Scalar::random(&mut rng);
-        let rk = ak.randomize(&alpha);
+        let rk = ak
+            .randomize(&alpha)
+            .expect("alpha was generated randomly, so the identity is vanishingly unlikely");
 
         let (_, _, output_note) = Note::dummy(&mut rng, Some(rho));
         let cmx = output_note.commitment().into();

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -181,7 +181,12 @@ impl Eq for SpendValidatingKey {}
 
 impl SpendValidatingKey {
     /// Randomizes this spend validating key with the given `randomizer`.
-    pub fn randomize(&self, randomizer: &pallas::Scalar) -> redpallas::VerificationKey<SpendAuth> {
+    ///
+    /// Returns `None` if randomization would produce the identity [`pallas::Point`].
+    pub fn randomize(
+        &self,
+        randomizer: &pallas::Scalar,
+    ) -> Option<redpallas::VerificationKey<SpendAuth>> {
         self.0.randomize(randomizer)
     }
 
@@ -204,11 +209,10 @@ impl SpendValidatingKey {
         <[u8; 32]>::try_from(bytes)
             .ok()
             .and_then(|b| {
-                // Structural validity checks for ak_P:
-                // - The point must not be the identity
-                //   (which for Pallas is canonically encoded as all-zeroes).
-                // - The sign of the y-coordinate must be positive.
-                if b != [0; 32] && b[31] & 0x80 == 0 {
+                // Structural validity check for ak_P: the sign of the y-coordinate must
+                // be positive. Rejection of the identity point is handled by
+                // `<redpallas::VerificationKey<SpendAuth>>::try_from`.
+                if b[31] & 0x80 == 0 {
                     <redpallas::VerificationKey<SpendAuth>>::try_from(b).ok()
                 } else {
                     None

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -128,7 +128,13 @@ impl SpendAuthorizingKey {
     /// Randomizes this spend authorizing key with the given `randomizer`.
     ///
     /// The resulting key can be used to actually sign a spend.
-    pub fn randomize(&self, randomizer: &pallas::Scalar) -> redpallas::SigningKey<SpendAuth> {
+    ///
+    /// Returns `None` if the randomized signing key would correspond to an identity
+    /// [`redpallas::VerificationKey`] (i.e. its scalar is zero).
+    pub fn randomize(
+        &self,
+        randomizer: &pallas::Scalar,
+    ) -> Option<redpallas::SigningKey<SpendAuth>> {
         self.0.randomize(randomizer)
     }
 }

--- a/src/pczt/signer.rs
+++ b/src/pczt/signer.rs
@@ -24,7 +24,12 @@ impl super::Action {
             .alpha
             .ok_or(SignerError::MissingSpendAuthRandomizer)?;
 
-        let rsk = ask.randomize(&alpha);
+        // If randomization produces a zero scalar the `ask` cannot match: the stored
+        // `rk` is guaranteed non-identity, so the honest `ask` randomized by `alpha`
+        // would never have a zero scalar.
+        let rsk = ask
+            .randomize(&alpha)
+            .ok_or(SignerError::WrongSpendAuthorizingKey)?;
         let rk = redpallas::VerificationKey::from(&rsk);
 
         if self.spend.rk == rk {

--- a/src/pczt/verify.rs
+++ b/src/pczt/verify.rs
@@ -108,7 +108,7 @@ impl super::Spend {
             .as_ref()
             .ok_or(VerifyError::MissingSpendAuthRandomizer)?;
 
-        if ak.randomize(alpha) == self.rk {
+        if ak.randomize(alpha) == Some(self.rk.clone()) {
             Ok(())
         } else {
             Err(VerifyError::InvalidRandomizedVerificationKey)

--- a/src/primitives/redpallas.rs
+++ b/src/primitives/redpallas.rs
@@ -263,27 +263,10 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
-    use group::ff::Field;
+    use group::ff::{Field, PrimeField};
     use pasta_curves::pallas;
 
-    use super::{Binding, SpendAuth, VerificationKey};
-
-    /// The byte-encoding of the basepoint for the Orchard `SpendAuthSig`, reproduced from
-    /// `reddsa::orchard::ORCHARD_SPENDAUTHSIG_BASEPOINT_BYTES` (which is not public).
-    const ORCHARD_SPENDAUTHSIG_BASEPOINT_BYTES: [u8; 32] = [
-        99, 201, 117, 184, 132, 114, 26, 141, 12, 161, 112, 123, 227, 12, 127, 12, 95, 68, 95, 62,
-        124, 24, 141, 59, 6, 214, 241, 40, 179, 35, 85, 183,
-    ];
-
-    #[test]
-    fn orchard_spendauth_basepoint() {
-        use group::GroupEncoding;
-        use pasta_curves::arithmetic::CurveExt;
-        assert_eq!(
-            pallas::Point::hash_to_curve("z.cash:Orchard")(b"G").to_bytes(),
-            ORCHARD_SPENDAUTHSIG_BASEPOINT_BYTES,
-        );
-    }
+    use super::{Binding, SigningKey, SpendAuth, VerificationKey};
 
     #[test]
     fn try_from_identity_bytes_is_rejected() {
@@ -312,11 +295,13 @@ mod tests {
 
     #[test]
     fn spendauth_randomize_to_identity_returns_none() {
-        // Construct a `VerificationKey<SpendAuth>` equal to the SpendAuthSig basepoint
-        // `G`, then randomize by `alpha = -1`. The resulting key is
-        // `rk = G + (-1) * G = identity`, which must be rejected.
-        let ak = VerificationKey::<SpendAuth>::try_from(ORCHARD_SPENDAUTHSIG_BASEPOINT_BYTES)
-            .expect("the SpendAuthSig basepoint is not the identity");
+        // Construct a `VerificationKey<SpendAuth>` corresponding to the
+        // signing key with scalar 1 (so, equal to the `SpendAuthSig` base
+        // point `G`), then randomize by `alpha = -1`. The resulting key is
+        // `rk = [1] G + [-1] G = identity`, which must be rejected.
+        let ask_bytes: [u8; 32] = pallas::Scalar::ONE.to_repr().into();
+        let ask = <SigningKey<SpendAuth>>::try_from(ask_bytes).expect("1 is a valid scalar");
+        let ak = <VerificationKey<SpendAuth>>::from(&ask);
         let alpha = -pallas::Scalar::ONE;
         assert!(
             ak.randomize(&alpha).is_none(),

--- a/src/primitives/redpallas.rs
+++ b/src/primitives/redpallas.rs
@@ -2,6 +2,7 @@
 
 use core::cmp::{Ord, Ordering, PartialOrd};
 
+use group::{Group as _, GroupEncoding as _};
 use pasta_curves::pallas;
 use rand::{CryptoRng, RngCore};
 
@@ -78,11 +79,32 @@ impl<T: SigType> From<&VerificationKey<T>> for [u8; 32] {
     }
 }
 
-impl<T: SigType> TryFrom<[u8; 32]> for VerificationKey<T> {
+impl TryFrom<[u8; 32]> for VerificationKey<SpendAuth> {
     type Error = reddsa::Error;
 
     fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
-        bytes.try_into().map(VerificationKey)
+        // Do not permit construction of `VerificationKey<SpendAuth>` if the underlying
+        // `pallas::Point` is the identity. Note that `pallas::Point::from_bytes` decodes
+        // the all-zeros encoding successfully (as the identity), so we must explicitly
+        // check `is_identity()` rather than relying on the decoding to fail.
+        let maybe_point = pallas::Point::from_bytes(&bytes);
+        if bool::from(
+            maybe_point
+                .unwrap_or(pallas::Point::identity())
+                .is_identity(),
+        ) {
+            Err(reddsa::Error::MalformedVerificationKey)
+        } else {
+            reddsa::VerificationKey::try_from(bytes).map(Self)
+        }
+    }
+}
+
+impl TryFrom<[u8; 32]> for VerificationKey<Binding> {
+    type Error = reddsa::Error;
+
+    fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
+        reddsa::VerificationKey::try_from(bytes).map(Self)
     }
 }
 
@@ -122,8 +144,20 @@ impl VerificationKey<SpendAuth> {
     /// Randomizes this verification key with the given `randomizer`.
     ///
     /// Randomization is only supported for `SpendAuth` keys.
-    pub fn randomize(&self, randomizer: &pallas::Scalar) -> Self {
-        VerificationKey(self.0.randomize(randomizer))
+    ///
+    /// Returns `None` if the [`pallas::Point`] corresponding to the randomized verification
+    /// key is the identity.
+    pub fn randomize(&self, randomizer: &pallas::Scalar) -> Option<Self> {
+        let randomized = self.0.randomize(randomizer);
+        let bytes = <[u8; 32]>::from(randomized);
+        let point: pallas::Point = Option::from(pallas::Point::from_bytes(&bytes))
+            .expect("VerificationKey bytes are always a canonical Pallas point encoding");
+
+        if bool::from(point.is_identity()) {
+            None
+        } else {
+            Some(VerificationKey(randomized))
+        }
     }
 
     /// Creates a batch validation item from a `SpendAuth` signature.
@@ -224,5 +258,69 @@ pub mod testing {
         pub fn arb_binding_verification_key()(sk in arb_binding_signing_key()) -> VerificationKey<Binding> {
             VerificationKey::from(&sk)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use group::ff::Field;
+    use pasta_curves::pallas;
+
+    use super::{Binding, SpendAuth, VerificationKey};
+
+    /// The byte-encoding of the basepoint for the Orchard `SpendAuthSig`, reproduced from
+    /// `reddsa::orchard::ORCHARD_SPENDAUTHSIG_BASEPOINT_BYTES` (which is not public).
+    const ORCHARD_SPENDAUTHSIG_BASEPOINT_BYTES: [u8; 32] = [
+        99, 201, 117, 184, 132, 114, 26, 141, 12, 161, 112, 123, 227, 12, 127, 12, 95, 68, 95, 62,
+        124, 24, 141, 59, 6, 214, 241, 40, 179, 35, 85, 183,
+    ];
+
+    #[test]
+    fn orchard_spendauth_basepoint() {
+        use group::GroupEncoding;
+        use pasta_curves::arithmetic::CurveExt;
+        assert_eq!(
+            pallas::Point::hash_to_curve("z.cash:Orchard")(b"G").to_bytes(),
+            ORCHARD_SPENDAUTHSIG_BASEPOINT_BYTES,
+        );
+    }
+
+    #[test]
+    fn try_from_identity_bytes_is_rejected() {
+        // The all-zeros encoding is the canonical encoding of the identity point on Pallas.
+        // `VerificationKey<SpendAuth>` must reject it, since an identity `rk` would allow
+        // forgery of spend authorization signatures.
+        let result = VerificationKey::<SpendAuth>::try_from([0u8; 32]);
+        assert!(
+            result.is_err(),
+            "VerificationKey::<SpendAuth>::try_from([0u8; 32]) must reject the identity",
+        );
+    }
+
+    #[test]
+    fn binding_try_from_identity_bytes_is_accepted() {
+        // Identity verification keys are permitted for `Binding` (Orchard uses a
+        // prime-order group, and the RedDSA specification allows identity verification
+        // keys; rejection is specific to `SpendAuth`, where an identity `rk` would permit
+        // forgery of spend authorization signatures).
+        let result = VerificationKey::<Binding>::try_from([0u8; 32]);
+        assert!(
+            result.is_ok(),
+            "VerificationKey::<Binding>::try_from([0u8; 32]) must accept the identity",
+        );
+    }
+
+    #[test]
+    fn spendauth_randomize_to_identity_returns_none() {
+        // Construct a `VerificationKey<SpendAuth>` equal to the SpendAuthSig basepoint
+        // `G`, then randomize by `alpha = -1`. The resulting key is
+        // `rk = G + (-1) * G = identity`, which must be rejected.
+        let ak = VerificationKey::<SpendAuth>::try_from(ORCHARD_SPENDAUTHSIG_BASEPOINT_BYTES)
+            .expect("the SpendAuthSig basepoint is not the identity");
+        let alpha = -pallas::Scalar::ONE;
+        assert!(
+            ak.randomize(&alpha).is_none(),
+            "randomizing the SpendAuthSig basepoint by -1 produces the identity, which must be rejected",
+        );
     }
 }

--- a/src/primitives/redpallas.rs
+++ b/src/primitives/redpallas.rs
@@ -39,7 +39,22 @@ impl<T: SigType> From<&SigningKey<T>> for [u8; 32] {
     }
 }
 
-impl<T: SigType> TryFrom<[u8; 32]> for SigningKey<T> {
+impl TryFrom<[u8; 32]> for SigningKey<SpendAuth> {
+    type Error = reddsa::Error;
+
+    fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
+        // Reject the zero scalar: the corresponding `VerificationKey<SpendAuth>` is the
+        // identity, which would permit forgery of spend authorization signatures. This
+        // maintains the invariant that no `SigningKey<SpendAuth>` can be constructed
+        // whose corresponding verification key is the identity.
+        if bytes == [0u8; 32] {
+            return Err(reddsa::Error::MalformedSigningKey);
+        }
+        bytes.try_into().map(SigningKey)
+    }
+}
+
+impl TryFrom<[u8; 32]> for SigningKey<Binding> {
     type Error = reddsa::Error;
 
     fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
@@ -51,8 +66,19 @@ impl SigningKey<SpendAuth> {
     /// Randomizes this signing key with the given `randomizer`.
     ///
     /// Randomization is only supported for `SpendAuth` keys.
-    pub fn randomize(&self, randomizer: &pallas::Scalar) -> Self {
-        SigningKey(self.0.randomize(randomizer))
+    ///
+    /// Returns `None` if the resulting [`SigningKey`] would correspond to an identity
+    /// [`VerificationKey`] (i.e. its scalar is zero).
+    pub fn randomize(&self, randomizer: &pallas::Scalar) -> Option<Self> {
+        let randomized = self.0.randomize(randomizer);
+        // `SigningKey<T>` encodes as the canonical little-endian repr of its scalar;
+        // scalar 0 (and only scalar 0) encodes as all zeros. The corresponding
+        // verification key is the identity iff the scalar is zero.
+        if <[u8; 32]>::from(randomized) == [0u8; 32] {
+            None
+        } else {
+            Some(SigningKey(randomized))
+        }
     }
 }
 
@@ -228,10 +254,10 @@ pub mod testing {
         /// Generate a uniformly distributed RedDSA spend authorization signing key.
         pub fn arb_spendauth_signing_key()(
             sk in prop::array::uniform32(prop::num::u8::ANY)
-                .prop_map(reddsa::SigningKey::try_from)
-                .prop_filter("Values must be parseable as valid signing keys", |r| r.is_ok())
+                .prop_map(SigningKey::<SpendAuth>::try_from)
+                .prop_filter("Values must be parseable as valid spend authorization signing keys", |r| r.is_ok())
         ) -> SigningKey<SpendAuth> {
-            SigningKey(sk.unwrap())
+            sk.unwrap()
         }
     }
 
@@ -277,6 +303,44 @@ mod tests {
         assert!(
             result.is_err(),
             "VerificationKey::<SpendAuth>::try_from([0u8; 32]) must reject the identity",
+        );
+    }
+
+    #[test]
+    fn signing_key_spendauth_try_from_zero_scalar_is_rejected() {
+        // The all-zeros encoding is the canonical encoding of the zero scalar, whose
+        // corresponding `VerificationKey<SpendAuth>` is the identity. `SigningKey<SpendAuth>`
+        // must reject it to maintain the invariant that no such signing key has an
+        // identity verification key.
+        let result = SigningKey::<SpendAuth>::try_from([0u8; 32]);
+        assert!(
+            result.is_err(),
+            "SigningKey::<SpendAuth>::try_from([0u8; 32]) must reject the zero scalar",
+        );
+    }
+
+    #[test]
+    fn signing_key_binding_try_from_zero_scalar_is_accepted() {
+        // `Binding` permits identity verification keys, so the zero scalar is a valid
+        // signing key for that role.
+        let result = SigningKey::<Binding>::try_from([0u8; 32]);
+        assert!(
+            result.is_ok(),
+            "SigningKey::<Binding>::try_from([0u8; 32]) must accept the zero scalar",
+        );
+    }
+
+    #[test]
+    fn signing_key_spendauth_randomize_to_zero_returns_none() {
+        // Construct a `SigningKey<SpendAuth>` with scalar 1, then randomize by `-1`.
+        // The resulting scalar is zero, whose verification key is the identity — so
+        // `randomize` must return `None`.
+        let ask_bytes: [u8; 32] = pallas::Scalar::ONE.to_repr().into();
+        let ask = <SigningKey<SpendAuth>>::try_from(ask_bytes).expect("1 is a valid scalar");
+        let alpha = -pallas::Scalar::ONE;
+        assert!(
+            ask.randomize(&alpha).is_none(),
+            "randomizing a scalar-1 signing key by -1 produces zero, which must be rejected",
         );
     }
 


### PR DESCRIPTION
Previously, proof verification could crash if a set of public inputs to the circuit contained an `rk` value that mapped to the identity.