### PR TITLE
orchard_internal split clarifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-All notable changes to this project will be documented in this file.
+All notable changes to the `orchard` crate will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to Rust's notion of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "orchard_internal"
-version = "0.12.0"
+version = "1.0.0"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,11 @@
 members = [".", "public"]
 
 [workspace.dependencies]
-__impl = { version = "=0.12.0", path = ".", package = "orchard_internal", default-features = false }
+__impl = { version = "1", path = ".", package = "orchard_internal", default-features = false }
 
 [package]
 name = "orchard_internal"
-version = "0.12.0"
+version = "1.0.0"
 authors = [
     "Sean Bowe <ewillbefull@gmail.com>",
     "Jack Grigg <thestr4d@gmail.com>",


### PR DESCRIPTION
1. `orchard_internal` should not have the same version convention as `orchard`, since the public API of `orchard_internal` is _intentionally_ being modified and exposed in ways that would decouple the two when following strict semantic versioning conventions, or require needless major version bumps to `orchard`.
2. Let's _not_ strictly pin from `orchard` to `orchard_internal`. (Just respect semver!)
3. Let's clarify that the `CHANGELOG.md` file applies to the `orchard` crate specifically to avoid mixing the two.