### PR TITLE
Add preverified PCZT signing parse path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ Existing callers keep the current behavior by constructing bundles with
   - `orchard::pczt::Bundle::bundle_version`, the generated getter for the bundle's
     `BundleVersion`, and `orchard::pczt::Bundle::flag_byte`, the infallible byte encoding of
     its flags under that version.
+  - `orchard::pczt::{Bundle, Action, Spend}::parse_preverified_for_signing`,
+    PCZT parse entry points for a preverified signing pass. They skip FVK
+    derivation and do not validate or preserve the wire `fvk`; callers must have
+    already run the full Verifier checks over the same PCZT bytes.
   - `orchard::pczt::Bundle::verify_cross_address_restriction`, so that Signers can
     check the cross-address restriction's same-expanded-receiver structural
     property before signing. It is a no-op for bundles that permit cross-address

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,10 +96,10 @@ Existing callers keep the current behavior by constructing bundles with
   - `orchard::pczt::Bundle::bundle_version`, the generated getter for the bundle's
     `BundleVersion`, and `orchard::pczt::Bundle::flag_byte`, the infallible byte encoding of
     its flags under that version.
-  - `orchard::pczt::{Bundle, Action, Spend}::parse_preverified_for_signing`,
-    PCZT parse entry points for a preverified signing pass. They skip FVK
-    derivation and do not validate or preserve the wire `fvk`; callers must have
-    already run the full Verifier checks over the same PCZT bytes.
+  - `orchard::pczt::Spend::parse_preverified_for_signing`, a PCZT spend parse
+    entry point for a preverified signing pass. It skips FVK derivation and does
+    not validate or preserve the wire `fvk`; callers must have already run the
+    full Verifier checks over the same PCZT bytes.
   - `orchard::pczt::Bundle::verify_cross_address_restriction`, so that Signers can
     check the cross-address restriction's same-expanded-receiver structural
     property before signing. It is a no-op for bundles that permit cross-address

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -826,6 +826,306 @@ mod tests {
         bundle.apply_binding_signature(sighash, rng).unwrap();
     }
 
