### PR TITLE
consensus: Reject identity `rk` in `Action::from_parts` and `Instance::from_parts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,29 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `orchard::primitives::redpallas::VerificationKey<T>::is_identity`, which
+  returns `true` if the verification key is the identity `pallas::Point`.
+- `orchard::primitives::redpallas::testing::arb_valid_spendauth_keypair`
+  (under the `test-dependencies` feature): a uniformly-distributed valid
+  `(rsk, rk)` key pair with non-identity `rk`.
+
 ### Changed
 - MSRV is now 1.85.1
 - Migrated from yanked `core2` library to `corez`
 - `orchard::pczt::Bundle::extract` now takes its `self` argument by
   reference instead of by value.
 - `orchard::zip32::Error` has added variant `MaxDerivationDepth`
+- `orchard::Action::from_parts` and `orchard::circuit::Instance::from_parts`
+  now return `Option<Self>`, yielding `None` when `rk` is the identity
+  `pallas::Point`. Callers that previously treated the return as `Self`
+  must now handle the `None` case. This aligns the crate with the
+  consensus rule introduced in zcashd v6.12.1 and Zebra 4.3.1 (see
+  <https://zodl.com/zcashd-zebra-april-2026-disclosure/> and
+  <https://zfnd.org/zebra-4-3-1-critical-security-fixes-dockerized-mining-and-ci-hardening/>);
+  the Zcash protocol specification will be updated to match.
+- `orchard::pczt::TxExtractorError` has added variant `IdentityRk`.
+- `orchard::pczt::ProverError` has added variant `IdentityRk`.
 
 ## [0.12.0] - 2025-12-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,12 +60,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,16 +265,15 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.30"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -343,25 +336,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
-name = "const-cstr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d0b5ff30645a68f35ece8cea4556ca14ef8a1651455f789a099a0513532a6"
 
 [[package]]
 name = "constant_time_eq"
@@ -371,9 +349,9 @@ checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -381,15 +359,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
-version = "0.22.3"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -400,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "core-graphics-types"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb142d41022986c1d8ff29103a1411c8a3dfad3552f87a4f8dc50d61d4f4e33"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -411,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "core-text"
-version = "19.2.0"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d74ada66e07c1cefa18f8abfba765b486f250de2e4a999e5727fc0dd4b4a25"
+checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
 dependencies = [
  "core-foundation",
  "core-graphics",
@@ -632,24 +610,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
+name = "dirs"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "cfg-if",
- "dirs-sys-next",
+ "dirs-sys",
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
+name = "dirs-sys"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -663,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "dwrote"
-version = "0.11.0"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b"
+checksum = "9e1b35532432acc8b19ceed096e35dfa088d3ea037fe4f3c085f1f97f33b4d02"
 dependencies = [
  "lazy_static",
  "libc",
@@ -687,7 +665,7 @@ checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -766,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "float-ord"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bad48618fdb549078c333a7a8528acb57af271d0433bdecd523eb620628364e"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "flume"
@@ -791,19 +769,19 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "font-kit"
-version = "0.11.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21fe28504d371085fae9ac7a3450f0b289ab71e07c8e57baa3fb68b9e57d6ce5"
+checksum = "2c7e611d49285d4c4b2e1727b72cf05353558885cc5252f93707b845dfcaf3d3"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "byteorder",
  "core-foundation",
  "core-graphics",
  "core-text",
- "dirs-next",
+ "dirs",
  "dwrote",
  "float-ord",
- "freetype",
+ "freetype-sys",
  "lazy_static",
  "libc",
  "log",
@@ -816,18 +794,30 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
+ "foreign-types-macros",
  "foreign-types-shared",
 ]
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
+name = "foreign-types-macros"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "fpe"
@@ -844,22 +834,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "freetype"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee38378a9e3db1cc693b4f88d166ae375338a0ff75cb8263e1c601d51f35dc6"
-dependencies = [
- "freetype-sys",
- "libc",
-]
-
-[[package]]
 name = "freetype-sys"
-version = "0.13.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37d4011c0cc628dfa766fcc195454f4b068d7afdc2adfd28861191d866e731a"
+checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
 dependencies = [
- "cmake",
+ "cc",
  "libc",
  "pkg-config",
 ]
@@ -914,7 +894,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1188,10 +1168,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1237,7 +1218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1245,6 +1226,15 @@ name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1434,6 +1424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orchard"
 version = "0.12.0"
 dependencies = [
@@ -1509,7 +1505,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "smallvec",
  "windows-targets",
 ]
@@ -1541,22 +1537,11 @@ dependencies = [
 
 [[package]]
 name = "pathfinder_simd"
-version = "0.5.1"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39fe46acc5503595e5949c17b818714d26fdf9b4920eacf3b2947f0199f4a6ff"
+checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
 dependencies = [
  "rustc_version",
-]
-
-[[package]]
-name = "pest"
-version = "2.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33"
-dependencies = [
- "memchr",
- "thiserror",
- "ucd-trie",
 ]
 
 [[package]]
@@ -1576,7 +1561,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1593,9 +1578,9 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "plotters"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "chrono",
  "font-kit",
@@ -1613,15 +1598,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-bitmap"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cebbe1f70205299abc69e8b295035bb52a6a70ee35474ad10011f0a4efb8543"
+checksum = "72ce181e3f6bf82d6c1dc569103ca7b1bd964c60ba03d7e6cdfbb3e3eb7f7405"
 dependencies = [
  "gif 0.12.0",
  "image",
@@ -1630,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
@@ -1680,7 +1665,7 @@ dependencies = [
  "smallvec",
  "symbolic-demangle",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.48",
 ]
 
 [[package]]
@@ -1708,14 +1693,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1757,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1845,17 +1830,8 @@ dependencies = [
  "pasta_curves",
  "rand_core",
  "serde",
- "thiserror",
+ "thiserror 1.0.48",
  "zeroize",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1869,13 +1845,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom",
- "redox_syscall 0.2.16",
- "thiserror",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1930,9 +1906,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -1947,8 +1923,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -1991,21 +1973,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2024,7 +1994,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2154,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.31"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2188,9 +2158,9 @@ checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2205,7 +2175,16 @@ version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.48",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2216,7 +2195,18 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2260,7 +2250,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2274,21 +2264,15 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.17.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375812fa44dab6df41c195cd2f7fecb488f6c09fbaafb62807488cefab642bff"
+checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "uint"
@@ -2344,7 +2328,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2374,34 +2358,22 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
-dependencies = [
- "bumpalo",
- "log",
  "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.31",
+ "rustversion",
+ "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2409,28 +2381,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
- "wasm-bindgen-backend",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2483,12 +2458,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2568,11 +2558,10 @@ dependencies = [
 
 [[package]]
 name = "yeslogic-fontconfig-sys"
-version = "3.2.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bbd69036d397ebbff671b1b8e4d918610c181c5a16073b96f984a38d08c386"
+checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
 dependencies = [
- "const-cstr",
  "dlib",
  "once_cell",
  "pkg-config",
@@ -2617,7 +2606,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/public/src/lib.rs
+++ b/public/src/lib.rs
@@ -176,7 +176,7 @@ pub mod primitives {
             #[doc(inline)]
             pub use __impl::primitives::redpallas::testing::{
                 arb_binding_signing_key, arb_binding_verification_key, arb_spendauth_signing_key,
-                arb_spendauth_verification_key,
+                arb_spendauth_verification_key, arb_valid_spendauth_keypair,
             };
         }
     }

--- a/src/action.rs
+++ b/src/action.rs
@@ -10,6 +10,10 @@ use crate::{
 ///
 /// This both creates a note (adding a commitment to the global ledger), and consumes
 /// some note created prior to this action (adding a nullifier to the global ledger).
+///
+/// # Invariants
+///
+/// Every `Action` has a non-identity `rk`.
 #[derive(Debug, Clone)]
 pub struct Action<A> {
     /// The nullifier of the note being spent.
@@ -28,6 +32,16 @@ pub struct Action<A> {
 
 impl<T> Action<T> {
     /// Constructs an `Action` from its constituent parts.
+    ///
+    /// Returns `None` if `rk` is the identity [`pasta_curves::pallas::Point`].
+    /// zcashd v6.12.1 and Zebra 4.3.1 both added a consensus rule rejecting
+    /// transactions whose Orchard actions have an identity `rk`; the Zcash
+    /// protocol specification will be updated to match, and this crate aligns
+    /// with that rule.
+    ///
+    /// See:
+    /// - <https://zodl.com/zcashd-zebra-april-2026-disclosure/>
+    /// - <https://zfnd.org/zebra-4-3-1-critical-security-fixes-dockerized-mining-and-ci-hardening/>
     pub fn from_parts(
         nf: Nullifier,
         rk: redpallas::VerificationKey<SpendAuth>,
@@ -35,15 +49,15 @@ impl<T> Action<T> {
         encrypted_note: TransmittedNoteCiphertext,
         cv_net: ValueCommitment,
         authorization: T,
-    ) -> Self {
-        Action {
+    ) -> Option<Self> {
+        (!rk.is_identity()).then_some(Action {
             nf,
             rk,
             cmx,
             encrypted_note,
             cv_net,
             authorization,
-        }
+        })
     }
 
     /// Returns the nullifier of the note being spent.
@@ -132,10 +146,7 @@ pub(crate) mod testing {
             commitment::ExtractedNoteCommitment, nullifier::testing::arb_nullifier,
             testing::arb_note, TransmittedNoteCiphertext,
         },
-        primitives::redpallas::{
-            self,
-            testing::{arb_spendauth_signing_key, arb_spendauth_verification_key},
-        },
+        primitives::redpallas::{self, testing::arb_valid_spendauth_keypair},
         value::{NoteValue, ValueCommitTrapdoor, ValueCommitment},
     };
 
@@ -145,7 +156,7 @@ pub(crate) mod testing {
         /// Generate an action without authorization data.
         pub fn arb_unauthorized_action(spend_value: NoteValue, output_value: NoteValue)(
             nf in arb_nullifier(),
-            rk in arb_spendauth_verification_key(),
+            (_, rk) in arb_valid_spendauth_keypair(),
             note in arb_note(output_value),
         ) -> Action<()> {
             let cmx = ExtractedNoteCommitment::from(note.commitment());
@@ -174,7 +185,7 @@ pub(crate) mod testing {
         /// Generate an action with invalid (random) authorization data.
         pub fn arb_action(spend_value: NoteValue, output_value: NoteValue)(
             nf in arb_nullifier(),
-            sk in arb_spendauth_signing_key(),
+            (rsk, rk) in arb_valid_spendauth_keypair(),
             note in arb_note(output_value),
             rng_seed in prop::array::uniform32(prop::num::u8::ANY),
             fake_sighash in prop::array::uniform32(prop::num::u8::ANY),
@@ -196,12 +207,97 @@ pub(crate) mod testing {
 
             Action {
                 nf,
-                rk: redpallas::VerificationKey::from(&sk),
+                rk,
                 cmx,
                 encrypted_note,
                 cv_net,
-                authorization: sk.sign(rng, &fake_sighash),
+                authorization: rsk.sign(rng, &fake_sighash),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use group::ff::{Field as _, PrimeField as _};
+    use pasta_curves::pallas;
+
+    use super::Action;
+    use crate::{
+        note::{ExtractedNoteCommitment, Nullifier, TransmittedNoteCiphertext},
+        primitives::redpallas::{self, SpendAuth},
+        value::{ValueCommitTrapdoor, ValueCommitment, ValueSum},
+    };
+
+    /// The canonical Pallas encoding of the identity is [0u8; 32]; plain
+    /// redpallas accepts it as a `VerificationKey<SpendAuth>`.
+    fn identity_rk() -> redpallas::VerificationKey<SpendAuth> {
+        redpallas::VerificationKey::<SpendAuth>::try_from([0u8; 32])
+            .expect("plain redpallas accepts the identity encoding")
+    }
+
+    /// The verification key derived from a signing key with scalar 1 is the
+    /// SpendAuthSig basepoint G, which is not the identity.
+    fn non_identity_rk() -> redpallas::VerificationKey<SpendAuth> {
+        let ask_bytes: [u8; 32] = pallas::Scalar::ONE.to_repr().into();
+        let ask =
+            redpallas::SigningKey::<SpendAuth>::try_from(ask_bytes).expect("1 is a valid scalar");
+        (&ask).into()
+    }
+
+    /// Arbitrary non-zero values for the non-`rk` fields of an `Action`.
+    /// Distinct non-zero patterns (rather than all-zeros) avoid accidental
+    /// overlap with sentinel values.
+    ///
+    /// `cv_net` (a Pallas point encoding per the Orchard Spend statement)
+    /// is checked at deserialization by `ValueCommitment::from_bytes`
+    /// (e.g. `src/pczt/parse.rs`). `epk_bytes` is stored as raw bytes by
+    /// this crate; its type in an Action description (§4.6, §5.4.5.5)
+    /// is KA^{Orchard}.Public = ℙ*, but the consensus-level type check
+    /// lives at the transaction deserializer in a consumer crate such
+    /// as `zcash_primitives`. Neither check runs in `Action::from_parts`,
+    /// so the `epk_bytes` here is just a byte pattern and need not decode
+    /// to a curve point for this test.
+    fn dummy_other_fields() -> (
+        Nullifier,
+        ExtractedNoteCommitment,
+        TransmittedNoteCiphertext,
+        ValueCommitment,
+    ) {
+        let nf = Nullifier::from_bytes(&[1u8; 32]).unwrap();
+        let cmx = ExtractedNoteCommitment::from_bytes(&[2u8; 32]).unwrap();
+        let encrypted_note = TransmittedNoteCiphertext {
+            epk_bytes: [3u8; 32],
+            enc_ciphertext: [4u8; 580],
+            out_ciphertext: [5u8; 80],
+        };
+        let cv_net = ValueCommitment::derive(ValueSum::from_raw(42), ValueCommitTrapdoor::zero());
+        (nf, cmx, encrypted_note, cv_net)
+    }
+
+    #[test]
+    fn is_identity_detects_identity() {
+        assert!(identity_rk().is_identity());
+    }
+
+    #[test]
+    fn is_identity_rejects_non_identity() {
+        assert!(!non_identity_rk().is_identity());
+    }
+
+    #[test]
+    fn from_parts_rejects_identity_rk() {
+        let (nf, cmx, encrypted_note, cv_net) = dummy_other_fields();
+        let result = Action::from_parts(nf, identity_rk(), cmx, encrypted_note, cv_net, ());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn from_parts_accepts_non_identity_rk() {
+        let (nf, cmx, encrypted_note, cv_net) = dummy_other_fields();
+        let rk = non_identity_rk();
+        let action = Action::from_parts(nf, rk.clone(), cmx, encrypted_note, cv_net, ())
+            .expect("non-identity rk must be accepted");
+        assert_eq!(action.rk, rk);
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -460,7 +460,8 @@ impl ActionInfo {
                     dummy_ask: self.spend.dummy_sk.as_ref().map(SpendAuthorizingKey::from),
                     parts: SigningParts { ak, alpha },
                 },
-            ),
+            )
+            .expect("α was generated randomly, so an identity rk is vanishingly unlikely"),
             Circuit::from_action_context_unchecked(self.spend, note, alpha, self.rcv),
         )
     }

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -39,15 +39,16 @@ impl<T> Action<T> {
     /// Prepares the public instance for this action, for creating and verifying the
     /// bundle proof.
     pub fn to_instance(&self, flags: Flags, anchor: Anchor) -> Instance {
-        Instance {
+        Instance::from_parts(
             anchor,
-            cv_net: self.cv_net().clone(),
-            nf_old: *self.nullifier(),
-            rk: self.rk().clone(),
-            cmx: *self.cmx(),
-            enable_spend: flags.spends_enabled,
-            enable_output: flags.outputs_enabled,
-        }
+            self.cv_net().clone(),
+            *self.nullifier(),
+            self.rk().clone(),
+            *self.cmx(),
+            flags.spends_enabled,
+            flags.outputs_enabled,
+        )
+        .expect("this Action's rk is non-identity by construction (Action::from_parts)")
     }
 }
 

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -802,13 +802,13 @@ impl ProvingKey {
 /// Every `Instance` has a non-identity `rk`.
 #[derive(Clone, Debug)]
 pub struct Instance {
-    pub(crate) anchor: Anchor,
-    pub(crate) cv_net: ValueCommitment,
-    pub(crate) nf_old: Nullifier,
-    pub(crate) rk: VerificationKey<SpendAuth>,
-    pub(crate) cmx: ExtractedNoteCommitment,
-    pub(crate) enable_spend: bool,
-    pub(crate) enable_output: bool,
+    anchor: Anchor,
+    cv_net: ValueCommitment,
+    nf_old: Nullifier,
+    rk: VerificationKey<SpendAuth>,
+    cmx: ExtractedNoteCommitment,
+    enable_spend: bool,
+    enable_output: bool,
 }
 
 impl Instance {
@@ -847,6 +847,41 @@ impl Instance {
             enable_spend,
             enable_output,
         })
+    }
+
+    /// Returns the Merkle tree anchor of this instance.
+    pub(crate) fn anchor(&self) -> &Anchor {
+        &self.anchor
+    }
+
+    /// Returns the commitment to the net value of this instance.
+    pub(crate) fn cv_net(&self) -> &ValueCommitment {
+        &self.cv_net
+    }
+
+    /// Returns the nullifier of the note being spent by this instance.
+    pub(crate) fn nf_old(&self) -> &Nullifier {
+        &self.nf_old
+    }
+
+    /// Returns the randomized verification key of this instance.
+    pub(crate) fn rk(&self) -> &VerificationKey<SpendAuth> {
+        &self.rk
+    }
+
+    /// Returns the commitment to the new note being created by this instance.
+    pub(crate) fn cmx(&self) -> &ExtractedNoteCommitment {
+        &self.cmx
+    }
+
+    /// Returns whether spends are enabled for this instance.
+    pub(crate) fn enable_spend(&self) -> bool {
+        self.enable_spend
+    }
+
+    /// Returns whether outputs are enabled for this instance.
+    pub(crate) fn enable_output(&self) -> bool {
+        self.enable_output
     }
 
     fn to_halo2_instance(&self) -> [[vesta::Scalar; 9]; 1] {
@@ -1076,16 +1111,15 @@ mod tests {
             instance: &Instance,
             proof: &Proof,
         ) -> std::io::Result<()> {
-            w.write_all(&instance.anchor.to_bytes())?;
-            w.write_all(&instance.cv_net.to_bytes())?;
-            w.write_all(&instance.nf_old.to_bytes())?;
-            w.write_all(&<[u8; 32]>::from(instance.rk.clone()))?;
-            w.write_all(&instance.cmx.to_bytes())?;
+            w.write_all(&instance.anchor().to_bytes())?;
+            w.write_all(&instance.cv_net().to_bytes())?;
+            w.write_all(&instance.nf_old().to_bytes())?;
+            w.write_all(&<[u8; 32]>::from(instance.rk()))?;
+            w.write_all(&instance.cmx().to_bytes())?;
             w.write_all(&[
-                u8::from(instance.enable_spend),
-                u8::from(instance.enable_output),
+                u8::from(instance.enable_spend()),
+                u8::from(instance.enable_output()),
             ])?;
-
             w.write_all(proof.as_ref())?;
             Ok(())
         }
@@ -1243,7 +1277,7 @@ mod tests {
             let instance =
                 Instance::from_parts(anchor, cv_net, nf_old, rk.clone(), cmx, true, true)
                     .expect("non-identity rk must be accepted");
-            assert_eq!(instance.rk, rk);
+            assert_eq!(instance.rk(), &rk);
         }
     }
 }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -796,6 +796,10 @@ impl ProvingKey {
 }
 
 /// Public inputs to the Orchard Action circuit.
+///
+/// # Invariants
+///
+/// Every `Instance` has a non-identity `rk`.
 #[derive(Clone, Debug)]
 pub struct Instance {
     pub(crate) anchor: Anchor,
@@ -814,6 +818,16 @@ impl Instance {
     /// pipelines for many proofs, where you don't want to pass around the full bundle.
     /// Use [`Bundle::verify_proof`] instead if you have the full bundle.
     ///
+    /// Returns `None` if `rk` is the identity [`pasta_curves::pallas::Point`].
+    /// zcashd v6.12.1 and Zebra 4.3.1 both added a consensus rule rejecting
+    /// transactions whose Orchard actions have an identity `rk`; the Zcash
+    /// protocol specification will be updated to match, and this crate
+    /// aligns with that rule.
+    ///
+    /// See:
+    /// - <https://zodl.com/zcashd-zebra-april-2026-disclosure/>
+    /// - <https://zfnd.org/zebra-4-3-1-critical-security-fixes-dockerized-mining-and-ci-hardening/>
+    ///
     /// [`Bundle::verify_proof`]: crate::Bundle::verify_proof
     pub fn from_parts(
         anchor: Anchor,
@@ -823,8 +837,8 @@ impl Instance {
         cmx: ExtractedNoteCommitment,
         enable_spend: bool,
         enable_output: bool,
-    ) -> Self {
-        Instance {
+    ) -> Option<Self> {
+        (!rk.is_identity()).then_some(Instance {
             anchor,
             cv_net,
             nf_old,
@@ -832,7 +846,7 @@ impl Instance {
             cmx,
             enable_spend,
             enable_output,
-        }
+        })
     }
 
     fn to_halo2_instance(&self) -> [[vesta::Scalar; 9]; 1] {
@@ -844,10 +858,10 @@ impl Instance {
         instance[NF_OLD] = self.nf_old.0;
 
         let rk = pallas::Point::from_bytes(&self.rk.clone().into())
-            .unwrap()
+            .expect("the cached byte encoding of a VerificationKey<_> is canonical")
             .to_affine()
             .coordinates()
-            .unwrap();
+            .expect("rk is non-identity by construction");
 
         instance[RK_X] = *rk.x();
         instance[RK_Y] = *rk.y();
@@ -1101,7 +1115,8 @@ mod tests {
             let enable_spend = read_bool(&mut r);
             let enable_output = read_bool(&mut r);
             let instance =
-                Instance::from_parts(anchor, cv_net, nf_old, rk, cmx, enable_spend, enable_output);
+                Instance::from_parts(anchor, cv_net, nf_old, rk, cmx, enable_spend, enable_output)
+                    .expect("test vectors were generated with non-identity rk");
 
             let mut proof_bytes = vec![];
             r.read_to_end(&mut proof_bytes)?;
@@ -1174,5 +1189,61 @@ mod tests {
             .view_height(0..(1 << 11))
             .render(K, &circuit, &root)
             .unwrap();
+    }
+
+    mod from_parts_rk_identity {
+        use ff::{Field as _, PrimeField as _};
+        use pasta_curves::pallas;
+
+        use super::super::Instance;
+        use crate::{
+            note::{ExtractedNoteCommitment, Nullifier},
+            primitives::redpallas::{self, SpendAuth},
+            tree::Anchor,
+            value::{ValueCommitTrapdoor, ValueCommitment, ValueSum},
+        };
+
+        /// Non-rk fields for `Instance`. Distinct non-zero patterns avoid
+        /// accidental overlap with sentinel values. See the analogous helper
+        /// in `src/action.rs` for notes on which of these fields have
+        /// consensus-level validity checks elsewhere in the pipeline.
+        fn dummy_other_fields() -> (Anchor, ValueCommitment, Nullifier, ExtractedNoteCommitment) {
+            let anchor = Anchor::from_bytes([6u8; 32]).unwrap();
+            let cv_net =
+                ValueCommitment::derive(ValueSum::from_raw(42), ValueCommitTrapdoor::zero());
+            let nf_old = Nullifier::from_bytes(&[1u8; 32]).unwrap();
+            let cmx = ExtractedNoteCommitment::from_bytes(&[2u8; 32]).unwrap();
+            (anchor, cv_net, nf_old, cmx)
+        }
+
+        fn identity_rk() -> redpallas::VerificationKey<SpendAuth> {
+            redpallas::VerificationKey::<SpendAuth>::try_from([0u8; 32])
+                .expect("plain redpallas accepts the identity encoding")
+        }
+
+        fn non_identity_rk() -> redpallas::VerificationKey<SpendAuth> {
+            let ask_bytes: [u8; 32] = pallas::Scalar::ONE.to_repr().into();
+            let ask = redpallas::SigningKey::<SpendAuth>::try_from(ask_bytes)
+                .expect("1 is a valid scalar");
+            (&ask).into()
+        }
+
+        #[test]
+        fn rejects_identity_rk() {
+            let (anchor, cv_net, nf_old, cmx) = dummy_other_fields();
+            let result =
+                Instance::from_parts(anchor, cv_net, nf_old, identity_rk(), cmx, true, true);
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn accepts_non_identity_rk() {
+            let (anchor, cv_net, nf_old, cmx) = dummy_other_fields();
+            let rk = non_identity_rk();
+            let instance =
+                Instance::from_parts(anchor, cv_net, nf_old, rk.clone(), cmx, true, true)
+                    .expect("non-identity rk must be accepted");
+            assert_eq!(instance.rk, rk);
+        }
     }
 }

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -487,7 +487,7 @@ mod tests {
             let action = Action::from_parts(
                 // nf_old is the nullifier revealed by the receiving Action.
                 nf_old,
-                // We don't need a valid rk for this test.
+                // We don't need a real rk for this test.
                 redpallas::VerificationKey::dummy(),
                 cmx,
                 TransmittedNoteCiphertext {
@@ -497,7 +497,8 @@ mod tests {
                 },
                 cv_net.clone(),
                 (),
-            );
+            )
+            .expect("a key returned by VerificationKey::dummy() is vanishingly unlikely to be the identity");
 
             //
             // Test decryption

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -344,11 +344,38 @@ mod tests {
         constants::MERKLE_DEPTH_ORCHARD,
         keys::{FullViewingKey, Scope, SpendAuthorizingKey, SpendingKey},
         note::{ExtractedNoteCommitment, RandomSeed, Rho},
-        pczt::Zip32Derivation,
+        pczt::{ProverError, TxExtractorError, Zip32Derivation},
+        primitives::redpallas::{self, SpendAuth},
         tree::{MerkleHashOrchard, EMPTY_ROOTS},
         value::NoteValue,
         Note,
     };
+
+    /// Builds a minimal shielding-style pczt bundle, finalizes IO, and returns
+    /// it ready for `create_proof`. Used by identity-`rk` tests below.
+    fn minimal_finalized_pczt_bundle(mut rng: OsRng) -> super::Bundle {
+        let sk = SpendingKey::random(&mut rng);
+        let fvk = FullViewingKey::from(&sk);
+        let recipient = fvk.address_at(0u32, Scope::External);
+
+        let mut builder = Builder::new(
+            BundleType::DEFAULT,
+            EMPTY_ROOTS[MERKLE_DEPTH_ORCHARD].into(),
+        );
+        builder
+            .add_output(None, recipient, NoteValue::from_raw(5000), [0u8; 512])
+            .unwrap();
+        let mut pczt_bundle = builder.build_for_pczt(&mut rng).unwrap().0;
+
+        let sighash = [0; 32];
+        pczt_bundle.finalize_io(sighash, rng).unwrap();
+        pczt_bundle
+    }
+
+    fn identity_rk() -> redpallas::VerificationKey<SpendAuth> {
+        redpallas::VerificationKey::<SpendAuth>::try_from([0u8; 32])
+            .expect("plain redpallas accepts the identity encoding")
+    }
 
     #[test]
     fn shielding_bundle() {
@@ -493,5 +520,38 @@ mod tests {
         assert_eq!(bundle.value_balance(), &0);
         // We can successfully bind the bundle.
         bundle.apply_binding_signature(sighash, rng).unwrap();
+    }
+
+    #[test]
+    fn create_proof_rejects_identity_rk() {
+        let pk = ProvingKey::build();
+        let rng = OsRng;
+
+        let mut pczt_bundle = minimal_finalized_pczt_bundle(rng);
+        pczt_bundle.actions_mut()[0].spend.rk = identity_rk();
+
+        assert!(matches!(
+            pczt_bundle.create_proof(&pk, rng),
+            Err(ProverError::IdentityRk),
+        ));
+    }
+
+    #[test]
+    fn extract_rejects_identity_rk() {
+        let pk = ProvingKey::build();
+        let rng = OsRng;
+
+        let mut pczt_bundle = minimal_finalized_pczt_bundle(rng);
+        pczt_bundle.create_proof(&pk, rng).unwrap();
+
+        // Inject identity rk after a valid proof has been produced. Extract
+        // should reject at the `Action::from_parts` step, before any proof or
+        // signature check.
+        pczt_bundle.actions_mut()[0].spend.rk = identity_rk();
+
+        assert!(matches!(
+            pczt_bundle.extract::<i64>(),
+            Err(TxExtractorError::IdentityRk),
+        ));
     }
 }

--- a/src/pczt/prover.rs
+++ b/src/pczt/prover.rs
@@ -96,8 +96,9 @@ impl super::Bundle {
                     self.flags.spends_enabled(),
                     self.flags.outputs_enabled(),
                 )
+                .ok_or(ProverError::IdentityRk)
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, ProverError>>()?;
 
         let proof =
             Proof::create(pk, &circuits, &instances, rng).map_err(ProverError::ProofFailed)?;
@@ -136,6 +137,9 @@ pub enum ProverError {
     ProofFailed(plonk::Error),
     /// The `rho` of the `output_note` is not equal to the nullifier of the spent note.
     RhoMismatch,
+    /// An action has an identity `rk`, which is forbidden by the consensus
+    /// rule introduced in zcashd v6.12.1 and Zebra 4.3.1.
+    IdentityRk,
     /// The provided `fvk` does not own the spent note.
     WrongFvkForNote,
 }
@@ -168,6 +172,9 @@ impl fmt::Display for ProverError {
             ProverError::ProofFailed(e) => write!(f, "Failed to create proof: {e}"),
             ProverError::RhoMismatch => {
                 write!(f, "output's `rho` does not match spent note's nullifier")
+            }
+            ProverError::IdentityRk => {
+                write!(f, "an Orchard action with identity `rk` is not valid")
             }
             ProverError::WrongFvkForNote => write!(f, "`fvk` does not own the action's spent note"),
         }

--- a/src/pczt/tx_extractor.rs
+++ b/src/pczt/tx_extractor.rs
@@ -72,14 +72,15 @@ impl super::Bundle {
             .map(|action| {
                 let authorization = action_auth(action)?;
 
-                Ok(crate::Action::from_parts(
+                crate::Action::from_parts(
                     action.spend.nullifier,
                     action.spend.rk.clone(),
                     action.output.cmx,
                     action.output.encrypted_note.clone(),
                     action.cv_net.clone(),
                     authorization,
-                ))
+                )
+                .ok_or_else(|| TxExtractorError::IdentityRk.into())
             })
             .collect::<Result<_, E>>()?;
 
@@ -116,6 +117,9 @@ pub enum TxExtractorError {
     MissingSpendAuthSig,
     /// The value sum does not fit into a `valueBalance`.
     ValueSumOutOfRange,
+    /// An action has an identity `rk`, which is forbidden by the consensus
+    /// rule introduced in zcashd v6.12.1 and Zebra 4.3.1.
+    IdentityRk,
 }
 
 impl fmt::Display for TxExtractorError {
@@ -134,6 +138,9 @@ impl fmt::Display for TxExtractorError {
             ),
             TxExtractorError::ValueSumOutOfRange => {
                 write!(f, "value sum does not fit into a `valueBalance`")
+            }
+            TxExtractorError::IdentityRk => {
+                write!(f, "an Orchard action with identity `rk` is not valid")
             }
         }
     }

--- a/src/primitives/redpallas.rs
+++ b/src/primitives/redpallas.rs
@@ -154,6 +154,14 @@ impl<T: SigType> VerificationKey<T> {
     pub fn verify(&self, msg: &[u8], signature: &Signature<T>) -> Result<(), reddsa::Error> {
         self.0.verify(msg, &signature.0)
     }
+
+    /// Returns `true` if this verification key is the identity
+    /// [`pasta_curves::pallas::Point`], which is invalid as `rk`.
+    pub fn is_identity(&self) -> bool {
+        // The only encoding of the identity is `[0u8; 32]`, and
+        // `reddsa::VerificationKey<T>` caches the byte encoding.
+        <[u8; 32]>::from(self) == [0u8; 32]
+    }
 }
 
 /// A RedPallas signature.
@@ -223,6 +231,20 @@ pub mod testing {
         /// Generate a uniformly distributed RedDSA binding verification key.
         pub fn arb_binding_verification_key()(sk in arb_binding_signing_key()) -> VerificationKey<Binding> {
             VerificationKey::from(&sk)
+        }
+    }
+
+    prop_compose! {
+        /// Generate a uniformly distributed valid RedDSA spend authorization key pair
+        /// (rsk, rk), with nonidentity rk and nonzero rsk.
+        pub fn arb_valid_spendauth_keypair()(
+            rsk_and_rk in arb_spendauth_signing_key()
+                .prop_filter_map("rk must not be the identity", |sk| {
+                    let vk = VerificationKey::from(&sk);
+                    (!vk.is_identity()).then_some((sk, vk))
+                }),
+        ) -> (SigningKey<SpendAuth>, VerificationKey<SpendAuth>) {
+            rsk_and_rk
         }
     }
 }


### PR DESCRIPTION
## Summary

zcashd v6.12.1 and Zebra 4.3.1 both added a consensus rule rejecting transactions whose Orchard actions have an identity `rk`; the Zcash protocol specification will be updated to match. This PR aligns the `orchard` crate with that rule.

It is an alternative to #487. The approach taken in #487 attempted to exclude the identity point $\mathcal{O}_{\mathbb{P}}$ from `primitives::redpallas::VerificationKey<SpendAuth>`, but currently has a soundness gap that would require more disruptive changes in order to fix.

References for the disclosed vulnerability and the consensus-rule addition:

- <https://zodl.com/zcashd-zebra-april-2026-disclosure/>
- <https://zfnd.org/zebra-4-3-1-critical-security-fixes-dockerized-mining-and-ci-hardening/>

## Design

Enforcement lives at the `Action` and `Instance` constructors rather than at the `primitives::redpallas` or `reddsa` layer, because RedDSA (and by extension RedPallas) does not forbid the identity as a public key. Forbidding identity `rk` is an Orchard-specific consensus concern, not a signature-scheme concern, so the narrowed Orchard types are the right enforcement point.

## Changes

Commit 1 — consensus fix:
- `Action::from_parts` and `Instance::from_parts` now return `Option<Self>`, yielding `None` when `rk` is the identity.
- These checks use a new `pub fn is_identity` method on `VerificationKey<T>`, implemented by comparing the cached byte encoding to `[0u8; 32]`. `reddsa::VerificationKey<T>` caches the byte encoding, so the check is O(1).
- Both `Action` and `Instance` carry a `# Invariants` section documenting that `rk` is non-identity by construction.
- Callers updated:
  - `builder.rs` and the `note_encryption` test use `.expect(...)` — the randomizer $\alpha$ is generated from crypto-quality randomness, so a zero-scalar result is vanishingly unlikely.
  - `pczt/tx_extractor.rs` adds `TxExtractorError::IdentityRk` and propagates on identity `rk` in parsed PCZT actions.
  - `pczt/prover.rs` adds `ProverError::IdentityRk` and propagates on identity `rk` in the actions being proven.
  - The `circuit.rs` test-vector helper uses `.expect(...)` — the serialized test vectors were generated with non-identity `rk`.
  - `Instance::to_halo2_instance`'s `.unwrap()`s on `pallas::Point::from_bytes` and `.coordinates()` become `.expect(...)` with invariant-specific messages.
