### PR TITLE
Name AddChip polynomial constraint

### DIFF
--- a/src/circuit/gadget/add_chip.rs
+++ b/src/circuit/gadget/add_chip.rs
@@ -53,7 +53,7 @@ impl AddChip {
             let b = meta.query_advice(b, Rotation::cur());
             let c = meta.query_advice(c, Rotation::cur());
 
-            Constraints::with_selector(q_add, Some(a + b - c))
+            Constraints::with_selector(q_add, Some(("c = a + b", a + b - c)))
         });
 
         AddConfig { a, b, c, q_add }


### PR DESCRIPTION
Closes #125

This names the remaining anonymous polynomial constraint in `AddChip`. The polynomial is unchanged, this just makes Halo 2's circuit metadata/debug output include the same check name as the rest of the Orchard circuit constraints

Checks:
- `cargo fmt -- --check`
- `cargo test -q --no-default-features`
- `cargo test -q`
- `cargo test --all-features`
- `cargo clippy -- -D warnings`
- `cargo clippy --all-features -- -D warnings`
- `cargo doc --all-features --document-private-items`
- `cargo build --benches`