+    /// Proves the preverified signing parse produces a byte-identical `spend_auth_sig` to
+    /// the full parse.
+    ///
+    /// One real Orchard action's on-the-wire spend bytes (including the `fvk`) are re-parsed
+    /// twice — once with the full parse (which derives the FVK) and once with the preverified
+    /// signing parse (which skips it) — then signed with the same `ask`, `sighash`, and an
+    /// identically-seeded RNG. The signatures must match, since a `spend_auth_sig` depends
+    /// only on `alpha`, `rk`, and `ask`, never on `fvk`.
+    #[test]
+    fn preverified_parse_signs_identically_to_full_parse() {
+        use super::{Action, Spend};
+        use rand::{rngs::StdRng, SeedableRng};
+
+        let bundle_version = BundleVersion::orchard_v2();
+        let mut rng = OsRng;
+
+        // Derive the spending key material (the seed-derived `ask` the signer uses).
+        let sk = SpendingKey::random(&mut rng);
+        let ask = SpendAuthorizingKey::from(&sk);
+        let fvk = FullViewingKey::from(&sk);
+        let recipient = fvk.address_at(0u32, Scope::External);
+
+        // Pretend we already received a note.
+        let value = NoteValue::from_raw(15_000);
+        let note = {
+            let rho = Rho::from_bytes(&pallas::Base::random(&mut rng).to_repr()).unwrap();
+            loop {
+                if let Some(note) = Note::from_parts(
+                    recipient,
+                    value,
+                    rho,
+                    RandomSeed::random(&mut rng, &rho),
+                    bundle_version.note_version(),
+                )
+                .into_option()
+                {
+                    break note;
+                }
+            }
+        };
+
+        // Single-leaf tree, for the witness/anchor.
+        let (anchor, merkle_path) = {
+            let cmx: ExtractedNoteCommitment = note.commitment().into();
+            let leaf = MerkleHashOrchard::from_cmx(&cmx);
+            let mut tree: ShardTree<MemoryShardStore<MerkleHashOrchard, u32>, 32, 16> =
+                ShardTree::new(MemoryShardStore::empty(), 100);
+            tree.append(
+                leaf,
+                Retention::Checkpoint {
+                    id: 0,
+                    marking: Marking::Marked,
+                },
+            )
+            .unwrap();
+            let root = tree.root_at_checkpoint_id(&0).unwrap().unwrap();
+            let position = tree.max_leaf_position(None).unwrap().unwrap();
+            let merkle_path = tree
+                .witness_at_checkpoint_id(position, &0)
+                .unwrap()
+                .unwrap();
+            assert_eq!(root, merkle_path.root(MerkleHashOrchard::from_cmx(&cmx)));
+            (root.into(), merkle_path)
+        };
+
+        // Creator + Constructor.
+        let mut builder = Builder::new(
+            BundleType::DEFAULT,
+            bundle_version,
+            bundle_version.default_flags(),
+            anchor,
+        )
+        .unwrap();
+        builder
+            .add_spend(fvk.clone(), note, merkle_path.into())
+            .unwrap();
+        builder
+            .add_output(None, recipient, NoteValue::from_raw(10_000), [0u8; 512])
+            .unwrap();
+        builder
+            .add_output(
+                Some(fvk.to_ovk(Scope::Internal)),
+                fvk.address_at(0u32, Scope::Internal),
+                NoteValue::from_raw(5_000),
+                [0u8; 512],
+            )
+            .unwrap();
+        let (mut pczt_bundle, _meta) = builder.build_for_pczt(&mut rng).unwrap();
+
+        // IO Finalizer sets the `alpha`/`rk` consistency needed for signing.
+        let sighash = [0u8; 32];
+        pczt_bundle.finalize_io(sighash, rng).unwrap();
+
+        // Find the real spend action (the one whose `ask` we hold) and capture the raw
+        // on-the-wire component bytes of its spend. The `fvk` IS present on the wire here,
+        // so the full parse will do the FVK derivation and the preverified signing parse
+        // will skip it.
+        let action = pczt_bundle
+            .actions()
+            .iter()
+            .find(|a| a.spend().value() == &Some(value))
+            .expect("the real spend is present");
+        let spend = action.spend();
+
+        // Sanity: this spend really carries an `fvk` on the wire (otherwise the test would
+        // be vacuous because both parses would skip the derivation).
+        assert!(
+            spend.fvk().is_some(),
+            "test precondition: the captured spend must carry an fvk on the wire",
+        );
+        // Sanity: `alpha` and a real (non-`None`) signature randomizer are present.
+        assert!(
+            spend.alpha().is_some(),
+            "alpha must be set after IO finalize"
+        );
+
+        // Raw component bytes (the same encoding `pczt::Bundle::serialize_from` produces).
+        let cv_net_bytes: [u8; 32] = action.cv_net().to_bytes();
+        let nf_bytes: [u8; 32] = spend.nullifier().to_bytes();
+        let rk_bytes: [u8; 32] = spend.rk().into();
+        let recipient_bytes = spend.recipient().map(|r| r.to_raw_address_bytes());
+        let value_raw = spend.value().map(|v| v.inner());
+        let rho_bytes = spend.rho().map(|rho| rho.to_bytes());
+        let rseed_bytes = spend.rseed().map(|rseed| *rseed.as_bytes());
+        let fvk_bytes = spend.fvk().as_ref().map(|fvk| fvk.to_bytes());
+        let witness_bytes = spend.witness().as_ref().map(|witness| {
+            (
+                u32::try_from(u64::from(witness.position())).unwrap(),
+                witness
+                    .auth_path()
+                    .iter()
+                    .map(|node| node.to_bytes())
+                    .collect::<alloc::vec::Vec<_>>()[..]
+                    .try_into()
+                    .expect("path is length 32"),
+            )
+        });
+        let alpha_bytes = spend.alpha().map(|alpha| alpha.to_repr());
+        let note_version = *spend.note_version();
+
+        // Build the spend's component bytes once, and a helper to parse with either path.
+        // The output half is irrelevant to signing but is required to assemble an `Action`;
+        // reuse the real output's bytes through the full output parse for both branches.
+        let output = action.output();
+        let build_output = || {
+            super::Output::parse(
+                *spend.nullifier(),
+                output.cmx().to_bytes(),
+                output.encrypted_note().epk_bytes,
+                output.encrypted_note().enc_ciphertext.to_vec(),
+                output.encrypted_note().out_ciphertext.to_vec(),
+                output.recipient().map(|r| r.to_raw_address_bytes()),
+                output.value().map(|v| v.inner()),
+                output.rseed().map(|rseed| *rseed.as_bytes()),
+                output.ock().as_ref().map(|ock| ock.0),
+                None,
+                output.user_address().clone(),
+                *output.note_version(),
+                output.proprietary().clone(),
+            )
+            .expect("output re-parses")
+        };
+        let rcv_bytes = action.rcv().as_ref().map(|rcv| rcv.to_bytes());
+
+        // === FULL parse path (derives the FVK) ===
+        let full_spend = Spend::parse(
+            nf_bytes,
+            rk_bytes,
+            None,
+            recipient_bytes,
+            value_raw,
+            rho_bytes,
+            rseed_bytes,
+            fvk_bytes,
+            witness_bytes,
+            alpha_bytes,
+            None,
+            None,
+            note_version,
+            alloc::collections::BTreeMap::new(),
+        )
+        .expect("full spend parse");
+        assert!(full_spend.fvk().is_some(), "full parse must derive the fvk",);
+        let mut full_action =
+            Action::parse(cv_net_bytes, full_spend, build_output(), rcv_bytes).unwrap();
+
+        // === PREVERIFIED SIGNING parse path (skips the FVK) ===
+        let preverified_spend = Spend::parse_preverified_for_signing(
+            nf_bytes,
+            rk_bytes,
+            None,
+            recipient_bytes,
+            value_raw,
+            rho_bytes,
+            rseed_bytes,
+            fvk_bytes,
+            witness_bytes,
+            alpha_bytes,
+            None,
+            None,
+            note_version,
+            alloc::collections::BTreeMap::new(),
+        )
+        .expect("preverified signing spend parse");
+        assert!(
+            preverified_spend.fvk().is_none(),
+            "preverified signing parse must omit the fvk",
+        );
+        let mut preverified_action = Action::parse_preverified_for_signing(
+            cv_net_bytes,
+            preverified_spend,
+            build_output(),
+            rcv_bytes,
+        )
+        .unwrap();
+
+        // Sign both with the SAME ask, sighash, and an identically-seeded RNG. RedPallas
+        // signing is randomized, so the RNGs must match for the signatures to be comparable.
+        let seed = [7u8; 32];
+        full_action
+            .sign(sighash, &ask, StdRng::from_seed(seed))
+            .expect("full-parsed action signs");
+        preverified_action
+            .sign(sighash, &ask, StdRng::from_seed(seed))
+            .expect("preverified signing action signs");
+
+        let full_sig: [u8; 64] = (&full_action
+            .spend()
+            .spend_auth_sig()
+            .clone()
+            .expect("full action signed"))
+            .into();
+        let preverified_sig: [u8; 64] = (&preverified_action
+            .spend()
+            .spend_auth_sig()
+            .clone()
+            .expect("preverified signing action signed"))
+            .into();
+
+        assert_eq!(
+            full_sig, preverified_sig,
+            "preverified signing signature must be byte-identical to the full-parsed signature",
+        );
+
+        // And both must verify against `rk` (defends against two matching-but-wrong sigs).
+        full_action
+            .apply_signature(
+                sighash,
+                redpallas::Signature::<SpendAuth>::from(preverified_sig),
+            )
+            .expect("the preverified signing signature verifies against the full action's rk");
+
+        // The one behavioural difference: the full parse rejects a malformed `fvk`, the
+        // preverified parse accepts it as `fvk: None` (sound per the invariant on that method).
+        let bad_fvk = Some([0xFFu8; 96]);
+        assert!(
+            matches!(
+                Spend::parse(
+                    nf_bytes,
+                    rk_bytes,
+                    None,
+                    recipient_bytes,
+                    value_raw,
+                    rho_bytes,
+                    rseed_bytes,
+                    bad_fvk,
+                    witness_bytes,
+                    alpha_bytes,
+                    None,
+                    None,
+                    note_version,
+                    alloc::collections::BTreeMap::new(),
+                ),
+                Err(super::ParseError::InvalidFullViewingKey)
+            ),
+            "the full parse must reject malformed fvk bytes",
+        );
+        let preverified_bad_fvk = Spend::parse_preverified_for_signing(
+            nf_bytes,
+            rk_bytes,
+            None,
+            recipient_bytes,
+            value_raw,
+            rho_bytes,
+            rseed_bytes,
+            bad_fvk,
+            witness_bytes,
+            alpha_bytes,
+            None,
+            None,
+            note_version,
+            alloc::collections::BTreeMap::new(),
+        )
+        .expect("the preverified signing parse ignores malformed fvk bytes");
+        assert!(
+            preverified_bad_fvk.fvk().is_none(),
+            "the preverified signing parse must leave fvk None even when the wire fvk bytes are malformed",
+        );
+    }
+
     #[test]
     fn create_proof_rejects_identity_rk() {
         let pk = ProvingKey::build(OrchardCircuitVersion::FixedPostNu6_2);

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -1034,13 +1034,8 @@ mod tests {
             preverified_spend.fvk().is_none(),
             "preverified signing parse must omit the fvk",
         );
-        let mut preverified_action = Action::parse_preverified_for_signing(
-            cv_net_bytes,
-            preverified_spend,
-            build_output(),
-            rcv_bytes,
-        )
-        .unwrap();
+        let mut preverified_action =
+            Action::parse(cv_net_bytes, preverified_spend, build_output(), rcv_bytes).unwrap();
 
         // Sign both with the SAME ask, sighash, and an identically-seeded RNG. RedPallas
         // signing is randomized, so the RNGs must match for the signatures to be comparable.
@@ -1123,39 +1118,6 @@ mod tests {
         assert!(
             preverified_bad_fvk.fvk().is_none(),
             "the preverified signing parse must leave fvk None even when the wire fvk bytes are malformed",
-        );
-    }
-
-    /// [`super::Bundle::parse_preverified_for_signing`] is a pure delegation to
-    /// [`super::Bundle::parse`] — the FVK elision lives entirely in the per-spend parse — so
-    /// on identical bundle-level bytes the two entry points must agree. An empty action list
-    /// keeps this focused on the bundle-level path.
-    #[test]
-    fn bundle_preverified_parse_delegates_to_full_parse() {
-        use super::Bundle;
-
-        let full = Bundle::parse(
-            alloc::vec::Vec::new(),
-            0,
-            BundleVersion::orchard_v2(),
-            (0, false),
-            [0u8; 32],
-            None,
-            None,
-        );
-        let preverified = Bundle::parse_preverified_for_signing(
-            alloc::vec::Vec::new(),
-            0,
-            BundleVersion::orchard_v2(),
-            (0, false),
-            [0u8; 32],
-            None,
-            None,
-        );
-        assert_eq!(
-            full.is_ok(),
-            preverified.is_ok(),
-            "preverified bundle parse must delegate to the full bundle parse",
         );
     }
 

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -1126,6 +1126,39 @@ mod tests {
         );
     }
 
