### PR TITLE
Release orchard v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,36 +7,13 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
-### Added
-- `orchard::value::NoteValue::ZERO`, a `const NoteValue` equal to zero.
-
-### Changed
-- The following APIs have changed or been made available behind the
-  `unstable-voting-circuits` feature flag, and are not covered by the
-  crate's semver stability guarantees and may change in any future
-  release:
-  - `orchard::constants::OrchardFixedBases` has been reorganized to wrap
-    two new fixed-base enums, each adding `SpendAuthG` as a supported
-    generator alongside the existing `NullifierK` / `ValueCommitV`
-    generators. Existing `From<NullifierK>` and `From<ValueCommitV>`
-    conversions to `OrchardFixedBases` are preserved.
-  - `orchard::constants::OrchardBaseFieldBases`: fixed bases for scalar
-    multiplication by a base-field scalar.
-  - `orchard::constants::OrchardShortScalarBases`: fixed bases for scalar
-    multiplication by a short signed scalar.
-
-## [0.13.0] - 2026-04-22
+## [0.13.1] - 2026-04-27
 
 ### Added
-- `orchard::primitives::redpallas::VerificationKey<T>::is_identity`, which
-  returns `true` if the verification key is the identity `pallas::Point`.
-- `orchard::primitives::redpallas::testing::arb_valid_spendauth_keypair`
-  (under the `test-dependencies` feature): a uniformly-distributed valid
-  `(rsk, rk)` key pair with non-identity `rk`.
 - `orchard::{L_ORCHARD_BASE, L_ORCHARD_SCALAR, L_VALUE}`, the bit-length
   parameters of the Orchard base field, scalar field, and value encoding
   as defined in the Zcash protocol specification.
-- `orchard::value::NoteValue::zero`, equivalent to `NoteValue::from_raw(0)`.
+- `orchard::value::NoteValue::ZERO`, a `const NoteValue` equal to zero.
 - The following modules and APIs are available behind the
   `unstable-voting-circuits` feature flag to support downstream
   voting-circuit development. These temporary APIs are not covered by the
@@ -52,6 +29,16 @@ and this project adheres to Rust's notion of
     `AddChip::{configure, construct}`,
     `CommitIvkChip::{configure, construct}`,
     `NoteCommitChip::{configure, construct}`.
+  - Fixed bases: `orchard::constants::OrchardFixedBases` has three
+    variants: `Full(OrchardFixedBasesFull)` for full-width scalar
+    multiplication, `Base(OrchardBaseFieldBases)` for base-field
+    scalars, and `Short(OrchardShortScalarBases)` for short signed
+    scalars. `OrchardBaseFieldBases` covers `NullifierK` and
+    `SpendAuthGBase`; `OrchardShortScalarBases` covers `ValueCommitV`
+    and `SpendAuthGShort`. `From<NullifierK>`, `From<ValueCommitV>`,
+    `From<OrchardFixedBasesFull>`, `From<OrchardBaseFieldBases>`, and
+    `From<OrchardShortScalarBases>` conversions to `OrchardFixedBases`
+    are provided.
   - Key, note, tree, and value APIs: `SpendingKey::random`,
     `SpendAuthorizingKey::derive_inner`, `NullifierDerivingKey` and
     `CommitIvkRandomness` and their `inner` methods,
@@ -63,6 +50,15 @@ and this project adheres to Rust's notion of
     `ExtractedNoteCommitment::inner`, `Nullifier::{from_inner, inner}`,
     `NonIdentityPallasPoint` and `NonIdentityPallasPoint::from_bytes`,
     `MerklePath::dummy`, and `MerkleHashOrchard::inner`.
+
+## [0.13.0] - 2026-04-22
+
+### Added
+- `orchard::primitives::redpallas::VerificationKey<T>::is_identity`, which
+  returns `true` if the verification key is the identity `pallas::Point`.
+- `orchard::primitives::redpallas::testing::arb_valid_spendauth_keypair`
+  (under the `test-dependencies` feature): a uniformly-distributed valid
+  `(rsk, rk)` key pair with non-identity `rk`.
 
 ### Changed
 - MSRV is now 1.85.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,14 +40,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "72832d73be48bac96a5d7944568f305d829ed55b0ce3b483647089dfaf6cf704"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -199,9 +200,9 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -1431,7 +1432,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aes",
  "bitvec",
@@ -1880,9 +1881,9 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rgb"
-version = "0.8.36"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ec2d3e3fc7a92ced357df9cebd5a10b6fb2aa1ee797bf7e9ce2f17dffc8f59"
+checksum = "0f86ae463694029097b846d8f99fd5536740602ae00022c0c50c5600720b2f71"
 dependencies = [
  "bytemuck",
 ]
@@ -1999,9 +2000,9 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3b5185835de4fb8cd2c6bcee1147a8d7eff15dd01810cda30cbd5cd0462fd6"
+checksum = "637e95dcd06bc1bb3f86ed9db1e1832a70125f32daae071ef37dcb7701b7d4fe"
 dependencies = [
  "bitflags 2.4.0",
  "either",
@@ -2576,6 +2577,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded3f58b93486aa79b85acba1001f5298f27a46489859934954d262533ee2915"
 dependencies = [
  "blake2b_simd",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchard"
-version = "0.13.0"
+version = "0.13.1"
 authors = [
     "Sean Bowe <ewillbefull@gmail.com>",
     "Jack Grigg <thestr4d@gmail.com>",


### PR DESCRIPTION
Patch release. Promotes the post-0.13.0 entries in `CHANGELOG.md` (the `NoteValue::ZERO` const, the `unstable-voting-circuits` `SpendAuthG` fixed-base additions, and the related visibility widenings) into a new `0.13.1` section. All changes are backwards-compatible. The `unstable-voting-circuits` APIs are explicitly outside the crate's semver guarantees.