### PR TITLE
Return an error from BatchValidator::add_bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- `orchard::bundle::BatchValidatorError`
+
+### Changed
+- `orchard::bundle::BatchValidator::add_bundle` now returns
+  `Result<(), BatchValidatorError>` instead of panicking if an action's `rk` is
+  the identity.
+
 ## [0.14.0] - 2026-06-02
 
 ### Added

--- a/src/action.rs
+++ b/src/action.rs
@@ -206,6 +206,20 @@ pub(crate) mod testing {
 
     use super::Action;
 
+    pub(crate) fn clone_with_rk_for_test<T: Clone>(
+        action: &Action<T>,
+        rk: redpallas::VerificationKey<SpendAuth>,
+    ) -> Action<T> {
+        Action {
+            nf: action.nf,
+            rk,
+            cmx: action.cmx,
+            encrypted_note: action.encrypted_note.clone(),
+            cv_net: action.cv_net.clone(),
+            authorization: action.authorization.clone(),
+        }
+    }
+
     /// Builds a real, decryptable `TransmittedNoteCiphertext` for `note`,
     /// mirroring `OutputInfo::build`: the same encryptor yields a non-identity
     /// ephemeral public key (satisfying the `Action::from_parts` epk invariant)

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -7,7 +7,7 @@ pub mod commitments;
 #[cfg(feature = "circuit")]
 mod batch;
 #[cfg(feature = "circuit")]
-pub use batch::BatchValidator;
+pub use batch::{BatchValidator, BatchValidatorError};
 
 use core::fmt;
 
@@ -38,7 +38,7 @@ use crate::circuit::{Instance, VerifyingKey};
 impl<T> Action<T> {
     /// Prepares the public instance for this action, for creating and verifying the
     /// bundle proof.
-    pub fn to_instance(&self, flags: Flags, anchor: Anchor) -> Instance {
+    pub(crate) fn try_to_instance(&self, flags: Flags, anchor: Anchor) -> Option<Instance> {
         Instance::from_parts(
             anchor,
             self.cv_net().clone(),
@@ -48,7 +48,13 @@ impl<T> Action<T> {
             flags.spends_enabled,
             flags.outputs_enabled,
         )
-        .expect("this Action's rk is non-identity by construction (Action::from_parts)")
+    }
+
+    /// Prepares the public instance for this action, for creating and verifying the
+    /// bundle proof.
+    pub fn to_instance(&self, flags: Flags, anchor: Anchor) -> Instance {
+        self.try_to_instance(flags, anchor)
+            .expect("this Action's rk is non-identity by construction (Action::from_parts)")
     }
 }
 
@@ -320,11 +326,17 @@ impl<T: Authorization, V> Bundle<T, V> {
     }
 
     #[cfg(feature = "circuit")]
-    pub(crate) fn to_instances(&self) -> Vec<Instance> {
+    pub(crate) fn try_to_instances(&self) -> Option<Vec<Instance>> {
         self.actions
             .iter()
-            .map(|a| a.to_instance(self.flags, self.anchor))
+            .map(|a| a.try_to_instance(self.flags, self.anchor))
             .collect()
+    }
+
+    #[cfg(feature = "circuit")]
+    pub(crate) fn to_instances(&self) -> Vec<Instance> {
+        self.try_to_instances()
+            .expect("this Bundle's actions are non-identity by construction")
     }
 
     /// Performs trial decryption of each action in the bundle with each of the

--- a/src/bundle/batch.rs
+++ b/src/bundle/batch.rs
@@ -1,5 +1,7 @@
 use alloc::vec::Vec;
 
+use core::fmt;
+
 use halo2_proofs::plonk;
 use pasta_curves::vesta;
 use rand::{CryptoRng, RngCore};
@@ -27,6 +29,27 @@ pub struct BatchValidator {
     signatures: Vec<BundleSignature>,
 }
 
+/// Errors that can occur when adding a bundle to a [`BatchValidator`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BatchValidatorError {
+    /// An action has an identity `rk`, which is forbidden by the consensus rule
+    /// introduced in zcashd v6.12.1 and Zebra 4.3.1.
+    IdentityRk,
+}
+
+impl fmt::Display for BatchValidatorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BatchValidatorError::IdentityRk => {
+                write!(f, "an Orchard action with identity `rk` is not valid")
+            }
+        }
+    }
+}
+
+impl core::error::Error for BatchValidatorError {}
+
 impl BatchValidator {
     /// Constructs a new batch validation context.
     pub fn new() -> Self {
@@ -37,11 +60,18 @@ impl BatchValidator {
     }
 
     /// Adds the proof and RedPallas signatures from the given bundle to the validator.
+    ///
+    /// Returns [`BatchValidatorError::IdentityRk`] without modifying the validator if
+    /// any action in the bundle has an identity `rk`.
     pub fn add_bundle<V: Copy + Into<i64>>(
         &mut self,
         bundle: &Bundle<Authorized, V>,
         sighash: [u8; 32],
-    ) {
+    ) -> Result<(), BatchValidatorError> {
+        let instances = bundle
+            .try_to_instances()
+            .ok_or(BatchValidatorError::IdentityRk)?;
+
         for action in bundle.actions().iter() {
             self.signatures.push(BundleSignature {
                 signature: action
@@ -59,7 +89,9 @@ impl BatchValidator {
         bundle
             .authorization()
             .proof()
-            .add_to_batch(&mut self.proofs, bundle.to_instances());
+            .add_to_batch(&mut self.proofs, instances);
+
+        Ok(())
     }
 
     /// Batch-validates the accumulated bundles.
@@ -90,6 +122,72 @@ impl BatchValidator {
                 debug!("RedPallas batch validation failed: {}", e);
                 false
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use nonempty::NonEmpty;
+    use proptest::prelude::*;
+
+    use super::{BatchValidator, BatchValidatorError};
+    use crate::{
+        action::testing::clone_with_rk_for_test,
+        bundle::{Authorized, Bundle, ProofSizeEnforcement},
+        primitives::redpallas::{self, SpendAuth},
+    };
+
+    fn identity_rk() -> redpallas::VerificationKey<SpendAuth> {
+        redpallas::VerificationKey::<SpendAuth>::try_from([0u8; 32])
+            .expect("plain redpallas accepts the identity encoding")
+    }
+
+    proptest! {
+        // The property is deterministic given the bundle.
+        #![proptest_config(ProptestConfig::with_cases(16))]
+
+        #[test]
+        fn add_bundle_accepts_valid_bundle(
+            bundle in crate::bundle::testing::arb_bundle(2),
+            sighash in prop::array::uniform32(prop::num::u8::ANY),
+        ) {
+            let bundle = bundle
+                .try_map_value_balance(|_| Ok::<i64, ()>(0))
+                .expect("mapping to i64 cannot fail");
+            let mut validator = BatchValidator::new();
+            prop_assert_eq!(validator.add_bundle(&bundle, sighash), Ok(()));
+        }
+
+        #[test]
+        fn add_bundle_rejects_identity_rk(
+            bundle in crate::bundle::testing::arb_bundle(1),
+            sighash in prop::array::uniform32(prop::num::u8::ANY),
+        ) {
+            let bundle = bundle
+                .try_map_value_balance(|_| Ok::<i64, ()>(0))
+                .expect("mapping to i64 cannot fail");
+            let action = clone_with_rk_for_test(bundle.actions().first(), identity_rk());
+            let invalid_bundle = Bundle::try_from_parts(
+                NonEmpty::from_vec(vec![action]).expect("one action"),
+                *bundle.flags(),
+                *bundle.value_balance(),
+                *bundle.anchor(),
+                Authorized::from_parts(
+                    bundle.authorization().proof().clone(),
+                    bundle.authorization().binding_signature().clone(),
+                ),
+                ProofSizeEnforcement::Strict,
+            )
+            .expect("proof size is unchanged");
+
+            let mut validator = BatchValidator::new();
+            prop_assert_eq!(
+                validator.add_bundle(&invalid_bundle, sighash),
+                Err(BatchValidatorError::IdentityRk)
+            );
         }
     }
 }


### PR DESCRIPTION
Fixes #497

`BatchValidator::add_bundle` now returns `Result<(), BatchValidatorError>` and turns the identity-`rk` path into an error instead of relying on `to_instances()` to panic

The method builds bundle instances before queueing signatures or proofs, so the validator stays unchanged if an identity `rk` is found

I also added coverage for a valid bundle and an injected identity-`rk` bundle

checks:
- `cargo fmt -- --check`
- `cargo test --verbose`
- `cargo test --all-features --lib`
- `cargo clippy --all-targets -- -D warnings`
- `cargo doc --all-features --document-private-items --no-deps`
- `cargo package --allow-dirty`