+    /// [`super::Bundle::parse_preverified_for_signing`] is a pure delegation to
+    /// [`super::Bundle::parse`] — the FVK elision lives entirely in the per-spend parse — so
+    /// on identical bundle-level bytes the two entry points must agree. An empty action list
+    /// keeps this focused on the bundle-level path.
+    #[test]
+    fn bundle_preverified_parse_delegates_to_full_parse() {
+        use super::Bundle;
+
+        let full = Bundle::parse(
+            alloc::vec::Vec::new(),
+            0,
+            BundleVersion::orchard_v2(),
+            (0, false),
+            [0u8; 32],
+            None,
+            None,
+        );
+        let preverified = Bundle::parse_preverified_for_signing(
+            alloc::vec::Vec::new(),
+            0,
+            BundleVersion::orchard_v2(),
+            (0, false),
+            [0u8; 32],
+            None,
+            None,
+        );
+        assert_eq!(
+            full.is_ok(),
+            preverified.is_ok(),
+            "preverified bundle parse must delegate to the full bundle parse",
+        );
+    }
+
     #[test]
     fn create_proof_rejects_identity_rk() {
         let pk = ProvingKey::build(OrchardCircuitVersion::FixedPostNu6_2);

--- a/src/pczt/parse.rs
+++ b/src/pczt/parse.rs
@@ -29,10 +29,6 @@ impl Bundle {
     /// See [`BundleVersion`] for the choice of `bundle_version`.
     ///
     /// `value_sum` is represented as `(magnitude, is_negative)`.
-    ///
-    /// The `actions` must have been parsed via [`Action::parse`] (the full parse). Use
-    /// this for the Verifier, Prover, Updater, or any caller that needs to validate or
-    /// preserve the wire `fvk`.
     pub fn parse(
         actions: Vec<Action>,
         flags: u8,
@@ -85,40 +81,10 @@ impl Bundle {
             bsk,
         })
     }
-
-    /// Parses a PCZT bundle for a preverified signing pass, from `actions` parsed via
-    /// [`Action::parse_preverified_for_signing`].
-    ///
-    /// Bundle-level fields are parsed identically to [`Bundle::parse`]; the only difference
-    /// is that each action's spend omits its [`FullViewingKey`]. See
-    /// [`Spend::parse_preverified_for_signing`] for the invariant and usage constraints.
-    pub fn parse_preverified_for_signing(
-        actions: Vec<Action>,
-        flags: u8,
-        bundle_version: BundleVersion,
-        value_sum: (u64, bool),
-        anchor: [u8; 32],
-        zkproof: Option<Vec<u8>>,
-        bsk: Option<[u8; 32]>,
-    ) -> Result<Self, ParseError> {
-        // Bundle-level parsing does no FVK work; the elision is entirely in the spend parse.
-        Self::parse(
-            actions,
-            flags,
-            bundle_version,
-            value_sum,
-            anchor,
-            zkproof,
-            bsk,
-        )
-    }
 }
 
 impl Action {
     /// Parses a PCZT action from its component parts.
-    ///
-    /// This performs the full parse: the `spend` must have been parsed via
-    /// [`Spend::parse`], which validates and preserves the wire `fvk` when present.
     pub fn parse(
         cv_net: [u8; 32],
         spend: Spend,
@@ -143,22 +109,6 @@ impl Action {
             output,
             rcv,
         })
-    }
-
-    /// Parses a PCZT action for a preverified signing pass, skipping the spend's
-    /// [`FullViewingKey`] derivation.
-    ///
-    /// Identical to [`Action::parse`] except that `spend` must have been parsed via
-    /// [`Spend::parse_preverified_for_signing`] (leaving `spend.fvk` as `None`); see that
-    /// method for the invariant and usage constraints.
-    pub fn parse_preverified_for_signing(
-        cv_net: [u8; 32],
-        spend: Spend,
-        output: Output,
-        rcv: Option<[u8; 32]>,
-    ) -> Result<Self, ParseError> {
-        // The FVK skip happens inside the spend parse, not here, so reuse `parse`.
-        Self::parse(cv_net, spend, output, rcv)
     }
 }
 

