### PR TITLE
Add PCZT recompute helpers and opt-in unpadded bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,13 @@ Existing callers keep the current behavior by constructing bundles with
   - `orchard::pczt::IoFinalizerError::CrossAddressRestriction`
   - `orchard::pczt::ProverError::DisallowedCrossAddressTransfer`, wrapping the
     underlying `orchard::pczt::VerifyError`.
+- `orchard::pczt::recompute`, byte-level helpers that recompute an action's derived
+  fields (`cv_net`, `nullifier`, `rk`, `cmx`, and `ephemeral_key` together with
+  `enc_ciphertext` under a caller-supplied memo) from the note component fields, so a
+  PCZT producer can omit those fields from the serialized encoding and the receiver can
+  repopulate them byte-identically before parsing.
+- `orchard::pczt::ParseError::Recompute`, wrapping the `orchard::pczt::VerifyError` from
+  a failed recomputation of an omitted derived field.
 
 ### Changed
 - Bundle construction now requires an explicit `BundleVersion` and `Flags`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,10 @@ Existing callers keep the current behavior by constructing bundles with
     `BundleVersion`.
   - `orchard::builder::BundleMetadata::output_action_index` now indexes the plain
     outputs first, followed by the wallet-controlled change outputs.
+- `orchard::builder::BundleType::Transactional` now carries a `pad_to_minimum` flag;
+  when `false`, the bundle is not padded to the 2-action minimum and contains exactly
+  the requested actions (at least one, if `bundle_required` is set).
+  `BundleType::DEFAULT` keeps padding enabled.
 - For `BundleVersion::orchard_v3()`, the builder constructs
   withdrawal/change bundles that disable cross-address transfers: every action's
   output is addressed to the expanded receiver of the note it spends. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,9 +80,8 @@ Existing callers keep the current behavior by constructing bundles with
 - New builder errors:
   - `orchard::builder::BuildError::{CrossAddressDisabled, InvalidNoteVersion, UnrepresentableFlags, CoinbaseSpendsEnabled}`
   - `orchard::builder::OutputError::{SpendsDisabled, CrossAddressDisabled, RecipientNotOwned}`
-- `orchard::builder::BundleType::DEFAULT_UNPADDED`, a transactional bundle type that
-  disables padding for transactions whose shape is already public (e.g. pool
-  migrations).
+- `orchard::builder::BundleType::UNPADDED`, a transactional bundle type that disables
+  padding for transactions whose shape is already public (e.g. pool migrations).
 - `orchard::builder::Builder::bundle_type`, returning the `BundleType` the builder
   was constructed with.
 - Ironwood and note-version APIs:
@@ -157,9 +156,12 @@ Existing callers keep the current behavior by constructing bundles with
     `BundleVersion`.
   - `orchard::builder::BundleMetadata::output_action_index` now indexes the plain
     outputs first, followed by the wallet-controlled change outputs.
-- `orchard::builder::BundleType::Transactional` now carries a `pad_to_minimum` flag;
-  when `false`, the bundle is not padded to the 2-action minimum and contains exactly
-  the requested actions (at least one, if `bundle_required` is set).
+- `orchard::builder::BundleType::Transactional` now carries a required
+  `pad_to_minimum: Option<u8>` field, so callers that directly construct or
+  pattern-match this public enum variant must update their code. When set to
+  `Some(1)`, the bundle is not padded to the 2-action minimum and contains
+  exactly the requested actions (at least one, if `bundle_required` is set).
+  When set to `None`, the default 2-action minimum is used.
   `BundleType::DEFAULT` keeps the existing padded behavior.
 - For `BundleVersion::orchard_v3()`, the builder constructs
   withdrawal/change bundles that disable cross-address transfers: every action's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,11 @@ Existing callers keep the current behavior by constructing bundles with
 - New builder errors:
   - `orchard::builder::BuildError::{CrossAddressDisabled, InvalidNoteVersion, UnrepresentableFlags, CoinbaseSpendsEnabled}`
   - `orchard::builder::OutputError::{SpendsDisabled, CrossAddressDisabled, RecipientNotOwned}`
