### PR TITLE
Add in v6 and Ironwood TX-id / Auth-ID code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,14 +199,12 @@ the current behavior by selecting `BundlePoolRestrictions::OrchardNu6_2Only` (an
     action count.
 - `orchard::pczt::Bundle::create_proof` now builds the Action circuits for
   the provided `ProvingKey`'s circuit version (previously always
-  `FixedPostNu6_2`), and checks the cross-address restriction's
-  same-expanded-receiver property, returning
-  `ProverError::DisallowedCrossAddressTransfer` (or
+  `FixedPostNu6_2`), and checks the cross-address restriction's same-expanded-receiver
+  property, returning `ProverError::DisallowedCrossAddressTransfer` (or
   `ProverError::MissingRecipient` if a `recipient` field is unset).
 - `orchard::pczt::{Spend, Output}::parse` now take the note plaintext version
   for the parsed spend or output, and `orchard::pczt::Bundle::parse` rejects
-  actions whose spend or output note version does not match the
-  `BundlePoolRestrictions`.
+  actions whose spend or output note version does not match the `BundlePoolRestrictions`.
 - `orchard::note_encryption::{OrchardNoteEncryption, IronwoodNoteEncryption}`
   documentation now clarifies that encryption uses the note's own
   `NoteVersion`; the aliases differ in which note plaintext versions they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ the current behavior by selecting `BundlePoolRestrictions::OrchardNu6_2Only` (an
   Variants: `OrchardPreNu6_2`, `OrchardNu6_2Only`, `OrchardNu6_3Onward`, and
   `IronwoodNu6_3Onward` (which shares the post-NU6.3 circuit and uses V3 note
   plaintexts).
+- `orchard::bundle::TxVersion`, the transaction version (`V5` or `V6`) a bundle's
+  commitments are computed for. At NU6.3 an Orchard bundle may be encoded in a v5
+  or a v6 transaction; the two use different commitment personalizations and place
+  the anchor in different digests (v5 in the transaction-ID effects, v6 in the
+  authorizing data). It is passed to `Bundle::commitment`,
+  `Bundle::authorizing_commitment`, and the `hash_bundle_*_empty` helpers.
 - `orchard::note::NoteVersion`, the note plaintext version selector used by
   low-level note constructors and accessors. `NoteVersion::V2` is the ZIP 212
   Orchard note plaintext format, and `NoteVersion::V3` is the quantum-recoverable
@@ -193,12 +199,14 @@ the current behavior by selecting `BundlePoolRestrictions::OrchardNu6_2Only` (an
     action count.
 - `orchard::pczt::Bundle::create_proof` now builds the Action circuits for
   the provided `ProvingKey`'s circuit version (previously always
-  `FixedPostNu6_2`), and checks the cross-address restriction's same-expanded-receiver
-  property, returning `ProverError::DisallowedCrossAddressTransfer` (or
+  `FixedPostNu6_2`), and checks the cross-address restriction's
+  same-expanded-receiver property, returning
+  `ProverError::DisallowedCrossAddressTransfer` (or
   `ProverError::MissingRecipient` if a `recipient` field is unset).
 - `orchard::pczt::{Spend, Output}::parse` now take the note plaintext version
   for the parsed spend or output, and `orchard::pczt::Bundle::parse` rejects
-  actions whose output note version does not match the `BundlePoolRestrictions`.
+  actions whose spend or output note version does not match the
+  `BundlePoolRestrictions`.
 - `orchard::note_encryption::{OrchardNoteEncryption, IronwoodNoteEncryption}`
   documentation now clarifies that encryption uses the note's own
   `NoteVersion`; the aliases differ in which note plaintext versions they
@@ -213,23 +221,29 @@ the current behavior by selecting `BundlePoolRestrictions::OrchardNu6_2Only` (an
     note version through their re-exported path.
   - `orchard::bundle::testing::{arb_action_n, arb_unauthorized_action_n}` now
     take a note version.
-  - `orchard::bundle::testing::{arb_bundle, arb_unauthorized_bundle}` now
-    generate a bundle pool restriction internally to select the note version.
+  - `orchard::bundle::testing::{arb_bundle, arb_unauthorized_bundle}` no longer
+    take bundle pool restrictions, and instead select them internally.
 - `orchard::pczt::Bundle::finalize_io` verifies the cross-address restriction
   before modifying the bundle, returning
   `IoFinalizerError::CrossAddressRestriction` (wrapping the underlying
   `VerifyError`) and leaving the bundle unmodified if the PCZT is missing
   recipient data or violates the restriction.
-- `orchard::Bundle::commitment` now takes the `BundlePoolRestrictions` the bundle
-  follows, and hashes that era's flag byte (via `Flags::to_byte`). The ZIP-244
-  Orchard digest — and therefore the transaction ID and sighash — now depends on
-  the `BundlePoolRestrictions`: under `IronwoodNu6_3Onward` an unrestricted bundle's
-  flag byte sets bit 2. Callers computing transaction IDs or sighashes (e.g.
-  `zcash_primitives`, or the `pczt` crate via `Flags::to_byte`) must pass the
-  protocol matching the transaction. It now returns
+- `orchard::Bundle::{commitment, authorizing_commitment}` now take a
+  `orchard::bundle::BundlePoolRestrictions` (which selects the flag-byte encoding) and
+  an `orchard::bundle::TxVersion` (which selects the commitment personalization
+  strings and the anchor placement for the transaction the bundle is encoded in). The
+  ZIP-244 digest — and therefore the transaction ID and sighash — now depends on both:
+  under a NU6.3 protocol an unrestricted bundle's flag byte sets bit 2, and
+  `TxVersion::V6` uses the v6 personalization strings and commits the anchor in the
+  authorizing commitment instead of the effects commitment. Callers computing
+  transaction IDs or sighashes must pass the restrictions and version matching the
+  transaction. `Bundle::commitment` now returns
   `Result<BundleCommitment, CommitmentError>`, returning
   `Err(CommitmentError::UnrepresentableFlags)` if the flags are unrepresentable
-  under that protocol (cross-address transfers disabled under a pre-NU6.3 protocol).
+  under those restrictions (for example, cross-address transfers disabled under
+  pre-NU6.3 restrictions).
+- `orchard::bundle::commitments::{hash_bundle_txid_empty, hash_bundle_auth_empty}`
+  now take a `BundlePoolRestrictions` and a `TxVersion`.
 - Behind the `unstable-voting-circuits` feature, `RandomSeed::rcm` is renamed to
   `RandomSeed::rcm_v2`, marking it as the rcm derivation for V2 (ZIP 212) notes.
   These APIs are not covered by the crate's semver guarantees.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,7 +204,7 @@ the current behavior by selecting `BundlePoolRestrictions::OrchardNu6_2Only` (an
   `ProverError::MissingRecipient` if a `recipient` field is unset).
 - `orchard::pczt::{Spend, Output}::parse` now take the note plaintext version
   for the parsed spend or output, and `orchard::pczt::Bundle::parse` rejects
-  actions whose spend or output note version does not match the `BundlePoolRestrictions`.
+  actions whose output note version does not match the `BundlePoolRestrictions`.
 - `orchard::note_encryption::{OrchardNoteEncryption, IronwoodNoteEncryption}`
   documentation now clarifies that encryption uses the note's own
   `NoteVersion`; the aliases differ in which note plaintext versions they
@@ -219,8 +219,8 @@ the current behavior by selecting `BundlePoolRestrictions::OrchardNu6_2Only` (an
     note version through their re-exported path.
   - `orchard::bundle::testing::{arb_action_n, arb_unauthorized_action_n}` now
     take a note version.
-  - `orchard::bundle::testing::{arb_bundle, arb_unauthorized_bundle}` no longer
-    take bundle pool restrictions, and instead select them internally.
+  - `orchard::bundle::testing::{arb_bundle, arb_unauthorized_bundle}` now
+    generate a bundle pool restriction internally to select the note version.
 - `orchard::pczt::Bundle::finalize_io` verifies the cross-address restriction
   before modifying the bundle, returning
   `IoFinalizerError::CrossAddressRestriction` (wrapping the underlying

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,7 +235,8 @@ the current behavior by selecting `BundlePoolRestrictions::OrchardNu6_2Only` (an
   `TxVersion::V6` uses the v6 personalization strings and commits the anchor in the
   authorizing commitment instead of the effects commitment. Callers computing
   transaction IDs or sighashes must pass the restrictions and version matching the
-  transaction. `Bundle::commitment` now returns
+  transaction; these APIs do not validate that the selected pool/era is consensus-valid
+  for the selected transaction version. `Bundle::commitment` now returns
   `Result<BundleCommitment, CommitmentError>`, returning
   `Err(CommitmentError::UnrepresentableFlags)` if the flags are unrepresentable
   under those restrictions (for example, cross-address transfers disabled under

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -167,7 +167,7 @@ impl BundleType {
     }
 }
 
-/// Decide, for a bundle targetting the consensus rules implied by `pool_restrictions`,
+/// Decide, for a bundle targeting the consensus rules implied by `pool_restrictions`,
 /// whether to enable cross-address transfers according to the least restrictive policy
 /// mandated by those rules (see [`BundlePoolRestrictions::requires_cross_address_restriction`]).
 ///

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -141,6 +141,27 @@ impl BundlePoolRestrictions {
     }
 }
 
+/// The transaction version a bundle's commitments are computed for.
+///
+/// An Orchard bundle at NU6.3 and later may be encoded in either a v5 or a v6 transaction.
+/// The two formats use different commitment personalization strings and place the bundle's
+/// anchor in different digests: v5 commits the anchor within the transaction-ID effects,
+/// while v6 commits it within the authorizing data. Ironwood bundles exist only in v6
+/// transactions, so their commitments ignore this value.
+///
+/// This is independent of the [`BundlePoolRestrictions`] that govern construction: the same
+/// Orchard bundle can be committed under either version, and the caller must pass the one
+/// matching the transaction the bundle is encoded in. See [`Bundle::commitment`] and
+/// [`Bundle::authorizing_commitment`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TxVersion {
+    /// A v5 transaction.
+    V5,
+    /// A v6 transaction.
+    V6,
+}
+
 /// Orchard-specific flags.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Flags {
@@ -628,20 +649,21 @@ impl<T: Authorization, V: Copy + Into<i64>> Bundle<T, V> {
     /// Computes a commitment to the effects of this bundle, suitable for inclusion within
     /// a transaction ID.
     ///
-    /// The flag byte is hashed as encoded under the `pool_restrictions` targetted by this
-    /// bundle, so the digest depends on the encoding epoch. See [`BundlePoolRestrictions`]
-    /// for why getting `pool_restrictions` wrong matters.
+    /// `pool_restrictions` selects the flag-byte encoding; `tx_version` selects the commitment
+    /// personalizations and the anchor placement for the transaction the bundle is encoded in.
+    /// In a v5 transaction the anchor is committed here (within the transaction-ID effects); in
+    /// a v6 transaction it is committed by [`Bundle::authorizing_commitment`] instead.
     ///
     /// # Errors
     ///
-    /// Returns [`CommitmentError::UnrepresentableFlags`] if the flags cannot be encoded under
-    /// `pool_restrictions` (cross-address transfers disabled pre-NU6.3, or enabled for Orchard
-    /// post-NU6.3).
+    /// Returns [`CommitmentError::UnrepresentableFlags`] if the flags cannot
+    /// be encoded under the given pool restrictions.
     pub fn commitment(
         &self,
         pool_restrictions: BundlePoolRestrictions,
+        tx_version: TxVersion,
     ) -> Result<BundleCommitment, CommitmentError> {
-        hash_bundle_txid_data(self, pool_restrictions)
+        hash_bundle_txid_data(self, pool_restrictions, tx_version)
             .map(BundleCommitment)
             .ok_or(CommitmentError::UnrepresentableFlags)
     }
@@ -821,9 +843,16 @@ impl<V> Bundle<Authorized, V> {
 
     /// Computes a commitment to the authorizing data within for this bundle.
     ///
-    /// This together with `Bundle::commitment` bind the entire bundle.
-    pub fn authorizing_commitment(&self) -> BundleAuthorizingCommitment {
-        BundleAuthorizingCommitment(hash_bundle_auth_data(self))
+    /// This together with `Bundle::commitment` bind the entire bundle. `pool_restrictions` and
+    /// `tx_version` select the commitment personalization; in a v6 transaction this commitment
+    /// also binds the bundle's anchor (in a v5 transaction the anchor is bound by
+    /// [`Bundle::commitment`] instead).
+    pub fn authorizing_commitment(
+        &self,
+        pool_restrictions: BundlePoolRestrictions,
+        tx_version: TxVersion,
+    ) -> BundleAuthorizingCommitment {
+        BundleAuthorizingCommitment(hash_bundle_auth_data(self, pool_restrictions, tx_version))
     }
 
     /// Verifies the proof for this bundle.
@@ -1086,7 +1115,9 @@ pub(crate) mod tests {
     use proptest::prelude::*;
 
     use super::testing::{arb_bundle, arb_flags, arb_flags_ironwood_post_nu6_3};
-    use super::{Authorized, Bundle, BundleError, BundlePoolRestrictions, CommitmentError, Flags};
+    use super::{
+        Authorized, Bundle, BundleError, BundlePoolRestrictions, CommitmentError, Flags, TxVersion,
+    };
     use crate::Proof;
 
     #[cfg(feature = "circuit")]
@@ -1276,6 +1307,33 @@ pub(crate) mod tests {
         );
     }
 
+    #[test]
+    fn empty_commitments_are_domain_separated() {
+        use crate::bundle::commitments::{hash_bundle_auth_empty, hash_bundle_txid_empty};
+
+        // The three commitment formats — Orchard v5, Orchard v6, Ironwood v6 — use distinct
+        // personalizations, so the absent-bundle digests are all different from one another.
+        let formats = [
+            (BundlePoolRestrictions::OrchardNu6_3Onward, TxVersion::V5),
+            (BundlePoolRestrictions::OrchardNu6_3Onward, TxVersion::V6),
+            (BundlePoolRestrictions::IronwoodNu6_3Onward, TxVersion::V6),
+        ];
+        for i in 0..formats.len() {
+            for j in (i + 1)..formats.len() {
+                let (pi, ti) = formats[i];
+                let (pj, tj) = formats[j];
+                assert_ne!(
+                    hash_bundle_txid_empty(pi, ti).as_bytes(),
+                    hash_bundle_txid_empty(pj, tj).as_bytes()
+                );
+                assert_ne!(
+                    hash_bundle_auth_empty(pi, ti).as_bytes(),
+                    hash_bundle_auth_empty(pj, tj).as_bytes()
+                );
+            }
+        }
+    }
+
     proptest! {
         // The property is deterministic given the actions, so a handful of cases suffices.
         #![proptest_config(ProptestConfig::with_cases(16))]
@@ -1335,11 +1393,11 @@ pub(crate) mod tests {
                 bundle.flags().to_byte(BundlePoolRestrictions::OrchardNu6_2Only)
             );
             let restricted_commitment: [u8; 32] = restricted
-                .commitment(BundlePoolRestrictions::OrchardNu6_3Onward)
+                .commitment(BundlePoolRestrictions::OrchardNu6_3Onward, TxVersion::V5)
                 .expect("restricted flags are representable under NU6.3")
                 .into();
             let legacy_commitment: [u8; 32] = bundle
-                .commitment(BundlePoolRestrictions::OrchardNu6_2Only)
+                .commitment(BundlePoolRestrictions::OrchardNu6_2Only, TxVersion::V5)
                 .expect("unrestricted flags are representable pre-NU6.3")
                 .into();
             prop_assert_eq!(restricted_commitment, legacy_commitment);
@@ -1347,7 +1405,7 @@ pub(crate) mod tests {
             // The unrestricted NU6.3 encoding sets bit 2, producing a distinct digest. Only
             // the Ironwood pool may set it; Orchard post-NU6.3 prohibits cross-address transfers.
             let unrestricted_commitment: [u8; 32] = bundle
-                .commitment(BundlePoolRestrictions::IronwoodNu6_3Onward)
+                .commitment(BundlePoolRestrictions::IronwoodNu6_3Onward, TxVersion::V6)
                 .expect("unrestricted flags are representable under Ironwood NU6.3")
                 .into();
             prop_assert_ne!(unrestricted_commitment, restricted_commitment);
@@ -1355,9 +1413,61 @@ pub(crate) mod tests {
             // The restricted flag set cannot be committed under pre-NU6.3 encoding.
             prop_assert_eq!(restricted.flags().to_byte(BundlePoolRestrictions::OrchardNu6_2Only), None);
             prop_assert!(matches!(
-                restricted.commitment(BundlePoolRestrictions::OrchardNu6_2Only),
+                restricted.commitment(BundlePoolRestrictions::OrchardNu6_2Only, TxVersion::V5),
                 Err(CommitmentError::UnrepresentableFlags)
             ));
+        }
+
+        /// The anchor is committed in the transaction-ID effects for the v5 format and in the
+        /// authorizing data for the v6 format, so changing only the anchor moves exactly one of
+        /// the two digests. The v5 and v6 Orchard formats are also domain-separated, so the same
+        /// bundle commits to distinct transaction-ID digests under each.
+        #[test]
+        fn anchor_placement_follows_tx_version(bundle in arb_bundle(3)) {
+            // Orchard post-NU6.3 cannot encode cross-address transfers, so clear the bit to keep
+            // the flags representable in every format under test.
+            let mut flags = *bundle.flags();
+            flags.cross_address_enabled = false;
+
+            let with_anchor = |anchor| {
+                Bundle::from_parts_unchecked(
+                    bundle.actions().clone(),
+                    flags,
+                    0i64,
+                    anchor,
+                    bundle.authorization().clone(),
+                )
+            };
+            let a = with_anchor(crate::Anchor::from_bytes([0u8; 32]).unwrap());
+            let b = with_anchor(crate::Anchor::from_bytes([6u8; 32]).unwrap());
+
+            for (pool_restrictions, tx, anchor_in_effects) in [
+                (BundlePoolRestrictions::OrchardNu6_3Onward, TxVersion::V5, true),
+                (BundlePoolRestrictions::OrchardNu6_3Onward, TxVersion::V6, false),
+                (BundlePoolRestrictions::IronwoodNu6_3Onward, TxVersion::V6, false),
+            ] {
+                let txid_a: [u8; 32] = a.commitment(pool_restrictions, tx).unwrap().into();
+                let txid_b: [u8; 32] = b.commitment(pool_restrictions, tx).unwrap().into();
+                let auth_a = a.authorizing_commitment(pool_restrictions, tx).0;
+                let auth_b = b.authorizing_commitment(pool_restrictions, tx).0;
+                if anchor_in_effects {
+                    prop_assert_ne!(txid_a, txid_b);
+                    prop_assert_eq!(auth_a.as_bytes(), auth_b.as_bytes());
+                } else {
+                    prop_assert_eq!(txid_a, txid_b);
+                    prop_assert_ne!(auth_a.as_bytes(), auth_b.as_bytes());
+                }
+            }
+
+            let orchard_v5: [u8; 32] = a
+                .commitment(BundlePoolRestrictions::OrchardNu6_3Onward, TxVersion::V5)
+                .unwrap()
+                .into();
+            let orchard_v6: [u8; 32] = a
+                .commitment(BundlePoolRestrictions::OrchardNu6_3Onward, TxVersion::V6)
+                .unwrap()
+                .into();
+            prop_assert_ne!(orchard_v5, orchard_v6);
         }
 
         #[test]
@@ -1462,7 +1572,7 @@ pub(crate) mod tests {
             .expect("generated bundle value balance fits in i64");
 
         assert!(matches!(
-            bundle.commitment(BundlePoolRestrictions::OrchardNu6_2Only),
+            bundle.commitment(BundlePoolRestrictions::OrchardNu6_2Only, TxVersion::V5),
             Err(CommitmentError::UnrepresentableFlags)
         ));
     }

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -144,10 +144,10 @@ impl BundlePoolRestrictions {
 /// The transaction version a bundle's commitments are computed for.
 ///
 /// An Orchard bundle at NU6.3 and later may be encoded in either a v5 or a v6 transaction.
-/// The two formats use different commitment personalization strings and place the bundle's
-/// anchor in different digests: v5 commits the anchor within the transaction-ID effects,
-/// while v6 commits it within the authorizing data. Ironwood bundles exist only in v6
-/// transactions, so their commitments ignore this value.
+/// The two formats use different commitment personalization strings and include the bundle's
+/// anchor in different digests: v5 includes the anchor in the transaction-ID digest, while v6
+/// includes it in the authorizing digest. Ironwood bundles exist only in v6 transactions, so
+/// their commitment format ignores this value.
 ///
 /// This is independent of the [`BundlePoolRestrictions`] that govern construction: the same
 /// Orchard bundle can be committed under either version, and the caller must pass the one
@@ -649,13 +649,12 @@ impl<T: Authorization, V> Bundle<T, V> {
 }
 
 impl<T: Authorization, V: Copy + Into<i64>> Bundle<T, V> {
-    /// Computes a commitment to the effects of this bundle, suitable for inclusion within
-    /// a transaction ID.
+    /// Computes this bundle's transaction-ID commitment component.
     ///
     /// `pool_restrictions` selects the flag-byte encoding; `tx_version` selects the commitment
-    /// personalizations and the anchor placement for the transaction the bundle is encoded in.
-    /// In a v5 transaction the anchor is committed here (within the transaction-ID effects); in
-    /// a v6 transaction it is committed by [`Bundle::authorizing_commitment`] instead.
+    /// personalizations and whether the bundle anchor bytes are included here or in the
+    /// authorizing digest. In a v5 transaction the anchor bytes are included here; in a v6
+    /// transaction they are included by [`Bundle::authorizing_commitment`] instead.
     ///
     /// # Errors
     ///
@@ -844,11 +843,11 @@ impl<V> Bundle<Authorized, V> {
         ))
     }
 
-    /// Computes a commitment to the authorizing data within for this bundle.
+    /// Computes the authorizing-data commitment for this bundle.
     ///
-    /// This together with `Bundle::commitment` bind the entire bundle. `pool_restrictions` and
-    /// `tx_version` select the commitment personalization; in a v6 transaction this commitment
-    /// also binds the bundle's anchor (in a v5 transaction the anchor is bound by
+    /// This together with `Bundle::commitment` binds the entire bundle. `pool_restrictions` and
+    /// `tx_version` select the commitment personalization; in a v6 transaction this digest also
+    /// includes the bundle anchor bytes (in a v5 transaction they are included by
     /// [`Bundle::commitment`] instead).
     pub fn authorizing_commitment(
         &self,
@@ -1421,10 +1420,10 @@ pub(crate) mod tests {
             ));
         }
 
-        /// The anchor is committed in the transaction-ID effects for the v5 format and in the
-        /// authorizing data for the v6 format, so changing only the anchor moves exactly one of
-        /// the two digests. The v5 and v6 Orchard formats are also domain-separated, so the same
-        /// bundle commits to distinct transaction-ID digests under each.
+        /// The anchor bytes are included in the transaction-ID digest for the v5 format and in
+        /// the authorizing digest for the v6 format, so changing only the anchor moves exactly
+        /// one of the two digests. The v5 and v6 Orchard formats are also domain-separated, so
+        /// the same bundle commits to distinct transaction-ID digests under each.
         #[test]
         fn anchor_placement_follows_tx_version(bundle in arb_bundle(3)) {
             // Orchard post-NU6.3 cannot encode cross-address transfers, so clear the bit to keep
@@ -1444,7 +1443,7 @@ pub(crate) mod tests {
             let a = with_anchor(crate::Anchor::from_bytes([0u8; 32]).unwrap());
             let b = with_anchor(crate::Anchor::from_bytes([6u8; 32]).unwrap());
 
-            for (pool_restrictions, tx, anchor_in_effects) in [
+            for (pool_restrictions, tx, anchor_in_txid_digest) in [
                 (BundlePoolRestrictions::OrchardNu6_3Onward, TxVersion::V5, true),
                 (BundlePoolRestrictions::OrchardNu6_3Onward, TxVersion::V6, false),
                 (BundlePoolRestrictions::IronwoodNu6_3Onward, TxVersion::V6, false),
@@ -1453,7 +1452,7 @@ pub(crate) mod tests {
                 let txid_b: [u8; 32] = b.commitment(pool_restrictions, tx).unwrap().into();
                 let auth_a = a.authorizing_commitment(pool_restrictions, tx).0;
                 let auth_b = b.authorizing_commitment(pool_restrictions, tx).0;
-                if anchor_in_effects {
+                if anchor_in_txid_digest {
                     prop_assert_ne!(txid_a, txid_b);
                     prop_assert_eq!(auth_a.as_bytes(), auth_b.as_bytes());
                 } else {

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -325,22 +325,25 @@ impl Flags {
         Some(value)
     }
 
-    /// Parses flags from a single byte as defined in [Zcash Protocol Spec § 7.1:
-    /// Transaction Encoding And Consensus][txencoding], according to the interpretation
-    /// implied by `pool_restrictions`. Returns `None` if unexpected bits are set in the flag byte.
+    /// Parses flags from a single byte as defined in [Zcash Protocol Spec §
+    /// 7.1: Transaction Encoding And Consensus][txencoding], according to the
+    /// interpretation implied by `pool_restrictions`. Returns `None` if
+    /// unexpected bits are set in the flag byte.
     ///
-    /// The protocol specification and ZIPs 225 and TODO:draft-zodl-valargroup-ironwood-txformat
-    /// define bit 2 of `flags` to be reserved in v5 transactions, and to encode the
-    /// `enableCrossAddress` flag in v6 transactions. However, we can (by design) parse and
-    /// validate the flags knowing only `pool_restrictions`: bit 2 can only be 1 when
-    /// `pool_restrictions == BundlePoolRestrictions::IronwoodNu6_3Onward`, and otherwise
-    /// MUST be 0. Assuming that has been checked, cross-address transactions are then
-    /// always enabled before NU6.3, and are taken to be enabled when bit 2 is set and
-    /// `pool_restrictions == BundlePoolRestrictions::IronwoodNu6_3Onward`, otherwise.
+    /// The protocol specification and ZIPs 225 and 229 define bit 2 of `flags`
+    /// to be reserved in v5 transactions, and to encode the
+    /// `enableCrossAddress` flag in v6 transactions. However, we can (by
+    /// design) parse and validate the flags knowing only `pool_restrictions`:
+    /// bit 2 can only be 1 when `pool_restrictions ==
+    /// BundlePoolRestrictions::IronwoodNu6_3Onward`, and otherwise MUST be 0.
+    /// Assuming that has been checked, cross-address transactions are then
+    /// always enabled before NU6.3, and are taken to be enabled when bit 2 is
+    /// set and `pool_restrictions ==
+    /// BundlePoolRestrictions::IronwoodNu6_3Onward`, otherwise.
     ///
-    /// Note: if the wrong value of `pool_restrictions` is passed for the actual pool and epoch
-    /// of the transaction, then a consensus-invalid transaction may be constructed (see
-    /// [`BundlePoolRestrictions`]).
+    /// Note: if the wrong value of `pool_restrictions` is passed for the actual
+    /// pool and epoch of the transaction, then a consensus-invalid transaction
+    /// may be constructed (see [`BundlePoolRestrictions`]).
     ///
     /// [txencoding]: https://zips.z.cash/protocol/protocol.pdf#txnencoding
     pub fn from_byte(value: u8, pool_restrictions: BundlePoolRestrictions) -> Option<Self> {

--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -109,14 +109,14 @@ fn hasher(personal: &[u8; 16]) -> State {
     Params::new().hash_length(32).personal(personal).to_state()
 }
 
-/// Write disjoint parts of each Orchard shielded action as 3 separate hashes
+/// Write disjoint parts of each bundle action as 3 separate hashes
 /// as defined in [ZIP-244: Transaction Identifier Non-Malleability][zip244]:
 /// * \[(nullifier, cmx, ephemeral_key, enc_ciphertext\[..52\])*\] personalized
-///   with ZCASH_ORCHARD_ACTIONS_COMPACT_HASH_PERSONALIZATION
+///   with the format's compact-action personalization string
 /// * \[enc_ciphertext\[52..564\]*\] (memo ciphertexts) personalized
-///   with ZCASH_ORCHARD_ACTIONS_MEMOS_HASH_PERSONALIZATION
+///   with the format's action-memos personalization string
 /// * \[(cv, rk, enc_ciphertext\[564..\], out_ciphertext)*\] personalized
-///   with ZCASH_ORCHARD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION
+///   with the format's non-compact-action personalization string
 ///
 /// Then, hash these together along with (flags, value_balance_orchard, and — for the v5
 /// transaction format only — anchor_orchard), personalized with the format's bundle

--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -2,13 +2,121 @@
 
 use blake2b_simd::{Hash as Blake2bHash, Params, State};
 
-use crate::bundle::{Authorization, Authorized, Bundle, BundlePoolRestrictions};
+use crate::bundle::{Authorization, Authorized, Bundle, BundlePoolRestrictions, TxVersion};
 
-const ZCASH_ORCHARD_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrchardHash";
+const ZCASH_ORCHARD_V5_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrchardHash";
+const ZCASH_ORCHARD_V6_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrchardH_v6";
 const ZCASH_ORCHARD_ACTIONS_COMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrcActCHash";
 const ZCASH_ORCHARD_ACTIONS_MEMOS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrcActMHash";
 const ZCASH_ORCHARD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrcActNHash";
-const ZCASH_ORCHARD_SIGS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxAuthOrchaHash";
+const ZCASH_ORCHARD_V5_SIGS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxAuthOrchaHash";
+const ZCASH_ORCHARD_V6_SIGS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxAuthOrchaH_v6";
+const ZCASH_IRONWOOD_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIronwd_H_v6";
+const ZCASH_IRONWOOD_ACTIONS_COMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIrnActCH_v6";
+const ZCASH_IRONWOOD_ACTIONS_MEMOS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIrnActMH_v6";
+const ZCASH_IRONWOOD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIrnActNH_v6";
+const ZCASH_IRONWOOD_SIGS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxAuthIrnwdH_v6";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AnchorCommitment {
+    Include,
+    Omit,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BundleCommitmentPersonalizations {
+    bundle: &'static [u8; 16],
+    actions_compact: &'static [u8; 16],
+    actions_memos: &'static [u8; 16],
+    actions_noncompact: &'static [u8; 16],
+    auth: &'static [u8; 16],
+}
+
+const ORCHARD_V5_PERSONALIZATIONS: BundleCommitmentPersonalizations =
+    BundleCommitmentPersonalizations {
+        bundle: ZCASH_ORCHARD_V5_HASH_PERSONALIZATION,
+        actions_compact: ZCASH_ORCHARD_ACTIONS_COMPACT_HASH_PERSONALIZATION,
+        actions_memos: ZCASH_ORCHARD_ACTIONS_MEMOS_HASH_PERSONALIZATION,
+        actions_noncompact: ZCASH_ORCHARD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION,
+        auth: ZCASH_ORCHARD_V5_SIGS_HASH_PERSONALIZATION,
+    };
+
+// Orchard v6 deliberately reuses the v5 action-level personalizations
+// (compact/memos/noncompact); only the top-level `bundle` and `auth` strings gain `_v6`.
+// Ironwood instead uses fresh `_v6` strings throughout. Either way the top-level digest is
+// domain-separated by its `bundle`/`auth` personalization, so reusing the action-level ones
+// cannot collide across formats.
+const ORCHARD_V6_PERSONALIZATIONS: BundleCommitmentPersonalizations =
+    BundleCommitmentPersonalizations {
+        bundle: ZCASH_ORCHARD_V6_HASH_PERSONALIZATION,
+        actions_compact: ZCASH_ORCHARD_ACTIONS_COMPACT_HASH_PERSONALIZATION,
+        actions_memos: ZCASH_ORCHARD_ACTIONS_MEMOS_HASH_PERSONALIZATION,
+        actions_noncompact: ZCASH_ORCHARD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION,
+        auth: ZCASH_ORCHARD_V6_SIGS_HASH_PERSONALIZATION,
+    };
+
+const IRONWOOD_V6_PERSONALIZATIONS: BundleCommitmentPersonalizations =
+    BundleCommitmentPersonalizations {
+        bundle: ZCASH_IRONWOOD_HASH_PERSONALIZATION,
+        actions_compact: ZCASH_IRONWOOD_ACTIONS_COMPACT_HASH_PERSONALIZATION,
+        actions_memos: ZCASH_IRONWOOD_ACTIONS_MEMOS_HASH_PERSONALIZATION,
+        actions_noncompact: ZCASH_IRONWOOD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION,
+        auth: ZCASH_IRONWOOD_SIGS_HASH_PERSONALIZATION,
+    };
+
+/// The commitment format used to compute a bundle's transaction-ID and authorizing
+/// commitments, selected from the bundle's pool and the version of the transaction it is
+/// encoded in. Orchard bundles use the v5 or v6 format according to the transaction; Ironwood
+/// bundles exist only in v6 transactions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BundleCommitmentFormat {
+    OrchardV5,
+    OrchardV6,
+    IronwoodV6,
+}
+
+impl BundlePoolRestrictions {
+    fn commitment_format(self, tx_version: TxVersion) -> BundleCommitmentFormat {
+        match self {
+            BundlePoolRestrictions::OrchardPreNu6_2
+            | BundlePoolRestrictions::OrchardNu6_2Only
+            | BundlePoolRestrictions::OrchardNu6_3Onward => match tx_version {
+                TxVersion::V5 => BundleCommitmentFormat::OrchardV5,
+                TxVersion::V6 => BundleCommitmentFormat::OrchardV6,
+            },
+            // Ironwood exists only in v6 transactions, so `tx_version` is irrelevant here.
+            BundlePoolRestrictions::IronwoodNu6_3Onward => BundleCommitmentFormat::IronwoodV6,
+        }
+    }
+}
+
+impl BundleCommitmentFormat {
+    fn personalizations(self) -> BundleCommitmentPersonalizations {
+        match self {
+            BundleCommitmentFormat::OrchardV5 => ORCHARD_V5_PERSONALIZATIONS,
+            BundleCommitmentFormat::OrchardV6 => ORCHARD_V6_PERSONALIZATIONS,
+            BundleCommitmentFormat::IronwoodV6 => IRONWOOD_V6_PERSONALIZATIONS,
+        }
+    }
+
+    fn effects_anchor_commitment(self) -> AnchorCommitment {
+        match self {
+            BundleCommitmentFormat::OrchardV5 => AnchorCommitment::Include,
+            BundleCommitmentFormat::OrchardV6 | BundleCommitmentFormat::IronwoodV6 => {
+                AnchorCommitment::Omit
+            }
+        }
+    }
+
+    fn auth_anchor_commitment(self) -> AnchorCommitment {
+        match self {
+            BundleCommitmentFormat::OrchardV5 => AnchorCommitment::Omit,
+            BundleCommitmentFormat::OrchardV6 | BundleCommitmentFormat::IronwoodV6 => {
+                AnchorCommitment::Include
+            }
+        }
+    }
+}
 
 fn hasher(personal: &[u8; 16]) -> State {
     Params::new().hash_length(32).personal(personal).to_state()
@@ -23,24 +131,25 @@ fn hasher(personal: &[u8; 16]) -> State {
 /// * \[(cv, rk, enc_ciphertext\[564..\], out_ciphertext)*\] personalized
 ///   with ZCASH_ORCHARD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION
 ///
-/// Then, hash these together along with (flags, value_balance_orchard, anchor_orchard),
-/// personalized with ZCASH_ORCHARD_ACTIONS_HASH_PERSONALIZATION
+/// Then, hash these together along with (flags, value_balance_orchard, and — for the v5
+/// transaction format only — anchor_orchard), personalized with the format's bundle
+/// personalization string. In the v6 format the anchor is committed by
+/// `hash_bundle_auth_data` instead.
 ///
-/// # Errors
-///
-/// Returns `None` if `bundle`'s flags cannot be encoded under `pool_restrictions`
-/// (cross-address transfers disabled for a bundle targetted to pre-NU6.3 Orchard);
-/// such a bundle cannot appear in a pre-NU6.3 transaction.
+/// Returns `None` if the bundle flags cannot be encoded in the domain's bundle format.
 ///
 /// [zip244]: https://zips.z.cash/zip-0244
 pub(crate) fn hash_bundle_txid_data<A: Authorization, V: Copy + Into<i64>>(
     bundle: &Bundle<A, V>,
     pool_restrictions: BundlePoolRestrictions,
+    tx_version: TxVersion,
 ) -> Option<Blake2bHash> {
-    let mut h = hasher(ZCASH_ORCHARD_HASH_PERSONALIZATION);
-    let mut ch = hasher(ZCASH_ORCHARD_ACTIONS_COMPACT_HASH_PERSONALIZATION);
-    let mut mh = hasher(ZCASH_ORCHARD_ACTIONS_MEMOS_HASH_PERSONALIZATION);
-    let mut nh = hasher(ZCASH_ORCHARD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION);
+    let format = pool_restrictions.commitment_format(tx_version);
+    let personalizations = format.personalizations();
+    let mut h = hasher(personalizations.bundle);
+    let mut ch = hasher(personalizations.actions_compact);
+    let mut mh = hasher(personalizations.actions_memos);
+    let mut nh = hasher(personalizations.actions_noncompact);
 
     for action in bundle.actions().iter() {
         ch.update(&action.nullifier().to_bytes());
@@ -61,7 +170,9 @@ pub(crate) fn hash_bundle_txid_data<A: Authorization, V: Copy + Into<i64>>(
     h.update(nh.finalize().as_bytes());
     h.update(&[bundle.flags().to_byte(pool_restrictions)?]);
     h.update(&(*bundle.value_balance()).into().to_le_bytes());
-    h.update(&bundle.anchor().to_bytes());
+    if format.effects_anchor_commitment() == AnchorCommitment::Include {
+        h.update(&bundle.anchor().to_bytes());
+    }
     Some(h.finalize())
 }
 
@@ -69,8 +180,17 @@ pub(crate) fn hash_bundle_txid_data<A: Authorization, V: Copy + Into<i64>>(
 /// [ZIP-244: Transaction Identifier Non-Malleability][zip244]
 ///
 /// [zip244]: https://zips.z.cash/zip-0244
-pub fn hash_bundle_txid_empty() -> Blake2bHash {
-    hasher(ZCASH_ORCHARD_HASH_PERSONALIZATION).finalize()
+pub fn hash_bundle_txid_empty(
+    pool_restrictions: BundlePoolRestrictions,
+    tx_version: TxVersion,
+) -> Blake2bHash {
+    hasher(
+        pool_restrictions
+            .commitment_format(tx_version)
+            .personalizations()
+            .bundle,
+    )
+    .finalize()
 }
 
 /// Construct the commitment to the authorizing data of an
@@ -78,8 +198,13 @@ pub fn hash_bundle_txid_empty() -> Blake2bHash {
 /// Identifier Non-Malleability][zip244]
 ///
 /// [zip244]: https://zips.z.cash/zip-0244
-pub(crate) fn hash_bundle_auth_data<V>(bundle: &Bundle<Authorized, V>) -> Blake2bHash {
-    let mut h = hasher(ZCASH_ORCHARD_SIGS_HASH_PERSONALIZATION);
+pub(crate) fn hash_bundle_auth_data<V>(
+    bundle: &Bundle<Authorized, V>,
+    pool_restrictions: BundlePoolRestrictions,
+    tx_version: TxVersion,
+) -> Blake2bHash {
+    let format = pool_restrictions.commitment_format(tx_version);
+    let mut h = hasher(format.personalizations().auth);
     h.update(bundle.authorization().proof().as_ref());
     for action in bundle.actions().iter() {
         h.update(&<[u8; 64]>::from(action.authorization()));
@@ -87,6 +212,9 @@ pub(crate) fn hash_bundle_auth_data<V>(bundle: &Bundle<Authorized, V>) -> Blake2
     h.update(&<[u8; 64]>::from(
         bundle.authorization().binding_signature(),
     ));
+    if format.auth_anchor_commitment() == AnchorCommitment::Include {
+        h.update(&bundle.anchor().to_bytes());
+    }
     h.finalize()
 }
 
@@ -94,6 +222,15 @@ pub(crate) fn hash_bundle_auth_data<V>(bundle: &Bundle<Authorized, V>) -> Blake2
 /// [ZIP-244: Transaction Identifier Non-Malleability][zip244]
 ///
 /// [zip244]: https://zips.z.cash/zip-0244
-pub fn hash_bundle_auth_empty() -> Blake2bHash {
-    hasher(ZCASH_ORCHARD_SIGS_HASH_PERSONALIZATION).finalize()
+pub fn hash_bundle_auth_empty(
+    pool_restrictions: BundlePoolRestrictions,
+    tx_version: TxVersion,
+) -> Blake2bHash {
+    hasher(
+        pool_restrictions
+            .commitment_format(tx_version)
+            .personalizations()
+            .auth,
+    )
+    .finalize()
 }

--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -17,12 +17,6 @@ const ZCASH_IRONWOOD_ACTIONS_MEMOS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIrnA
 const ZCASH_IRONWOOD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIrnActNH_v6";
 const ZCASH_IRONWOOD_SIGS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxAuthIrnwdH_v6";
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum AnchorCommitment {
-    Include,
-    Omit,
-}
-
 #[derive(Clone, Copy, Debug)]
 struct BundleCommitmentPersonalizations {
     bundle: &'static [u8; 16],
@@ -64,10 +58,10 @@ const IRONWOOD_V6_PERSONALIZATIONS: BundleCommitmentPersonalizations =
         auth: ZCASH_IRONWOOD_SIGS_HASH_PERSONALIZATION,
     };
 
-/// The commitment format used to compute a bundle's transaction-ID and authorizing
-/// commitments, selected from the bundle's pool and the version of the transaction it is
-/// encoded in. Orchard bundles use the v5 or v6 format according to the transaction; Ironwood
-/// bundles exist only in v6 transactions.
+/// The hash format used to compute a bundle's transaction-ID and authorizing digests,
+/// selected from the bundle's pool and the version of the transaction it is encoded in.
+/// Orchard bundles use the v5 or v6 format according to the transaction; Ironwood bundles
+/// exist only in v6 transactions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum BundleCommitmentFormat {
     OrchardV5,
@@ -99,22 +93,15 @@ impl BundleCommitmentFormat {
         }
     }
 
-    fn effects_anchor_commitment(self) -> AnchorCommitment {
-        match self {
-            BundleCommitmentFormat::OrchardV5 => AnchorCommitment::Include,
-            BundleCommitmentFormat::OrchardV6 | BundleCommitmentFormat::IronwoodV6 => {
-                AnchorCommitment::Omit
-            }
-        }
+    fn includes_anchor_in_txid_digest(self) -> bool {
+        matches!(self, BundleCommitmentFormat::OrchardV5)
     }
 
-    fn auth_anchor_commitment(self) -> AnchorCommitment {
-        match self {
-            BundleCommitmentFormat::OrchardV5 => AnchorCommitment::Omit,
-            BundleCommitmentFormat::OrchardV6 | BundleCommitmentFormat::IronwoodV6 => {
-                AnchorCommitment::Include
-            }
-        }
+    fn includes_anchor_in_authorizing_digest(self) -> bool {
+        matches!(
+            self,
+            BundleCommitmentFormat::OrchardV6 | BundleCommitmentFormat::IronwoodV6
+        )
     }
 }
 
@@ -133,7 +120,7 @@ fn hasher(personal: &[u8; 16]) -> State {
 ///
 /// Then, hash these together along with (flags, value_balance_orchard, and — for the v5
 /// transaction format only — anchor_orchard), personalized with the format's bundle
-/// personalization string. In the v6 format the anchor is committed by
+/// personalization string. In the v6 format the anchor is included by
 /// `hash_bundle_auth_data` instead.
 ///
 /// Returns `None` if the bundle flags cannot be encoded in the domain's bundle format.
@@ -170,7 +157,7 @@ pub(crate) fn hash_bundle_txid_data<A: Authorization, V: Copy + Into<i64>>(
     h.update(nh.finalize().as_bytes());
     h.update(&[bundle.flags().to_byte(pool_restrictions)?]);
     h.update(&(*bundle.value_balance()).into().to_le_bytes());
-    if format.effects_anchor_commitment() == AnchorCommitment::Include {
+    if format.includes_anchor_in_txid_digest() {
         h.update(&bundle.anchor().to_bytes());
     }
     Some(h.finalize())
@@ -212,7 +199,7 @@ pub(crate) fn hash_bundle_auth_data<V>(
     h.update(&<[u8; 64]>::from(
         bundle.authorization().binding_signature(),
     ));
-    if format.auth_anchor_commitment() == AnchorCommitment::Include {
+    if format.includes_anchor_in_authorizing_digest() {
         h.update(&bundle.anchor().to_bytes());
     }
     h.finalize()

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -3,7 +3,7 @@
 use incrementalmerkletree::{Hashable, Marking, Retention};
 use orchard::{
     builder::{Builder, BundleType},
-    bundle::{Authorized, BatchValidator, BundlePoolRestrictions},
+    bundle::{Authorized, BatchValidator, BundlePoolRestrictions, TxVersion},
     circuit::{OrchardCircuitVersion, ProvingKey, VerifyingKey},
     keys::{FullViewingKey, PreparedIncomingViewingKey, Scope, SpendAuthorizingKey, SpendingKey},
     note::{ExtractedNoteCommitment, NoteVersion},
@@ -44,10 +44,11 @@ fn verify_bundle(
     bundle: &Bundle<Authorized, i64>,
     vk: &VerifyingKey,
     pool_restrictions: BundlePoolRestrictions,
+    tx_version: TxVersion,
 ) {
     assert!(matches!(bundle.verify_proof(vk), Ok(())));
     let sighash: [u8; 32] = bundle
-        .commitment(pool_restrictions)
+        .commitment(pool_restrictions, tx_version)
         .expect("bundle flags are representable in this format")
         .into();
     let bvk = bundle.binding_validating_key();
@@ -116,7 +117,7 @@ fn bundle_chain() {
         );
 
         let sighash = unauthorized
-            .commitment(BundlePoolRestrictions::OrchardNu6_2Only)
+            .commitment(BundlePoolRestrictions::OrchardNu6_2Only, TxVersion::V5)
             .expect("bundle flags are representable in this format")
             .into();
         let proven = unauthorized.create_proof(&pk, &mut rng).unwrap();
@@ -128,6 +129,7 @@ fn bundle_chain() {
         &shielding_bundle,
         &vk,
         BundlePoolRestrictions::OrchardNu6_2Only,
+        TxVersion::V5,
     );
 
     // Create a shielded bundle spending the previous output.
@@ -158,7 +160,7 @@ fn bundle_chain() {
         );
         let (unauthorized, _) = builder.build(&mut rng).unwrap().unwrap();
         let sighash = unauthorized
-            .commitment(BundlePoolRestrictions::OrchardNu6_2Only)
+            .commitment(BundlePoolRestrictions::OrchardNu6_2Only, TxVersion::V5)
             .expect("bundle flags are representable in this format")
             .into();
         let proven = unauthorized.create_proof(&pk, &mut rng).unwrap();
@@ -172,6 +174,7 @@ fn bundle_chain() {
         &shielded_bundle,
         &vk,
         BundlePoolRestrictions::OrchardNu6_2Only,
+        TxVersion::V5,
     );
 }
 
@@ -197,7 +200,7 @@ fn builder_builds_for_insecure_circuit_version() {
 
     let (unauthorized, _) = builder.build::<i64>(&mut rng).unwrap().unwrap();
     let sighash: [u8; 32] = unauthorized
-        .commitment(BundlePoolRestrictions::OrchardPreNu6_2)
+        .commitment(BundlePoolRestrictions::OrchardPreNu6_2, TxVersion::V5)
         .expect("bundle flags are representable in this format")
         .into();
     let proven = unauthorized.create_proof(&insecure_pk, &mut rng).unwrap();
@@ -230,7 +233,7 @@ fn builder_builds_for_post_nu6_3_circuit_version() {
     );
 
     let sighash: [u8; 32] = unauthorized
-        .commitment(BundlePoolRestrictions::IronwoodNu6_3Onward)
+        .commitment(BundlePoolRestrictions::IronwoodNu6_3Onward, TxVersion::V6)
         .expect("bundle flags are representable in this format")
         .into();
     let proven = unauthorized.create_proof(&post_nu6_3_pk, &mut rng).unwrap();
@@ -240,6 +243,7 @@ fn builder_builds_for_post_nu6_3_circuit_version() {
         &bundle,
         &post_nu6_3_vk,
         BundlePoolRestrictions::IronwoodNu6_3Onward,
+        TxVersion::V6,
     );
 }
 
@@ -368,7 +372,7 @@ fn post_nu6_3_coinbase_bundle_proves_and_verifies() {
     assert!(unauthorized.flags().cross_address_enabled());
 
     let sighash: [u8; 32] = unauthorized
-        .commitment(BundlePoolRestrictions::IronwoodNu6_3Onward)
+        .commitment(BundlePoolRestrictions::IronwoodNu6_3Onward, TxVersion::V6)
         .expect("bundle flags are representable in this format")
         .into();
     let proven = unauthorized.create_proof(&post_nu6_3_pk, &mut rng).unwrap();
@@ -378,6 +382,7 @@ fn post_nu6_3_coinbase_bundle_proves_and_verifies() {
         &bundle,
         &post_nu6_3_vk,
         BundlePoolRestrictions::IronwoodNu6_3Onward,
+        TxVersion::V6,
     );
 }
 
@@ -405,7 +410,7 @@ fn post_nu6_3_restricted_bundle_chain() {
 
         let (unauthorized, _) = builder.build(&mut rng).unwrap().unwrap();
         let sighash = unauthorized
-            .commitment(BundlePoolRestrictions::OrchardNu6_2Only)
+            .commitment(BundlePoolRestrictions::OrchardNu6_2Only, TxVersion::V5)
             .expect("bundle flags are representable in this format")
             .into();
         let proven = unauthorized.create_proof(&fixed_pk, &mut rng).unwrap();
@@ -416,6 +421,7 @@ fn post_nu6_3_restricted_bundle_chain() {
         &shielding_bundle,
         &fixed_vk,
         BundlePoolRestrictions::OrchardNu6_2Only,
+        TxVersion::V5,
     );
 
     let change_addr = fvk.address_at(0u32, Scope::Internal);
@@ -488,7 +494,7 @@ fn post_nu6_3_restricted_bundle_chain() {
             .is_none());
 
         let sighash = unauthorized
-            .commitment(BundlePoolRestrictions::OrchardNu6_3Onward)
+            .commitment(BundlePoolRestrictions::OrchardNu6_3Onward, TxVersion::V5)
             .expect("bundle flags are representable in this format")
             .into();
         let proven = unauthorized.create_proof(&post_nu6_3_pk, &mut rng).unwrap();
@@ -502,6 +508,7 @@ fn post_nu6_3_restricted_bundle_chain() {
         &restricted_bundle,
         &post_nu6_3_vk,
         BundlePoolRestrictions::OrchardNu6_3Onward,
+        TxVersion::V5,
     );
     assert!(restricted_bundle.verify_proof(&fixed_vk).is_err());
 
@@ -510,7 +517,7 @@ fn post_nu6_3_restricted_bundle_chain() {
         .add_bundle(
             &restricted_bundle,
             restricted_bundle
-                .commitment(BundlePoolRestrictions::OrchardNu6_3Onward)
+                .commitment(BundlePoolRestrictions::OrchardNu6_3Onward, TxVersion::V5)
                 .expect("bundle flags are representable in this format")
                 .into(),
         )
@@ -524,7 +531,7 @@ fn post_nu6_3_restricted_bundle_chain() {
         .add_bundle(
             &restricted_bundle,
             restricted_bundle
-                .commitment(BundlePoolRestrictions::OrchardNu6_3Onward)
+                .commitment(BundlePoolRestrictions::OrchardNu6_3Onward, TxVersion::V5)
                 .expect("bundle flags are representable in this format")
                 .into(),
         )
@@ -556,7 +563,7 @@ fn ironwood_post_nu6_3_unrestricted_bundle_proves_and_verifies() {
         );
         let (unauthorized, _) = builder.build(&mut rng).unwrap().unwrap();
         let sighash = unauthorized
-            .commitment(BundlePoolRestrictions::IronwoodNu6_3Onward)
+            .commitment(BundlePoolRestrictions::IronwoodNu6_3Onward, TxVersion::V6)
             .expect("bundle flags are representable in this format")
             .into();
         let proven = unauthorized.create_proof(&post_nu6_3_pk, &mut rng).unwrap();
@@ -606,7 +613,7 @@ fn ironwood_post_nu6_3_unrestricted_bundle_proves_and_verifies() {
     assert_eq!(flag_byte & 0b100, 0b100);
 
     let sighash = unauthorized
-        .commitment(BundlePoolRestrictions::IronwoodNu6_3Onward)
+        .commitment(BundlePoolRestrictions::IronwoodNu6_3Onward, TxVersion::V6)
         .expect("bundle flags are representable in this format")
         .into();
     let proven = unauthorized.create_proof(&post_nu6_3_pk, &mut rng).unwrap();
@@ -618,5 +625,6 @@ fn ironwood_post_nu6_3_unrestricted_bundle_proves_and_verifies() {
         &bundle,
         &post_nu6_3_vk,
         BundlePoolRestrictions::IronwoodNu6_3Onward,
+        TxVersion::V6,
     );
 }


### PR DESCRIPTION
This PR brings the v6 transaction hashing (txid / authorizing digest) code for Orchard and Ironwood bundles into the branch. It originated as the V6 tx-hashing work from #505 layered on the QR note-version PR (#509).

Rather than introducing a single combined struct, commitment computation is selected by **two parameters** threaded through the public commitment API:

- `BundlePoolRestrictions` — the `(pool, era)` selector. It determines the **flag-byte encoding** (pre-NU6.3 rules where bit 2 is reserved, vs. NU6.3 rules where bit 2 is `enableCrossAddress`).
- `TxVersion` (`V5` / `V6`) — the transaction version the bundle is encoded in. It selects the **commitment personalization strings** and **where the anchor is committed**: a v5 transaction includes the anchor in the transaction-ID (effects) digest, while a v6 transaction includes it in the authorizing digest instead.

Both are now arguments to `Bundle::commitment`, `Bundle::<Authorized, V>::authorizing_commitment`, and the `hash_bundle_txid_empty` / `hash_bundle_auth_empty` helpers. This is required because the sighashing code definitively needs to know both the pool (for the flag byte) and the transaction version (for the personalizations and anchor placement) — neither alone is sufficient.

_Internally_, `(pool_restrictions, tx_version)` is resolved by `BundlePoolRestrictions::commitment_format(tx_version)` into a private `BundleCommitmentFormat` enum with three variants:

- `OrchardV5` — anchor in the txid digest; legacy personalizations.
- `OrchardV6` — anchor in the authorizing digest; reuses the v5 action-level personalizations and gains `_v6` top-level `bundle`/`auth` strings.
- `IronwoodV6` — anchor in the authorizing digest; fresh `_v6` personalizations throughout (Ironwood bundles exist only in v6 transactions).

Each format carries its set of BLAKE2b personalization strings. Because `Bundle::commitment` now depends on the pool restrictions, it returns `Result<BundleCommitment, CommitmentError>` and fails with `CommitmentError::UnrepresentableFlags` when a bundle's flags cannot be encoded under the given pool (e.g. a cross-address-restricted bundle under a pre-NU6.3 pool).

New personalization strings:

- Orchard v6: `ZTxIdOrchardH_v6`, `ZTxAuthOrchaH_v6`
- Ironwood v6: `ZTxIdIronwd_H_v6`, `ZTxIdIrnActCH_v6`, `ZTxIdIrnActMH_v6`, `ZTxIdIrnActNH_v6`, `ZTxAuthIrnwdH_v6`

All constants should match:
- [ZIP 229](https://zips.z.cash/zip-0229) (Ironwood transaction format)
- https://github.com/zcash/zcash-test-vectors/pull/130
  - Note: these test vectors are in librustzcash only, not in Orchard