- Added a new `arb_valid_spendauth_keypair` proptest generator that produces uniformly-distributed valid `(rsk, rk)` pairs with non-identity `rk`, and updated the existing `arb_unauthorized_action` and `arb_action` helpers to use it. This is more clarifying than strictly necessary: it is consistent with enforcing non-identity `rk` as invariants of `Action` and `Instance` rather than of `VerificationKey<SpendAuth>`.
- Unit tests for `VerificationKey<SpendAuth>::is_identity`, for both `Action::from_parts` outcomes, and for both `Instance::from_parts` outcomes.

Commit 2 — tighten `Instance` field visibility:
- Fields are now fully private, with `pub(crate)` accessor methods matching the pattern already in use on `Action`, preventing in-crate code from bypassing `Instance::from_parts` and accidentally violating the invariant.
- `Action::to_instance` now routes through `Instance::from_parts`, with an `.expect(...)` justified by the Action-side invariant.

Commit 3 — PCZT `IdentityRk` test coverage:
- Two tests in `src/pczt.rs` exercise the error wiring on the pczt boundary: `create_proof` returns `ProverError::IdentityRk` when an action has an identity `rk`, and `extract` returns `TxExtractorError::IdentityRk` in the same situation. Both inject identity `rk` via `pczt::Bundle::actions_mut()` after the bundle has reached a valid state, then invoke the method under test.

## Unchanged

- No breaking changes to `primitives::redpallas` module; no need for changes to the `reddsa` crate.
- The `epk_bytes` field in `TransmittedNoteCiphertext` is not checked here; its type in an Action description (§4.6, §5.4.5.5) is `KA^{Orchard}.Public = ℙ*`, but the consensus-level type check lives at the transaction deserializer in a consumer crate such as `zcash_primitives`.

🤖 Filed with [Claude Code](https://claude.com/claude-code).