--- a/src/pczt/parse.rs
+++ b/src/pczt/parse.rs
@@ -29,6 +29,10 @@ impl Bundle {
     /// See [`BundleVersion`] for the choice of `bundle_version`.
     ///
     /// `value_sum` is represented as `(magnitude, is_negative)`.
+    ///
+    /// The `actions` must have been parsed via [`Action::parse`] (the full parse). Use
+    /// this for the Verifier, Prover, Updater, or any caller that needs to validate or
+    /// preserve the wire `fvk`.
     pub fn parse(
         actions: Vec<Action>,
         flags: u8,
@@ -81,10 +85,40 @@ impl Bundle {
             bsk,
         })
     }
+
+    /// Parses a PCZT bundle for a preverified signing pass, from `actions` parsed via
+    /// [`Action::parse_preverified_for_signing`].
+    ///
+    /// Bundle-level fields are parsed identically to [`Bundle::parse`]; the only difference
+    /// is that each action's spend omits its [`FullViewingKey`]. See
+    /// [`Spend::parse_preverified_for_signing`] for the invariant and usage constraints.
+    pub fn parse_preverified_for_signing(
+        actions: Vec<Action>,
+        flags: u8,
+        bundle_version: BundleVersion,
+        value_sum: (u64, bool),
+        anchor: [u8; 32],
+        zkproof: Option<Vec<u8>>,
+        bsk: Option<[u8; 32]>,
+    ) -> Result<Self, ParseError> {
+        // Bundle-level parsing does no FVK work; the elision is entirely in the spend parse.
+        Self::parse(
+            actions,
+            flags,
+            bundle_version,
+            value_sum,
+            anchor,
+            zkproof,
+            bsk,
+        )
+    }
 }
 
 impl Action {
     /// Parses a PCZT action from its component parts.
+    ///
+    /// This performs the full parse: the `spend` must have been parsed via
+    /// [`Spend::parse`], which validates and preserves the wire `fvk` when present.
     pub fn parse(
         cv_net: [u8; 32],
         spend: Spend,
@@ -110,10 +144,35 @@ impl Action {
             rcv,
         })
     }