+- `orchard::builder::BundleType::DEFAULT_UNPADDED`, a transactional bundle type that
+  disables padding for transactions whose shape is already public (e.g. pool
+  migrations).
+- `orchard::builder::Builder::bundle_type`, returning the `BundleType` the builder
+  was constructed with.
 - Ironwood and note-version APIs:
   - `orchard::NoteVersion`, the note plaintext version selector, with variants
     `V2` (the ZIP 212 Orchard note plaintext format) and `V3` (the
@@ -155,7 +160,7 @@ Existing callers keep the current behavior by constructing bundles with
 - `orchard::builder::BundleType::Transactional` now carries a `pad_to_minimum` flag;
   when `false`, the bundle is not padded to the 2-action minimum and contains exactly
   the requested actions (at least one, if `bundle_required` is set).
-  `BundleType::DEFAULT` uses this unpadded transactional behavior.
+  `BundleType::DEFAULT` keeps the existing padded behavior.
 - For `BundleVersion::orchard_v3()`, the builder constructs
   withdrawal/change bundles that disable cross-address transfers: every action's
   output is addressed to the expanded receiver of the note it spends. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,7 +155,7 @@ Existing callers keep the current behavior by constructing bundles with
 - `orchard::builder::BundleType::Transactional` now carries a `pad_to_minimum` flag;
   when `false`, the bundle is not padded to the 2-action minimum and contains exactly
   the requested actions (at least one, if `bundle_required` is set).
-  `BundleType::DEFAULT` keeps padding enabled.
+  `BundleType::DEFAULT` uses this unpadded transactional behavior.
 - For `BundleVersion::orchard_v3()`, the builder constructs
   withdrawal/change bundles that disable cross-address transfers: every action's
   output is addressed to the expanded receiver of the note it spends. The

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -34,53 +34,63 @@ use {
     nonempty::NonEmpty,
 };
 
-const MIN_ACTIONS: usize = 2;
+const DEFAULT_MIN_ACTIONS: u8 = 2;
 
 /// An enumeration of rules for Orchard bundle construction.
 ///
-/// This selects only the construction discipline; the bundle's [`Flags`] are supplied separately
-/// to the builder (see [`Builder::new`] and [`BundleVersion::default_flags`]).
+/// This selects only the construction discipline; the bundle's [`Flags`] are
+/// supplied separately to the builder (see [`Builder::new`] and
+/// [`BundleVersion::default_flags`]).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BundleType {
-    /// A transactional bundle is padded, when `pad_to_minimum` is set, to contain at least
-    /// 2 actions, irrespective of whether any genuine actions are required.
+    /// A transactional bundle is padded to contain at least the configured
+    /// `pad_to_minimum` actions, defaulting to 2 actions when
+    /// `pad_to_minimum` is [`None`].
     Transactional {
-        /// A flag that, when set to `true`, indicates that a bundle should be produced even if no
-        /// spends or outputs have been added to the bundle; in such a circumstance, all of the
-        /// actions in the resulting bundle will be dummies.
+        /// A flag that, when set to `true`, indicates that a bundle should be
+        /// produced even if no spends or outputs have been added to the bundle;
+        /// in such a circumstance, all of the actions in the resulting bundle
+        /// will be dummies.
         bundle_required: bool,
-        /// A flag that, when set to `false`, disables padding of the bundle to the 2-action
-        /// minimum: the bundle contains exactly the requested actions (at least one, if
+        /// The minimum number of actions to pad the transaction to.
+        ///
+        /// If this is [`None`], the default 2-action minimum is used. Set this
+        /// to `Some(1)` for transactions whose shape is already public: the
+        /// bundle then contains exactly the requested actions (at least one, if
         /// `bundle_required` is set). One-action bundles are consensus-valid
-        /// ([`BundleType::Coinbase`] bundles are never padded); the minimum exists to improve
-        /// indistinguishability, so disabling it lets the action count reveal the
-        /// transaction shape.
-        pad_to_minimum: bool,
+        /// ([`BundleType::Coinbase`] bundles are never padded); the default minimum
+        /// exists to improve indistinguishability, so reducing it lets the action
+        /// count reveal the transaction shape.
+        pad_to_minimum: Option<u8>,
     },
-    /// A coinbase bundle performs no padding and requires the bundle's flags to disable spends.
+    /// A coinbase bundle performs no padding and requires the bundle's flags to
+    /// disable spends.
     ///
-    /// Since coinbase transactions have `enableSpends = 0`, every spend must be a dummy. Coinbase
-    /// transactions are not otherwise any different wrt cross-address restrictions from other
-    /// transactions that have dummy inputs.
+    /// Since coinbase transactions have `enableSpends = 0`, every spend must be
+    /// a dummy. Coinbase transactions are not otherwise any different wrt
+    /// cross-address restrictions from other transactions that have dummy
+    /// inputs.
     Coinbase,
 }
 
 impl BundleType {
-    /// The default bundle type: a padded transactional bundle that is not required to be
-    /// produced if no spends or outputs have been added.
+    /// The default bundle type: a transactional bundle padded to the default
+    /// minimum action count, and not required to be produced if no spends or
+    /// outputs have been added.
     pub const DEFAULT: BundleType = BundleType::Transactional {
         bundle_required: false,
-        pad_to_minimum: true,
+        pad_to_minimum: Some(DEFAULT_MIN_ACTIONS),
     };
 
-    /// [`BundleType::DEFAULT`] without padding: the bundle contains exactly the requested
-    /// actions. Intended for transactions whose shape is already public — such as pool
-    /// migrations, where the per-pool value balances reveal the transfer — since the
-    /// action count reveals the transaction shape (see
+    /// Unpadded transactional bundle: the bundle is padded only to the
+    /// one-action consensus minimum, so it contains exactly the requested
+    /// actions. Intended for transactions whose shape is already public — such
+    /// as pool migrations, where the per-pool value balances reveal the
+    /// transfer — since the action count reveals the transaction shape (see
     /// [`BundleType::Transactional::pad_to_minimum`]).
-    pub const DEFAULT_UNPADDED: BundleType = BundleType::Transactional {
+    pub const UNPADDED: BundleType = BundleType::Transactional {
         bundle_required: false,
-        pad_to_minimum: false,
+        pad_to_minimum: Some(1),
     };
 
     /// Returns the number of logical actions that the builder will produce in constructing a bundle
@@ -125,7 +135,12 @@ impl BundleType {
                 } else if !flags.outputs_enabled() && num_outputs > 0 {
                     Err("Outputs are disabled, so num_outputs must be zero")
                 } else {
-                    let min_actions = if *pad_to_minimum { MIN_ACTIONS } else { 1 };
+                    let mut min_actions =
+                        usize::from(pad_to_minimum.unwrap_or(DEFAULT_MIN_ACTIONS));
+                    if *bundle_required {
+                        min_actions = core::cmp::max(min_actions, 1);
+                    }
+
                     Ok(if *bundle_required || num_requested_actions > 0 {
                         core::cmp::max(num_requested_actions, min_actions)
                     } else {
@@ -1851,6 +1866,7 @@ mod tests {
 
     use super::{
         bundle, BuildError, Builder, ChangeInfo, MaybeSigned, OutputError, OutputInfo, SpendInfo,
+        DEFAULT_MIN_ACTIONS,
     };
     use crate::{
         builder::BundleType,
@@ -1882,36 +1898,51 @@ mod tests {
     fn transactional(bundle_required: bool) -> BundleType {
         BundleType::Transactional {
             bundle_required,
-            pad_to_minimum: true,
+            pad_to_minimum: None,
         }
     }
 
     #[test]
     fn num_actions_respects_pad_to_minimum() {
         let padded = transactional(false);
+        let explicitly_padded = BundleType::Transactional {
+            bundle_required: false,
+            pad_to_minimum: Some(DEFAULT_MIN_ACTIONS),
+        };
+        let padded_to_three = BundleType::Transactional {
+            bundle_required: false,
+            pad_to_minimum: Some(3),
+        };
         let unpadded = BundleType::Transactional {
             bundle_required: false,
-            pad_to_minimum: false,
+            pad_to_minimum: Some(1),
+        };
+        let required_no_padding = BundleType::Transactional {
+            bundle_required: true,
+            pad_to_minimum: Some(0),
         };
         let required_unpadded = BundleType::Transactional {
             bundle_required: true,
-            pad_to_minimum: false,
+            pad_to_minimum: Some(1),
         };
 
         // Cross-address transfers enabled: requested actions = max(spends, outputs).
         let flags = BundleVersion::ironwood_v3().default_flags();
         assert_eq!(padded.num_actions(flags, 0, 1), Ok(2));
+        assert_eq!(explicitly_padded.num_actions(flags, 0, 1), Ok(2));
+        assert_eq!(padded_to_three.num_actions(flags, 0, 1), Ok(3));
         assert_eq!(unpadded.num_actions(flags, 0, 1), Ok(1));
         assert_eq!(BundleType::DEFAULT.num_actions(flags, 0, 1), Ok(2));
-        assert_eq!(BundleType::DEFAULT_UNPADDED.num_actions(flags, 0, 1), Ok(1));
+        assert_eq!(BundleType::UNPADDED.num_actions(flags, 0, 1), Ok(1));
         assert_eq!(unpadded.num_actions(flags, 2, 3), Ok(3));
         assert_eq!(unpadded.num_actions(flags, 0, 0), Ok(0));
         // `bundle_required` still guarantees a bundle exists: a single all-dummy action.
+        assert_eq!(required_no_padding.num_actions(flags, 0, 0), Ok(1));
         assert_eq!(required_unpadded.num_actions(flags, 0, 0), Ok(1));
 
         let flags = BundleVersion::orchard_v2().default_flags();
         assert_eq!(BundleType::DEFAULT.num_actions(flags, 0, 1), Ok(2));
-        assert_eq!(BundleType::DEFAULT_UNPADDED.num_actions(flags, 0, 1), Ok(1));
+        assert_eq!(BundleType::UNPADDED.num_actions(flags, 0, 1), Ok(1));
 
         // Cross-address transfers disabled: requested actions = spends + outputs.
         let flags = BundleVersion::orchard_v3().default_flags();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -418,8 +418,8 @@ pub struct OutputInfo {
     note_version: NoteVersion,
     /// When set, `build` fills `enc_ciphertext` with random bytes instead of encrypting the
     /// note to `recipient`. This is used only for the zero-valued output that a builder with
-    /// cross-address actions disabled pairs with a real spend, which is addressed to the
-    /// spent note's own receiver. A real ciphertext there would trial-decrypt under that
+    /// cross-address actions disabled pairs with a real external-scope spend, which is addressed
+    /// to the spent note's own receiver. A real ciphertext there would trial-decrypt under that
     /// receiver's incoming viewing key in the same action that carries the spend's nullifier,
     /// letting anyone who holds the ivk -- including a quantum adversary who recovered it from
     /// the published address -- detect the spend. The note and its commitment are unchanged.
@@ -453,16 +453,22 @@ impl OutputInfo {
     /// Constructs the zero-valued output that a builder with cross-address actions
     /// disabled pairs with a real spend.
     ///
-    /// `recipient` is the spent note's own receiver, so the output's `enc_ciphertext` is
-    /// randomized rather than encrypted to it (see the `randomized_ciphertext` field).
-    fn fabricated_for_spend(note_version: NoteVersion, recipient: Address) -> Self {
+    /// `recipient` is the spent note's own receiver. For external-scope spends, the output's
+    /// `enc_ciphertext` is randomized rather than encrypted to it (see the
+    /// `randomized_ciphertext` field). Internal-scope spends do not have the same external-address
+    /// exposure, so the deterministic ciphertext remains recomputable.
+    fn fabricated_for_spend(
+        note_version: NoteVersion,
+        recipient: Address,
+        spent_scope: Scope,
+    ) -> Self {
         Self {
             ovk: None,
             recipient,
             value: NoteValue::ZERO,
             memo: [0u8; 512],
             note_version,
-            randomized_ciphertext: true,
+            randomized_ciphertext: matches!(spent_scope, Scope::External),
         }
     }
 
@@ -818,11 +824,12 @@ impl Builder {
     /// the given note.
     ///
     /// In a bundle that disables cross-address transfers, each spend is paired with a
-    /// fabricated zero-valued output addressed to the spent note's own receiver. That output's
-    /// note ciphertext is randomized rather than encrypted to the receiver, so it is
-    /// undecryptable: the owning wallet does not see it when scanning, and no holder of the
-    /// receiver's incoming viewing key -- including a quantum adversary who recovered it from
-    /// the published address -- can use it to detect the spend.
+    /// fabricated zero-valued output addressed to the spent note's own receiver. For
+    /// external-scope spends, that output's note ciphertext is randomized rather than encrypted
+    /// to the receiver, so it is undecryptable: the owning wallet does not see it when scanning,
+    /// and no holder of the receiver's incoming viewing key -- including a quantum adversary who
+    /// recovered it from the published address -- can use it to detect the spend. Internal-scope
+    /// spends do not need this randomization.
     ///
     /// [`MerkleHashOrchard`]: crate::tree::MerkleHashOrchard
     pub fn add_spend(
@@ -1228,7 +1235,8 @@ fn build_bundle<B, R: RngCore>(
         let mut pairs = Vec::with_capacity(num_actions);
 
         for (spend_idx, spend) in spends.into_iter().enumerate() {
-            let output = OutputInfo::fabricated_for_spend(note_version, spend.note.recipient());
+            let output =
+                OutputInfo::fabricated_for_spend(note_version, spend.note.recipient(), spend.scope);
             pairs.push((Some(spend_idx), None, spend, output));
         }
 
@@ -2177,10 +2185,11 @@ mod tests {
         assert_eq!(spend_action.output.recipient, Some(spend_recipient));
         assert_eq!(spend_action.output.value, Some(NoteValue::ZERO));
 
-        // The spend-paired output's ciphertext is randomized, so signers (e.g. Keystone) must be
-        // able to classify it as a zero-valued dummy and tolerate the undecryptable ciphertext
-        // rather than reconstructing and rejecting it. That requires the explicit note fields to
-        // be present (so the commitment verifies), no `user_address`, and a zero value.
+        // This external-scope spend's paired output ciphertext is randomized, so signers
+        // (e.g. Keystone) must be able to classify it as a zero-valued dummy and tolerate the
+        // undecryptable ciphertext rather than reconstructing and rejecting it. That requires the
+        // explicit note fields to be present (so the commitment verifies), no `user_address`, and
+        // a zero value.
         assert!(spend_action.output.user_address.is_none());
         assert!(spend_action.output.rseed.is_some());
         assert!(spend_action

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -66,9 +66,19 @@ pub enum BundleType {
 }
 
 impl BundleType {
-    /// The default bundle type: an unpadded transactional bundle that is not required to be
+    /// The default bundle type: a padded transactional bundle that is not required to be
     /// produced if no spends or outputs have been added.
     pub const DEFAULT: BundleType = BundleType::Transactional {
+        bundle_required: false,
+        pad_to_minimum: true,
+    };
+
+    /// [`BundleType::DEFAULT`] without padding: the bundle contains exactly the requested
+    /// actions. Intended for transactions whose shape is already public — such as pool
+    /// migrations, where the per-pool value balances reveal the transfer — since the
+    /// action count reveals the transaction shape (see
+    /// [`BundleType::Transactional::pad_to_minimum`]).
+    pub const DEFAULT_UNPADDED: BundleType = BundleType::Transactional {
         bundle_required: false,
         pad_to_minimum: false,
     };
@@ -781,6 +791,15 @@ impl Builder {
             changes: vec![],
             anchor,
         })
+    }
+
+    /// Returns the bundle type this builder was constructed with.
+    ///
+    /// Lets callers that must predict the builder's action count (e.g. fee
+    /// calculation) read back the exact [`BundleType`] the bundle will be built
+    /// with, so the two cannot drift.
+    pub fn bundle_type(&self) -> BundleType {
+        self.bundle_type
     }
 
     /// Returns the note version associated with this builder's bundle version.
@@ -1875,14 +1894,16 @@ mod tests {
         let flags = BundleVersion::ironwood_v3().default_flags();
         assert_eq!(padded.num_actions(flags, 0, 1), Ok(2));
         assert_eq!(unpadded.num_actions(flags, 0, 1), Ok(1));
-        assert_eq!(BundleType::DEFAULT.num_actions(flags, 0, 1), Ok(1));
+        assert_eq!(BundleType::DEFAULT.num_actions(flags, 0, 1), Ok(2));
+        assert_eq!(BundleType::DEFAULT_UNPADDED.num_actions(flags, 0, 1), Ok(1));
         assert_eq!(unpadded.num_actions(flags, 2, 3), Ok(3));
         assert_eq!(unpadded.num_actions(flags, 0, 0), Ok(0));
         // `bundle_required` still guarantees a bundle exists: a single all-dummy action.
         assert_eq!(required_unpadded.num_actions(flags, 0, 0), Ok(1));
 
         let flags = BundleVersion::orchard_v2().default_flags();
-        assert_eq!(BundleType::DEFAULT.num_actions(flags, 0, 1), Ok(1));
+        assert_eq!(BundleType::DEFAULT.num_actions(flags, 0, 1), Ok(2));
+        assert_eq!(BundleType::DEFAULT_UNPADDED.num_actions(flags, 0, 1), Ok(1));
 
         // Cross-address transfers disabled: requested actions = spends + outputs.
         let flags = BundleVersion::orchard_v3().default_flags();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -66,11 +66,11 @@ pub enum BundleType {
 }
 
 impl BundleType {
-    /// The default bundle type: a transactional bundle, padded to the 2-action minimum, that
-    /// is not required to be produced if no spends or outputs have been added.
+    /// The default bundle type: an unpadded transactional bundle that is not required to be
+    /// produced if no spends or outputs have been added.
     pub const DEFAULT: BundleType = BundleType::Transactional {
         bundle_required: false,
-        pad_to_minimum: true,
+        pad_to_minimum: false,
     };
 
     /// Returns the number of logical actions that the builder will produce in constructing a bundle
@@ -1875,10 +1875,14 @@ mod tests {
         let flags = BundleVersion::ironwood_v3().default_flags();
         assert_eq!(padded.num_actions(flags, 0, 1), Ok(2));
         assert_eq!(unpadded.num_actions(flags, 0, 1), Ok(1));
+        assert_eq!(BundleType::DEFAULT.num_actions(flags, 0, 1), Ok(1));
         assert_eq!(unpadded.num_actions(flags, 2, 3), Ok(3));
         assert_eq!(unpadded.num_actions(flags, 0, 0), Ok(0));
         // `bundle_required` still guarantees a bundle exists: a single all-dummy action.
         assert_eq!(required_unpadded.num_actions(flags, 0, 0), Ok(1));
+
+        let flags = BundleVersion::orchard_v2().default_flags();
+        assert_eq!(BundleType::DEFAULT.num_actions(flags, 0, 1), Ok(1));
 
         // Cross-address transfers disabled: requested actions = spends + outputs.
         let flags = BundleVersion::orchard_v3().default_flags();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -42,13 +42,20 @@ const MIN_ACTIONS: usize = 2;
 /// to the builder (see [`Builder::new`] and [`BundleVersion::default_flags`]).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BundleType {
-    /// A transactional bundle will be padded if necessary to contain at least 2 actions,
-    /// irrespective of whether any genuine actions are required.
+    /// A transactional bundle is padded, when `pad_to_minimum` is set, to contain at least
+    /// 2 actions, irrespective of whether any genuine actions are required.
     Transactional {
         /// A flag that, when set to `true`, indicates that a bundle should be produced even if no
         /// spends or outputs have been added to the bundle; in such a circumstance, all of the
         /// actions in the resulting bundle will be dummies.
         bundle_required: bool,
+        /// A flag that, when set to `false`, disables padding of the bundle to the 2-action
+        /// minimum: the bundle contains exactly the requested actions (at least one, if
+        /// `bundle_required` is set). One-action bundles are consensus-valid
+        /// ([`BundleType::Coinbase`] bundles are never padded); the minimum exists to improve
+        /// indistinguishability, so disabling it lets the action count reveal the
+        /// transaction shape.
+        pad_to_minimum: bool,
     },
     /// A coinbase bundle performs no padding and requires the bundle's flags to disable spends.
     ///
@@ -59,10 +66,11 @@ pub enum BundleType {
 }
 
 impl BundleType {
-    /// The default bundle type: a transactional bundle that is not required to be produced if no
-    /// spends or outputs have been added.
+    /// The default bundle type: a transactional bundle, padded to the 2-action minimum, that
+    /// is not required to be produced if no spends or outputs have been added.
     pub const DEFAULT: BundleType = BundleType::Transactional {
         bundle_required: false,
+        pad_to_minimum: true,
     };
 
     /// Returns the number of logical actions that the builder will produce in constructing a bundle
@@ -86,7 +94,10 @@ impl BundleType {
         num_outputs: usize,
     ) -> Result<usize, &'static str> {
         match self {
-            BundleType::Transactional { bundle_required } => {
+            BundleType::Transactional {
+                bundle_required,
+                pad_to_minimum,
+            } => {
                 // When cross-address transfers are disabled, every action's output is
                 // addressed to the note it spends. For this implementation, a requested
                 // spend and a requested output never share an action: each is paired with
@@ -104,8 +115,9 @@ impl BundleType {
                 } else if !flags.outputs_enabled() && num_outputs > 0 {
                     Err("Outputs are disabled, so num_outputs must be zero")
                 } else {
+                    let min_actions = if *pad_to_minimum { MIN_ACTIONS } else { 1 };
                     Ok(if *bundle_required || num_requested_actions > 0 {
-                        core::cmp::max(num_requested_actions, MIN_ACTIONS)
+                        core::cmp::max(num_requested_actions, min_actions)
                     } else {
                         0
                     })
@@ -1841,7 +1853,37 @@ mod tests {
     }
 
     fn transactional(bundle_required: bool) -> BundleType {
-        BundleType::Transactional { bundle_required }
+        BundleType::Transactional {
+            bundle_required,
+            pad_to_minimum: true,
+        }
+    }
+
+    #[test]
+    fn num_actions_respects_pad_to_minimum() {
+        let padded = transactional(false);
+        let unpadded = BundleType::Transactional {
+            bundle_required: false,
+            pad_to_minimum: false,
+        };
+        let required_unpadded = BundleType::Transactional {
+            bundle_required: true,
+            pad_to_minimum: false,
+        };
+
+        // Cross-address transfers enabled: requested actions = max(spends, outputs).
+        let flags = BundleVersion::ironwood_v3().default_flags();
+        assert_eq!(padded.num_actions(flags, 0, 1), Ok(2));
+        assert_eq!(unpadded.num_actions(flags, 0, 1), Ok(1));
+        assert_eq!(unpadded.num_actions(flags, 2, 3), Ok(3));
+        assert_eq!(unpadded.num_actions(flags, 0, 0), Ok(0));
+        // `bundle_required` still guarantees a bundle exists: a single all-dummy action.
+        assert_eq!(required_unpadded.num_actions(flags, 0, 0), Ok(1));
+
+        // Cross-address transfers disabled: requested actions = spends + outputs.
+        let flags = BundleVersion::orchard_v3().default_flags();
+        assert_eq!(unpadded.num_actions(flags, 1, 0), Ok(1));
+        assert_eq!(unpadded.num_actions(flags, 1, 1), Ok(2));
     }
 
     #[test]

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -24,7 +24,7 @@ mod parse;
 pub use parse::ParseError;
 
 mod verify;
-pub use verify::VerifyError;
+pub use verify::{recompute, VerifyError};
 
 mod io_finalizer;
 pub use io_finalizer::IoFinalizerError;

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -1404,7 +1404,10 @@ mod tests {
 
         let bundle_version = BundleVersion::orchard_v3();
         let mut builder = Builder::new(
-            BundleType::DEFAULT,
+            BundleType::Transactional {
+                bundle_required: false,
+                pad_to_minimum: true,
+            },
             bundle_version,
             bundle_version.default_flags(),
             anchor,

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -262,8 +262,9 @@ pub struct Output {
     /// - The Signer can use `recipient` and `rseed` (if present) to verify that
     ///   `enc_ciphertext` is correctly encrypted (and contains a note plaintext matching
     ///   the public commitments), and to confirm the value of the memo. This does not apply
-    ///   to the restricted builder's zero-valued output paired with a real spend, whose
-    ///   `enc_ciphertext` is deliberately randomized; its note commitment remains verifiable.
+    ///   to the restricted builder's zero-valued output paired with a real external-scope spend,
+    ///   whose `enc_ciphertext` is deliberately randomized; its note commitment remains
+    ///   verifiable.
     pub(crate) recipient: Option<Address>,
 
     /// The value of the output.
@@ -282,8 +283,9 @@ pub struct Output {
     /// - The Signer can use `recipient` and `rseed` (if present) to verify that
     ///   `enc_ciphertext` is correctly encrypted (and contains a note plaintext matching
     ///   the public commitments), and to confirm the value of the memo. This does not apply
-    ///   to the restricted builder's zero-valued output paired with a real spend, whose
-    ///   `enc_ciphertext` is deliberately randomized; its note commitment remains verifiable.
+    ///   to the restricted builder's zero-valued output paired with a real external-scope spend,
+    ///   whose `enc_ciphertext` is deliberately randomized; its note commitment remains
+    ///   verifiable.
     pub(crate) rseed: Option<RandomSeed>,
 
     /// The `ock` value used to encrypt `out_ciphertext`.

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -1408,7 +1408,7 @@ mod tests {
         let mut builder = Builder::new(
             BundleType::Transactional {
                 bundle_required: false,
-                pad_to_minimum: true,
+                pad_to_minimum: None,
             },
             bundle_version,
             bundle_version.default_flags(),

--- a/src/pczt/parse.rs
+++ b/src/pczt/parse.rs
@@ -484,6 +484,10 @@ pub enum ParseError {
     UnexpectedFlagBitsSet,
     /// An invalid `note_version` was provided.
     InvalidNoteVersion,
+    /// A derived field that was omitted from the PCZT could not be recomputed from the
+    /// note's component fields. Wraps the [`VerifyError`](super::VerifyError) identifying
+    /// the component that was missing or invalid.
+    Recompute(super::VerifyError),
 }
 
 impl fmt::Display for ParseError {
@@ -511,6 +515,9 @@ impl fmt::Display for ParseError {
             }
             ParseError::UnexpectedFlagBitsSet => write!(f, "`flags` field had unexpected bits set"),
             ParseError::InvalidNoteVersion => write!(f, "invalid `note_version`"),
+            ParseError::Recompute(e) => {
+                write!(f, "could not recompute an omitted derived field: {e}")
+            }
         }
     }
 }

--- a/src/pczt/verify.rs
+++ b/src/pczt/verify.rs
@@ -1,11 +1,167 @@
+use alloc::vec::Vec;
 use core::fmt;
+
+use ff::PrimeField;
+use pasta_curves::pallas;
 
 use crate::{
     keys::{FullViewingKey, SpendValidatingKey},
-    note::{ExtractedNoteCommitment, Rho},
-    value::ValueCommitment,
-    Note,
+    note::{ExtractedNoteCommitment, NoteVersion, Nullifier, RandomSeed, Rho},
+    note_encryption::OrchardNoteEncryption,
+    value::{NoteValue, ValueCommitTrapdoor, ValueCommitment},
+    Address, Note,
 };
+
+/// Byte-level recompute helpers for the derived fields of a PCZT action.
+///
+/// A PCZT producer may omit an action's derived fields (`cv_net`, `nullifier`, `rk`,
+/// `cmx`, `ephemeral_key`, `enc_ciphertext`) to shrink the serialized encoding, leaving
+/// the receiver to recompute them from the note component fields it already holds. These
+/// functions perform the same derivations as the builder, directly on the PCZT wire byte
+/// encodings, so the receiver can repopulate an omitted field -- with a value
+/// byte-identical to the one the producer elided -- before the protocol structs are
+/// parsed, keeping every downstream consumer working with fully-populated actions.
+///
+/// Errors identify the note component that was missing or could not be decoded.
+pub mod recompute {
+    use super::*;
+
+    /// Reconstructs a note from its raw component byte fields.
+    fn note_from_bytes(
+        recipient: &[u8; 43],
+        value: u64,
+        rho: Rho,
+        rseed: &[u8; 32],
+        note_version: NoteVersion,
+    ) -> Result<Note, VerifyError> {
+        let recipient = Address::from_raw_address_bytes(recipient)
+            .into_option()
+            .ok_or(VerifyError::MissingRecipient)?;
+        let rseed = RandomSeed::from_bytes(*rseed, &rho)
+            .into_option()
+            .ok_or(VerifyError::MissingRandomSeed)?;
+        Note::from_parts(
+            recipient,
+            NoteValue::from_raw(value),
+            rho,
+            rseed,
+            note_version,
+        )
+        .into_option()
+        .ok_or(VerifyError::InvalidSpendNote)
+    }
+
+    /// Recomputes `cv_net` from the spend and output values and the value commitment
+    /// trapdoor, returning its byte encoding.
+    pub fn cv_net(
+        spend_value: u64,
+        output_value: u64,
+        rcv: &[u8; 32],
+    ) -> Result<[u8; 32], VerifyError> {
+        let rcv = ValueCommitTrapdoor::from_bytes(*rcv)
+            .into_option()
+            .ok_or(VerifyError::MissingValueCommitTrapdoor)?;
+        let value = NoteValue::from_raw(spend_value) - NoteValue::from_raw(output_value);
+        Ok(ValueCommitment::derive(value, rcv).to_bytes())
+    }
+
+    /// Recomputes a spent note's `nullifier` from its component fields and full viewing
+    /// key, returning its byte encoding.
+    pub fn nullifier(
+        recipient: &[u8; 43],
+        value: u64,
+        rho: &[u8; 32],
+        rseed: &[u8; 32],
+        fvk: &[u8; 96],
+        note_version: NoteVersion,
+    ) -> Result<[u8; 32], VerifyError> {
+        let rho = Rho::from_bytes(rho)
+            .into_option()
+            .ok_or(VerifyError::MissingRho)?;
+        let note = note_from_bytes(recipient, value, rho, rseed, note_version)?;
+        let fvk = FullViewingKey::from_bytes(fvk).ok_or(VerifyError::MissingFullViewingKey)?;
+        // The nullifier only constrains `nk` within the FVK; we additionally confirm the
+        // FVK owns the note, matching `Spend::verify_nullifier`.
+        fvk.scope_for_address(&note.recipient())
+            .ok_or(VerifyError::WrongFvkForNote)?;
+        Ok(note.nullifier(&fvk).to_bytes())
+    }
+
+    /// Recomputes a spend's randomized verification key `rk` from its full viewing key
+    /// and spend authorization randomizer, returning its byte encoding.
+    pub fn rk(fvk: &[u8; 96], alpha: &[u8; 32]) -> Result<[u8; 32], VerifyError> {
+        let fvk = FullViewingKey::from_bytes(fvk).ok_or(VerifyError::MissingFullViewingKey)?;
+        let alpha = pallas::Scalar::from_repr(*alpha)
+            .into_option()
+            .ok_or(VerifyError::MissingSpendAuthRandomizer)?;
+        let ak = SpendValidatingKey::from(fvk);
+        Ok((&ak.randomize(&alpha)).into())
+    }
+
+    /// Reconstructs an output note from its component fields. The output note's `rho` is
+    /// derived from the spent note's nullifier, so `spend_nullifier` must be the already
+    /// recomputed (or supplied) nullifier of the same action.
+    fn output_note(
+        recipient: &[u8; 43],
+        value: u64,
+        spend_nullifier: &[u8; 32],
+        rseed: &[u8; 32],
+        note_version: NoteVersion,
+    ) -> Result<Note, VerifyError> {
+        let nf = Nullifier::from_bytes(spend_nullifier)
+            .into_option()
+            .ok_or(VerifyError::InvalidNullifier)?;
+        let rho = Rho::from_nf_old(nf);
+        note_from_bytes(recipient, value, rho, rseed, note_version).map_err(|_| {
+            // Distinguish output-note reconstruction failure from spend-note failure.
+            VerifyError::InvalidOutputNote
+        })
+    }
+
+    /// Recomputes an output's note commitment `cmx` from its component fields, returning
+    /// its byte encoding.
+    pub fn cmx(
+        recipient: &[u8; 43],
+        value: u64,
+        spend_nullifier: &[u8; 32],
+        rseed: &[u8; 32],
+        note_version: NoteVersion,
+    ) -> Result<[u8; 32], VerifyError> {
+        let note = output_note(recipient, value, spend_nullifier, rseed, note_version)?;
+        Ok(ExtractedNoteCommitment::from(note.commitment()).to_bytes())
+    }
+
+    /// Recomputes an output's `ephemeral_key` and `enc_ciphertext` from its component
+    /// fields and the note's `memo`, returning `(ephemeral_key, enc_ciphertext)`.
+    ///
+    /// This reproduces the builder's deterministic note encryption byte-for-byte for any
+    /// memo; `note_version` selects the note plaintext lead byte, and `ephemeral_key` is
+    /// memo-independent. (Migration wallets use two memo constants: the all-zero memo
+    /// carried by dummy outputs, and the ZIP 302 empty memo, `0xF6` followed by zeroes,
+    /// carried by the real migrated output.) The encryption is independent of the
+    /// sender's `ovk`, which affects only `out_ciphertext`; that field is RNG-derived and
+    /// can never be recomputed. The one `enc_ciphertext` that also cannot be recomputed
+    /// is the zero-valued output paired with a real spend by a builder that disables
+    /// cross-address transfers, which is deliberately randomized.
+    pub fn ephemeral_key_and_enc_ciphertext(
+        recipient: &[u8; 43],
+        value: u64,
+        spend_nullifier: &[u8; 32],
+        rseed: &[u8; 32],
+        memo: &[u8; 512],
+        note_version: NoteVersion,
+    ) -> Result<([u8; 32], Vec<u8>), VerifyError> {
+        let note = output_note(recipient, value, spend_nullifier, rseed, note_version)?;
+        // The Orchard and Ironwood encryptor aliases share encryption behavior (the
+        // note's version selects the lead byte), so a single alias serves both note
+        // versions, exactly as in `OutputInfo::build`.
+        let encryptor = OrchardNoteEncryption::new(None, note, *memo);
+        Ok((
+            encryptor.epk().to_bytes().0,
+            encryptor.encrypt_note_plaintext().to_vec(),
+        ))
+    }
+}
 
 impl super::Bundle {
     /// If this bundle disables cross-address transfers, verifies that every action's
@@ -265,3 +421,216 @@ impl fmt::Display for VerifyError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for VerifyError {}
+
+#[cfg(test)]
+mod tests {
+    use ff::PrimeField;
+    use rand::rngs::OsRng;
+
+    use super::recompute;
+    use crate::{
+        builder::{Builder, BundleType},
+        bundle::BundleVersion,
+        constants::MERKLE_DEPTH_ORCHARD,
+        keys::{FullViewingKey, Scope, SpendingKey},
+        note::{NoteVersion, Nullifier, Rho},
+        tree::{MerklePath, EMPTY_ROOTS},
+        value::NoteValue,
+        Note,
+    };
+
+    /// Asserts that every derived field of `action` is byte-identical to its
+    /// recomputation from the action's note component fields, using `memo` for the
+    /// output's note plaintext.
+    ///
+    /// Pass `expect_enc_match: false` for the fabricated output paired with a real spend
+    /// in a bundle that disables cross-address transfers: its `enc_ciphertext` is
+    /// deliberately randomized, so `ephemeral_key` must still match but `enc_ciphertext`
+    /// must not.
+    fn assert_action_recomputes(
+        action: &crate::pczt::Action,
+        memo: &[u8; 512],
+        expect_enc_match: bool,
+    ) {
+        let spend = action.spend();
+        let output = action.output();
+
+        let spend_value = spend.value().expect("builder sets spend value").inner();
+        let output_value = output.value().expect("builder sets output value").inner();
+        let rcv = action.rcv().as_ref().expect("builder sets rcv").to_bytes();
+        assert_eq!(
+            recompute::cv_net(spend_value, output_value, &rcv).unwrap(),
+            action.cv_net().to_bytes(),
+        );
+
+        let spend_recipient = spend
+            .recipient()
+            .expect("builder sets spend recipient")
+            .to_raw_address_bytes();
+        let rho = spend.rho().expect("builder sets rho").to_bytes();
+        let spend_rseed = *spend
+            .rseed()
+            .as_ref()
+            .expect("builder sets spend rseed")
+            .as_bytes();
+        let fvk = spend
+            .fvk()
+            .as_ref()
+            .expect("builder sets spend fvk")
+            .to_bytes();
+        assert_eq!(
+            recompute::nullifier(
+                &spend_recipient,
+                spend_value,
+                &rho,
+                &spend_rseed,
+                &fvk,
+                *spend.note_version(),
+            )
+            .unwrap(),
+            spend.nullifier().to_bytes(),
+        );
+
+        let alpha = spend.alpha().expect("builder sets alpha").to_repr();
+        assert_eq!(
+            recompute::rk(&fvk, &alpha).unwrap(),
+            <[u8; 32]>::from(spend.rk()),
+        );
+
+        let output_recipient = output
+            .recipient()
+            .expect("builder sets output recipient")
+            .to_raw_address_bytes();
+        let output_rseed = *output
+            .rseed()
+            .as_ref()
+            .expect("builder sets output rseed")
+            .as_bytes();
+        let spend_nullifier = spend.nullifier().to_bytes();
+        assert_eq!(
+            recompute::cmx(
+                &output_recipient,
+                output_value,
+                &spend_nullifier,
+                &output_rseed,
+                *output.note_version(),
+            )
+            .unwrap(),
+            output.cmx().to_bytes(),
+        );
+
+        let (ephemeral_key, enc_ciphertext) = recompute::ephemeral_key_and_enc_ciphertext(
+            &output_recipient,
+            output_value,
+            &spend_nullifier,
+            &output_rseed,
+            memo,
+            *output.note_version(),
+        )
+        .unwrap();
+        assert_eq!(ephemeral_key, output.encrypted_note().epk_bytes);
+        if expect_enc_match {
+            assert_eq!(
+                enc_ciphertext[..],
+                output.encrypted_note().enc_ciphertext[..],
+            );
+        } else {
+            assert_ne!(
+                enc_ciphertext[..],
+                output.encrypted_note().enc_ciphertext[..],
+            );
+        }
+    }
+
+    /// Pins the Ironwood (V3) `enc_ciphertext` encoding of a real migration-style output:
+    /// a builder-built output carrying the ZIP 302 empty memo (`0xF6` followed by zeroes)
+    /// must be byte-identical to its recomputation, which is the precondition for eliding
+    /// it from a wire PCZT. Building with `Some(ovk)` and recomputing without it also
+    /// pins that `enc_ciphertext` is independent of the sender's `ovk`. The padding
+    /// action covers the all-zero dummy memo under V3.
+    #[test]
+    fn recompute_reproduces_ironwood_empty_memo_output() {
+        let mut rng = OsRng;
+        let sk = SpendingKey::random(&mut rng);
+        let fvk = FullViewingKey::from(&sk);
+        let recipient = fvk.address_at(0u32, Scope::External);
+        let bundle_version = BundleVersion::ironwood_v3();
+
+        // The ZIP 302 encoding of "no memo", as `MemoBytes::empty()` produces for the
+        // real migration output.
+        let mut empty_memo = [0u8; 512];
+        empty_memo[0] = 0xF6;
+
+        let mut builder = Builder::new(
+            BundleType::DEFAULT,
+            bundle_version,
+            bundle_version.default_flags(),
+            EMPTY_ROOTS[MERKLE_DEPTH_ORCHARD].into(),
+        )
+        .unwrap();
+        builder
+            .add_output(
+                Some(fvk.to_ovk(Scope::Internal)),
+                recipient,
+                NoteValue::from_raw(5_000),
+                empty_memo,
+            )
+            .unwrap();
+        let (bundle, bundle_meta) = builder.build_for_pczt(&mut rng).unwrap();
+        let real_index = bundle_meta.output_action_index(0).unwrap();
+
+        assert_eq!(bundle.actions().len(), 2);
+        for (index, action) in bundle.actions().iter().enumerate() {
+            assert_eq!(*action.output().note_version(), NoteVersion::V3);
+            let memo = if index == real_index {
+                &empty_memo
+            } else {
+                &[0u8; 512]
+            };
+            assert_action_recomputes(action, memo, true);
+        }
+    }
+
+    /// In a bundle that disables cross-address transfers (post-NU6.3 Orchard, V2 notes),
+    /// every derived field recomputes byte-identically, except the `enc_ciphertext` of
+    /// the fabricated output paired with the real spend, which is deliberately randomized
+    /// and must not be reproducible. The padding action covers the all-zero dummy memo
+    /// under V2.
+    #[test]
+    fn recompute_reproduces_restricted_orchard_bundle() {
+        let mut rng = OsRng;
+        let sk = SpendingKey::random(&mut rng);
+        let fvk = FullViewingKey::from(&sk);
+        let recipient = fvk.address_at(0u32, Scope::External);
+        let bundle_version = BundleVersion::orchard_v3();
+        let note_version = bundle_version.note_version();
+
+        let rho = Rho::from_nf_old(Nullifier::dummy(&mut rng));
+        let note = Note::new(
+            recipient,
+            NoteValue::from_raw(15_000),
+            rho,
+            note_version,
+            &mut rng,
+        );
+        let merkle_path = MerklePath::dummy(&mut rng);
+        let anchor = merkle_path.root(note.commitment().into());
+
+        let mut builder = Builder::new(
+            BundleType::DEFAULT,
+            bundle_version,
+            bundle_version.default_flags(),
+            anchor,
+        )
+        .unwrap();
+        builder.add_spend(fvk, note, merkle_path).unwrap();
+        let (bundle, bundle_meta) = builder.build_for_pczt(&mut rng).unwrap();
+        let spend_index = bundle_meta.spend_action_index(0).unwrap();
+
+        assert_eq!(bundle.actions().len(), 2);
+        for (index, action) in bundle.actions().iter().enumerate() {
+            assert_eq!(*action.output().note_version(), NoteVersion::V2);
+            assert_action_recomputes(action, &[0u8; 512], index != spend_index);
+        }
+    }
+}

--- a/src/pczt/verify.rs
+++ b/src/pczt/verify.rs
@@ -564,7 +564,7 @@ mod tests {
         let mut builder = Builder::new(
             BundleType::Transactional {
                 bundle_required: false,
-                pad_to_minimum: true,
+                pad_to_minimum: None,
             },
             bundle_version,
             bundle_version.default_flags(),
@@ -619,7 +619,7 @@ mod tests {
         let mut builder = Builder::new(
             BundleType::Transactional {
                 bundle_required: false,
-                pad_to_minimum: true,
+                pad_to_minimum: None,
             },
             bundle_version,
             bundle_version.default_flags(),

--- a/src/pczt/verify.rs
+++ b/src/pczt/verify.rs
@@ -141,8 +141,8 @@ pub mod recompute {
     /// carried by the real migrated output.) The encryption is independent of the
     /// sender's `ovk`, which affects only `out_ciphertext`; that field is RNG-derived and
     /// can never be recomputed. The one `enc_ciphertext` that also cannot be recomputed
-    /// is the zero-valued output paired with a real spend by a builder that disables
-    /// cross-address transfers, which is deliberately randomized.
+    /// is the zero-valued output paired with a real external-scope spend by a builder that
+    /// disables cross-address transfers, which is deliberately randomized.
     pub fn ephemeral_key_and_enc_ciphertext(
         recipient: &[u8; 43],
         value: u64,
@@ -443,10 +443,10 @@ mod tests {
     /// recomputation from the action's note component fields, using `memo` for the
     /// output's note plaintext.
     ///
-    /// Pass `expect_enc_match: false` for the fabricated output paired with a real spend
-    /// in a bundle that disables cross-address transfers: its `enc_ciphertext` is
-    /// deliberately randomized, so `ephemeral_key` must still match but `enc_ciphertext`
-    /// must not.
+    /// Pass `expect_enc_match: false` for the fabricated output paired with a real
+    /// external-scope spend in a bundle that disables cross-address transfers: its
+    /// `enc_ciphertext` is deliberately randomized, so `ephemeral_key` must still match but
+    /// `enc_ciphertext` must not.
     fn assert_action_recomputes(
         action: &crate::pczt::Action,
         memo: &[u8; 512],
@@ -594,17 +594,14 @@ mod tests {
         }
     }
 
-    /// In a bundle that disables cross-address transfers (post-NU6.3 Orchard, V2 notes),
-    /// every derived field recomputes byte-identically, except the `enc_ciphertext` of
-    /// the fabricated output paired with the real spend, which is deliberately randomized
-    /// and must not be reproducible. An explicit padded action covers the all-zero dummy
-    /// memo under V2.
-    #[test]
-    fn recompute_reproduces_restricted_orchard_bundle() {
+    fn assert_restricted_orchard_spend_recomputes(
+        spend_scope: Scope,
+        expect_spend_output_enc_match: bool,
+    ) {
         let mut rng = OsRng;
         let sk = SpendingKey::random(&mut rng);
         let fvk = FullViewingKey::from(&sk);
-        let recipient = fvk.address_at(0u32, Scope::External);
+        let recipient = fvk.address_at(0u32, spend_scope);
         let bundle_version = BundleVersion::orchard_v3();
         let note_version = bundle_version.note_version();
 
@@ -636,7 +633,28 @@ mod tests {
         assert_eq!(bundle.actions().len(), 2);
         for (index, action) in bundle.actions().iter().enumerate() {
             assert_eq!(*action.output().note_version(), NoteVersion::V2);
-            assert_action_recomputes(action, &[0u8; 512], index != spend_index);
+            assert_action_recomputes(
+                action,
+                &[0u8; 512],
+                index != spend_index || expect_spend_output_enc_match,
+            );
         }
+    }
+
+    /// In a bundle that disables cross-address transfers (post-NU6.3 Orchard, V2 notes),
+    /// every derived field recomputes byte-identically, except the `enc_ciphertext` of
+    /// the fabricated output paired with an external-scope real spend, which is deliberately
+    /// randomized and must not be reproducible. An explicit padded action covers the all-zero
+    /// dummy memo under V2.
+    #[test]
+    fn recompute_reproduces_restricted_external_orchard_bundle_except_ciphertext() {
+        assert_restricted_orchard_spend_recomputes(Scope::External, false);
+    }
+
+    /// Internal-scope spends do not have the same external-address exposure, so the fabricated
+    /// zero-valued output paired with the spend remains deterministic and recomputable.
+    #[test]
+    fn recompute_reproduces_restricted_internal_orchard_bundle() {
+        assert_restricted_orchard_spend_recomputes(Scope::Internal, true);
     }
 }

--- a/src/pczt/verify.rs
+++ b/src/pczt/verify.rs
@@ -546,7 +546,7 @@ mod tests {
     /// a builder-built output carrying the ZIP 302 empty memo (`0xF6` followed by zeroes)
     /// must be byte-identical to its recomputation, which is the precondition for eliding
     /// it from a wire PCZT. Building with `Some(ovk)` and recomputing without it also
-    /// pins that `enc_ciphertext` is independent of the sender's `ovk`. The padding
+    /// pins that `enc_ciphertext` is independent of the sender's `ovk`. An explicit padded
     /// action covers the all-zero dummy memo under V3.
     #[test]
     fn recompute_reproduces_ironwood_empty_memo_output() {
@@ -562,7 +562,10 @@ mod tests {
         empty_memo[0] = 0xF6;
 
         let mut builder = Builder::new(
-            BundleType::DEFAULT,
+            BundleType::Transactional {
+                bundle_required: false,
+                pad_to_minimum: true,
+            },
             bundle_version,
             bundle_version.default_flags(),
             EMPTY_ROOTS[MERKLE_DEPTH_ORCHARD].into(),
@@ -594,8 +597,8 @@ mod tests {
     /// In a bundle that disables cross-address transfers (post-NU6.3 Orchard, V2 notes),
     /// every derived field recomputes byte-identically, except the `enc_ciphertext` of
     /// the fabricated output paired with the real spend, which is deliberately randomized
-    /// and must not be reproducible. The padding action covers the all-zero dummy memo
-    /// under V2.
+    /// and must not be reproducible. An explicit padded action covers the all-zero dummy
+    /// memo under V2.
     #[test]
     fn recompute_reproduces_restricted_orchard_bundle() {
         let mut rng = OsRng;
@@ -617,7 +620,10 @@ mod tests {
         let anchor = merkle_path.root(note.commitment().into());
 
         let mut builder = Builder::new(
-            BundleType::DEFAULT,
+            BundleType::Transactional {
+                bundle_required: false,
+                pad_to_minimum: true,
+            },
             bundle_version,
             bundle_version.default_flags(),
             anchor,

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -344,12 +344,12 @@ fn post_nu6_3_coinbase_bundle_proves_and_verifies() {
     verify_bundle(&bundle, &post_nu6_3_vk, TxVersion::V6);
 }
 
-// An unpadded transactional bundle: `pad_to_minimum: false` builds exactly the requested
-// single action instead of padding to the 2-action minimum, and the result proves and
-// verifies on the post-NU6.3 circuit like any other bundle (coinbase bundles already
-// demonstrate that consensus accepts 1-action bundles).
+// The default transactional bundle type builds exactly the requested single action instead
+// of padding to the 2-action minimum, and the result proves and verifies on the post-NU6.3
+// circuit like any other bundle (coinbase bundles already demonstrate that consensus accepts
+// 1-action bundles).
 #[test]
-fn unpadded_ironwood_bundle_builds_single_action_and_verifies() {
+fn default_ironwood_bundle_builds_single_action_and_verifies() {
     let mut rng = OsRng;
     let post_nu6_3_pk = ProvingKey::build(OrchardCircuitVersion::PostNu6_3);
     let post_nu6_3_vk = VerifyingKey::build(OrchardCircuitVersion::PostNu6_3);
@@ -358,14 +358,7 @@ fn unpadded_ironwood_bundle_builds_single_action_and_verifies() {
     let fvk = FullViewingKey::from(&sk);
     let recipient = fvk.address_at(0u32, Scope::External);
 
-    let builder = output_only_builder(
-        BundleVersion::ironwood_v3(),
-        BundleType::Transactional {
-            bundle_required: false,
-            pad_to_minimum: false,
-        },
-        recipient,
-    );
+    let builder = output_only_builder(BundleVersion::ironwood_v3(), BundleType::DEFAULT, recipient);
 
     let (unauthorized, bundle_meta) = builder.build::<i64>(&mut rng).unwrap().unwrap();
     assert_eq!(unauthorized.actions().len(), 1);

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -344,6 +344,43 @@ fn post_nu6_3_coinbase_bundle_proves_and_verifies() {
     verify_bundle(&bundle, &post_nu6_3_vk, TxVersion::V6);
 }
 
+// An unpadded transactional bundle: `pad_to_minimum: false` builds exactly the requested
+// single action instead of padding to the 2-action minimum, and the result proves and
+// verifies on the post-NU6.3 circuit like any other bundle (coinbase bundles already
+// demonstrate that consensus accepts 1-action bundles).
+#[test]
+fn unpadded_ironwood_bundle_builds_single_action_and_verifies() {
+    let mut rng = OsRng;
+    let post_nu6_3_pk = ProvingKey::build(OrchardCircuitVersion::PostNu6_3);
+    let post_nu6_3_vk = VerifyingKey::build(OrchardCircuitVersion::PostNu6_3);
+
+    let sk = SpendingKey::from_bytes([0; 32]).unwrap();
+    let fvk = FullViewingKey::from(&sk);
+    let recipient = fvk.address_at(0u32, Scope::External);
+
+    let builder = output_only_builder(
+        BundleVersion::ironwood_v3(),
+        BundleType::Transactional {
+            bundle_required: false,
+            pad_to_minimum: false,
+        },
+        recipient,
+    );
+
+    let (unauthorized, bundle_meta) = builder.build::<i64>(&mut rng).unwrap().unwrap();
+    assert_eq!(unauthorized.actions().len(), 1);
+    assert_eq!(bundle_meta.output_action_index(0), Some(0));
+
+    let sighash: [u8; 32] = unauthorized
+        .commitment(TxVersion::V6)
+        .expect("bundle flags are representable in this format")
+        .into();
+    let proven = unauthorized.create_proof(&post_nu6_3_pk, &mut rng).unwrap();
+    let bundle = proven.apply_signatures(rng, sighash, &[]).unwrap();
+
+    verify_bundle(&bundle, &post_nu6_3_vk, TxVersion::V6);
+}
+
 // A post-NU 6.3 restricted bundle chain: an ordinary shielding bundle, followed by a bundle
 // that disables cross-address transfers, withdraws part of the shielded value,
 // and retains the rest as wallet-controlled change.

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -344,12 +344,12 @@ fn post_nu6_3_coinbase_bundle_proves_and_verifies() {
     verify_bundle(&bundle, &post_nu6_3_vk, TxVersion::V6);
 }
 
-// The default transactional bundle type builds exactly the requested single action instead
-// of padding to the 2-action minimum, and the result proves and verifies on the post-NU6.3
-// circuit like any other bundle (coinbase bundles already demonstrate that consensus accepts
-// 1-action bundles).
+// An explicitly unpadded transactional bundle builds exactly the requested single action
+// instead of padding to the 2-action minimum, and the result proves and verifies on the
+// post-NU6.3 circuit like any other bundle (coinbase bundles already demonstrate that
+// consensus accepts 1-action bundles).
 #[test]
-fn default_ironwood_bundle_builds_single_action_and_verifies() {
+fn unpadded_ironwood_bundle_builds_single_action_and_verifies() {
     let mut rng = OsRng;
     let post_nu6_3_pk = ProvingKey::build(OrchardCircuitVersion::PostNu6_3);
     let post_nu6_3_vk = VerifyingKey::build(OrchardCircuitVersion::PostNu6_3);
@@ -358,7 +358,11 @@ fn default_ironwood_bundle_builds_single_action_and_verifies() {
     let fvk = FullViewingKey::from(&sk);
     let recipient = fvk.address_at(0u32, Scope::External);
 
-    let builder = output_only_builder(BundleVersion::ironwood_v3(), BundleType::DEFAULT, recipient);
+    let builder = output_only_builder(
+        BundleVersion::ironwood_v3(),
+        BundleType::DEFAULT_UNPADDED,
+        recipient,
+    );
 
     let (unauthorized, bundle_meta) = builder.build::<i64>(&mut rng).unwrap().unwrap();
     assert_eq!(unauthorized.actions().len(), 1);

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -360,7 +360,7 @@ fn unpadded_ironwood_bundle_builds_single_action_and_verifies() {
 
     let builder = output_only_builder(
         BundleVersion::ironwood_v3(),
-        BundleType::DEFAULT_UNPADDED,
+        BundleType::UNPADDED,
         recipient,
     );
 


### PR DESCRIPTION
## Summary

Two changes that shrink the PCZT a producer sends an air-gapped signer like Keystone, and for single-action Orchard-pool bundles shrink the transaction itself.

- **Recomputable derived fields:** new `orchard::pczt::recompute` helpers rebuild an action's 6 derived fields (`cv_net`, `nullifier`, `rk`, `cmx`, `ephemeral_key`, `enc_ciphertext`) from the note components the PCZT already carries, so a producer can omit them and the signer regenerates them byte-identically before parsing. `out_ciphertext` is excluded because it is RNG-derived from `ovk` and never recomputable. Adds a non-breaking `ParseError::Recompute` variant.
- **Opt-in unpadded transactional bundles:** `BundleType::Transactional` gains a `pad_to_minimum` flag. `BundleType::DEFAULT` keeps the padded 2-action-minimum behavior; the new `BundleType::DEFAULT_UNPADDED` builds exactly the requested actions, for transactions whose shape is already public (e.g. pool migrations). `Builder::bundle_type()` lets fee calculation read back the configured type.

Every recomputed field is asserted byte-identical to the value the builder itself produced, for Orchard V2 and Ironwood V3 bundles; a one-action Ironwood bundle also proves and verifies end-to-end.