+
+    /// Parses a PCZT action for a preverified signing pass, skipping the spend's
+    /// [`FullViewingKey`] derivation.
+    ///
+    /// Identical to [`Action::parse`] except that `spend` must have been parsed via
+    /// [`Spend::parse_preverified_for_signing`] (leaving `spend.fvk` as `None`); see that
+    /// method for the invariant and usage constraints.
+    pub fn parse_preverified_for_signing(
+        cv_net: [u8; 32],
+        spend: Spend,
+        output: Output,
+        rcv: Option<[u8; 32]>,
+    ) -> Result<Self, ParseError> {
+        // The FVK skip happens inside the spend parse, not here, so reuse `parse`.
+        Self::parse(cv_net, spend, output, rcv)
+    }
 }
 
 impl Spend {
     /// Parses a PCZT spend from its component parts.
+    ///
+    /// This is the **full** parse used when the caller needs to validate or preserve the
+    /// wire `fvk`: when `fvk` is provided, it derives the [`FullViewingKey`] via
+    /// [`FullViewingKey::from_bytes`] (a relatively expensive operation involving Pallas
+    /// point decompression and two `commit_ivk` Sinsemilla hashes).
+    ///
+    /// The byte-for-byte behaviour of this method is part of the full verification contract
+    /// and must not change. The preverified signing variant lives in
+    /// [`Spend::parse_preverified_for_signing`].
     #[allow(clippy::too_many_arguments)]
     pub fn parse(
         nullifier: [u8; 32],
@@ -130,6 +189,108 @@ impl Spend {
         dummy_sk: Option<[u8; 32]>,
         note_version: NoteVersion,
         proprietary: BTreeMap<String, Vec<u8>>,
+    ) -> Result<Self, ParseError> {
+        Self::parse_inner(
+            nullifier,
+            rk,
+            spend_auth_sig,
+            recipient,
+            value,
+            rho,
+            rseed,
+            fvk,
+            witness,
+            alpha,
+            zip32_derivation,
+            dummy_sk,
+            note_version,
+            proprietary,
+            false,
+        )
+    }
+
+    /// Parses a PCZT spend for a preverified signing pass, deliberately skipping the
+    /// [`FullViewingKey`] derivation.
+    ///
+    /// The resulting `Spend` has `fvk: None` even when an `fvk` was present on the wire. It
+    /// retains everything the spend-authorization signature depends on (`rk`, `alpha`, and
+    /// the nullifier), so [`Action::sign`](super::Action::sign) produces a byte-identical
+    /// `spend_auth_sig` to one produced from a full parse. Unlike [`Spend::parse`], the
+    /// on-wire `fvk` bytes are not validated: a malformed `fvk` still parses (as `fvk: None`),
+    /// making this the one respect in which the parse is more permissive.
+    ///
+    /// # Invariant (why this is sound)
+    ///
+    /// Skipping FVK derivation is valid because [`Action::sign`](super::Action::sign) never
+    /// reads `spend.fvk` (only `alpha`, `rk`, and the seed-derived `ask`), and because callers
+    /// MUST have already run the full verifier checks (`verify_nullifier` / `verify_rk`) over
+    /// the identical PCZT bytes before signing — which do derive and check the FVK (including
+    /// the malformed-`fvk` case above). The signer therefore need not re-derive it.
+    ///
+    /// A `Spend` produced by this method must not be:
+    /// - passed to the Verifier check path
+    ///   ([`verify_nullifier`](super::Spend::verify_nullifier),
+    ///   [`verify_rk`](super::Spend::verify_rk)): with `fvk: None` it can no longer cross-check
+    ///   the on-wire `fvk`, and dummy-note verification fails;
+    /// - passed to the Prover, which requires `fvk`;
+    /// - re-serialized where the `fvk` field must be preserved, as it would be dropped.
+    #[allow(clippy::too_many_arguments)]
+    pub fn parse_preverified_for_signing(
+        nullifier: [u8; 32],
+        rk: [u8; 32],
+        spend_auth_sig: Option<[u8; 64]>,
+        recipient: Option<[u8; 43]>,
+        value: Option<u64>,
+        rho: Option<[u8; 32]>,
+        rseed: Option<[u8; 32]>,
+        fvk: Option<[u8; 96]>,
+        witness: Option<(u32, [[u8; 32]; NOTE_COMMITMENT_TREE_DEPTH])>,
+        alpha: Option<[u8; 32]>,
+        zip32_derivation: Option<Zip32Derivation>,
+        dummy_sk: Option<[u8; 32]>,
+        note_version: NoteVersion,
+        proprietary: BTreeMap<String, Vec<u8>>,
+    ) -> Result<Self, ParseError> {
+        Self::parse_inner(
+            nullifier,
+            rk,
+            spend_auth_sig,
+            recipient,
+            value,
+            rho,
+            rseed,
+            fvk,
+            witness,
+            alpha,
+            zip32_derivation,
+            dummy_sk,
+            note_version,
+            proprietary,
+            true,
+        )
+    }
+
+    /// The shared body of [`Spend::parse`] and [`Spend::parse_preverified_for_signing`].
+    /// With `skip_fvk` false the on-wire `fvk` is derived via [`FullViewingKey::from_bytes`];
+    /// with `skip_fvk` true it is ignored and the parsed `fvk` is left `None`. Every other
+    /// field is parsed identically.
+    #[allow(clippy::too_many_arguments)]
+    fn parse_inner(
+        nullifier: [u8; 32],
+        rk: [u8; 32],
+        spend_auth_sig: Option<[u8; 64]>,
+        recipient: Option<[u8; 43]>,
+        value: Option<u64>,
+        rho: Option<[u8; 32]>,
+        rseed: Option<[u8; 32]>,
+        fvk: Option<[u8; 96]>,
+        witness: Option<(u32, [[u8; 32]; NOTE_COMMITMENT_TREE_DEPTH])>,
+        alpha: Option<[u8; 32]>,
+        zip32_derivation: Option<Zip32Derivation>,
+        dummy_sk: Option<[u8; 32]>,
+        note_version: NoteVersion,
+        proprietary: BTreeMap<String, Vec<u8>>,
+        skip_fvk: bool,
     ) -> Result<Self, ParseError> {
         let nullifier = Nullifier::from_bytes(&nullifier)
             .into_option()
@@ -168,9 +329,14 @@ impl Spend {
             })
             .transpose()?;
 
-        let fvk = fvk
-            .map(|fvk| FullViewingKey::from_bytes(&fvk).ok_or(ParseError::InvalidFullViewingKey))
-            .transpose()?;
+        // Skip the (relatively expensive) FVK derivation in the preverified signing parse;
+        // see `parse_preverified_for_signing` for why it is sound. The full parse derives it.
+        let fvk = if skip_fvk {
+            None
+        } else {
+            fvk.map(|fvk| FullViewingKey::from_bytes(&fvk).ok_or(ParseError::InvalidFullViewingKey))
+                .transpose()?
+        };
 
         let witness = witness
             .map(|(position, auth_path)| {

--- a/src/pczt/parse.rs
+++ b/src/pczt/parse.rs
@@ -112,6 +112,14 @@ impl Action {
     }
 }
 
+/// Whether [`Spend::parse_inner`] derives the on-wire `fvk` (the full parse) or ignores it,
+/// leaving the parsed `fvk` as `None` (the preverified signing parse). See
+/// [`Spend::parse_preverified_for_signing`] for why skipping is sound.
+enum FvkHandling {
+    Derive,
+    Skip,
+}
+
 impl Spend {
     /// Parses a PCZT spend from its component parts.
     ///
@@ -155,7 +163,7 @@ impl Spend {
             dummy_sk,
             note_version,
             proprietary,
-            false,
+            FvkHandling::Derive,
         )
     }
 
@@ -216,14 +224,14 @@ impl Spend {
             dummy_sk,
             note_version,
             proprietary,
-            true,
+            FvkHandling::Skip,
         )
     }
 
     /// The shared body of [`Spend::parse`] and [`Spend::parse_preverified_for_signing`].
-    /// With `skip_fvk` false the on-wire `fvk` is derived via [`FullViewingKey::from_bytes`];
-    /// with `skip_fvk` true it is ignored and the parsed `fvk` is left `None`. Every other
-    /// field is parsed identically.
+    /// With [`FvkHandling::Derive`] the on-wire `fvk` is derived via
+    /// [`FullViewingKey::from_bytes`]; with [`FvkHandling::Skip`] it is ignored and the
+    /// parsed `fvk` is left `None`. Every other field is parsed identically.
     #[allow(clippy::too_many_arguments)]
     fn parse_inner(
         nullifier: [u8; 32],
@@ -240,7 +248,7 @@ impl Spend {
         dummy_sk: Option<[u8; 32]>,
         note_version: NoteVersion,
         proprietary: BTreeMap<String, Vec<u8>>,
-        skip_fvk: bool,
+        fvk_handling: FvkHandling,
     ) -> Result<Self, ParseError> {
         let nullifier = Nullifier::from_bytes(&nullifier)
             .into_option()
@@ -281,11 +289,13 @@ impl Spend {
 
         // Skip the (relatively expensive) FVK derivation in the preverified signing parse;
         // see `parse_preverified_for_signing` for why it is sound. The full parse derives it.
-        let fvk = if skip_fvk {
-            None
-        } else {
-            fvk.map(|fvk| FullViewingKey::from_bytes(&fvk).ok_or(ParseError::InvalidFullViewingKey))
-                .transpose()?
+        let fvk = match fvk_handling {
+            FvkHandling::Skip => None,
+            FvkHandling::Derive => fvk
+                .map(|fvk| {
+                    FullViewingKey::from_bytes(&fvk).ok_or(ParseError::InvalidFullViewingKey)
+                })
+                .transpose()?,
         };
 
         let witness = witness


### PR DESCRIPTION
## Summary

Adds preverified PCZT signing parse entry points: `Bundle::parse_preverified_for_signing`, `Action::parse_preverified_for_signing`, and `Spend::parse_preverified_for_signing`. They behave identically to the existing `parse` methods except that the spend parse skips `FullViewingKey` derivation and does not validate or preserve the wire `fvk`.

The full `parse` methods are unchanged and remain the default for the Verifier, Prover, Updater, and any caller that needs to validate or retain `fvk`. The preverified signing path is only for a signing pass after the caller has already run the full Verifier checks over the exact same PCZT bytes. `Action::sign` reads only `alpha`, `rk`, and the seed-derived `ask`, never `fvk`, so a preverified-signing parsed action produces a byte-identical `spend_auth_sig`.

## Motivation

The consumer is a Keystone that signs Orchard PCZTs after a full verify pass, where `FullViewingKey::from_bytes` dominates signing-time parse and is redundant with the review pass that already derived and checked the FVK.

## Testing

- `cargo fmt --all -- --check`
- `cargo test preverified_parse_signs_identically_to_full_parse --locked`
- `cargo test --all-features preverified_parse_signs_identically_to_full_parse --locked`

The test builds a real Orchard action, re-parses its wire bytes through both the full and preverified signing paths, signs both with the same `ask`, `sighash`, and seeded RNG, and asserts the two `spend_auth_sig` values are byte-identical. It also verifies the preverified signing signature against the full action’s `rk`, and checks that a malformed on-wire `fvk` still parses as `None` on the preverified signing path after full parse rejects it.
