### PR TITLE
Randomize restricted dummy ciphertexts only for external spends

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -408,8 +408,8 @@ pub struct OutputInfo {
     note_version: NoteVersion,
     /// When set, `build` fills `enc_ciphertext` with random bytes instead of encrypting the
     /// note to `recipient`. This is used only for the zero-valued output that a builder with
-    /// cross-address actions disabled pairs with a real spend, which is addressed to the
-    /// spent note's own receiver. A real ciphertext there would trial-decrypt under that
+    /// cross-address actions disabled pairs with a real external-scope spend, which is addressed
+    /// to the spent note's own receiver. A real ciphertext there would trial-decrypt under that
     /// receiver's incoming viewing key in the same action that carries the spend's nullifier,
     /// letting anyone who holds the ivk -- including a quantum adversary who recovered it from
     /// the published address -- detect the spend. The note and its commitment are unchanged.
@@ -443,16 +443,22 @@ impl OutputInfo {
     /// Constructs the zero-valued output that a builder with cross-address actions
     /// disabled pairs with a real spend.
     ///
-    /// `recipient` is the spent note's own receiver, so the output's `enc_ciphertext` is
-    /// randomized rather than encrypted to it (see the `randomized_ciphertext` field).
-    fn fabricated_for_spend(note_version: NoteVersion, recipient: Address) -> Self {
+    /// `recipient` is the spent note's own receiver. For external-scope spends, the output's
+    /// `enc_ciphertext` is randomized rather than encrypted to it (see the
+    /// `randomized_ciphertext` field). Internal-scope spends do not have the same external-address
+    /// exposure, so the deterministic ciphertext remains recomputable.
+    fn fabricated_for_spend(
+        note_version: NoteVersion,
+        recipient: Address,
+        spent_scope: Scope,
+    ) -> Self {
         Self {
             ovk: None,
             recipient,
             value: NoteValue::ZERO,
             memo: [0u8; 512],
             note_version,
-            randomized_ciphertext: true,
+            randomized_ciphertext: matches!(spent_scope, Scope::External),
         }
     }
 
@@ -799,11 +805,12 @@ impl Builder {
     /// the given note.
     ///
     /// In a bundle that disables cross-address transfers, each spend is paired with a
-    /// fabricated zero-valued output addressed to the spent note's own receiver. That output's
-    /// note ciphertext is randomized rather than encrypted to the receiver, so it is
-    /// undecryptable: the owning wallet does not see it when scanning, and no holder of the
-    /// receiver's incoming viewing key -- including a quantum adversary who recovered it from
-    /// the published address -- can use it to detect the spend.
+    /// fabricated zero-valued output addressed to the spent note's own receiver. For
+    /// external-scope spends, that output's note ciphertext is randomized rather than encrypted
+    /// to the receiver, so it is undecryptable: the owning wallet does not see it when scanning,
+    /// and no holder of the receiver's incoming viewing key -- including a quantum adversary who
+    /// recovered it from the published address -- can use it to detect the spend. Internal-scope
+    /// spends do not need this randomization.
     ///
     /// [`MerkleHashOrchard`]: crate::tree::MerkleHashOrchard
     pub fn add_spend(
@@ -1209,7 +1216,8 @@ fn build_bundle<B, R: RngCore>(
         let mut pairs = Vec::with_capacity(num_actions);
 
         for (spend_idx, spend) in spends.into_iter().enumerate() {
-            let output = OutputInfo::fabricated_for_spend(note_version, spend.note.recipient());
+            let output =
+                OutputInfo::fabricated_for_spend(note_version, spend.note.recipient(), spend.scope);
             pairs.push((Some(spend_idx), None, spend, output));
         }
 
@@ -2156,10 +2164,11 @@ mod tests {
         assert_eq!(spend_action.output.recipient, Some(spend_recipient));
         assert_eq!(spend_action.output.value, Some(NoteValue::ZERO));
 
-        // The spend-paired output's ciphertext is randomized, so signers (e.g. Keystone) must be
-        // able to classify it as a zero-valued dummy and tolerate the undecryptable ciphertext
-        // rather than reconstructing and rejecting it. That requires the explicit note fields to
-        // be present (so the commitment verifies), no `user_address`, and a zero value.
+        // This external-scope spend's paired output ciphertext is randomized, so signers
+        // (e.g. Keystone) must be able to classify it as a zero-valued dummy and tolerate the
+        // undecryptable ciphertext rather than reconstructing and rejecting it. That requires the
+        // explicit note fields to be present (so the commitment verifies), no `user_address`, and
+        // a zero value.
         assert!(spend_action.output.user_address.is_none());
         assert!(spend_action.output.rseed.is_some());
         assert!(spend_action

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -262,8 +262,9 @@ pub struct Output {
     /// - The Signer can use `recipient` and `rseed` (if present) to verify that
     ///   `enc_ciphertext` is correctly encrypted (and contains a note plaintext matching
     ///   the public commitments), and to confirm the value of the memo. This does not apply
-    ///   to the restricted builder's zero-valued output paired with a real spend, whose
-    ///   `enc_ciphertext` is deliberately randomized; its note commitment remains verifiable.
+    ///   to the restricted builder's zero-valued output paired with a real external-scope spend,
+    ///   whose `enc_ciphertext` is deliberately randomized; its note commitment remains
+    ///   verifiable.
     pub(crate) recipient: Option<Address>,
 
     /// The value of the output.
@@ -282,8 +283,9 @@ pub struct Output {
     /// - The Signer can use `recipient` and `rseed` (if present) to verify that
     ///   `enc_ciphertext` is correctly encrypted (and contains a note plaintext matching
     ///   the public commitments), and to confirm the value of the memo. This does not apply
-    ///   to the restricted builder's zero-valued output paired with a real spend, whose
-    ///   `enc_ciphertext` is deliberately randomized; its note commitment remains verifiable.
+    ///   to the restricted builder's zero-valued output paired with a real external-scope spend,
+    ///   whose `enc_ciphertext` is deliberately randomized; its note commitment remains
+    ///   verifiable.
     pub(crate) rseed: Option<RandomSeed>,
 
     /// The `ock` value used to encrypt `out_ciphertext`.

--- a/src/pczt/verify.rs
+++ b/src/pczt/verify.rs
@@ -141,8 +141,8 @@ pub mod recompute {
     /// carried by the real migrated output.) The encryption is independent of the
     /// sender's `ovk`, which affects only `out_ciphertext`; that field is RNG-derived and
     /// can never be recomputed. The one `enc_ciphertext` that also cannot be recomputed
-    /// is the zero-valued output paired with a real spend by a builder that disables
-    /// cross-address transfers, which is deliberately randomized.
+    /// is the zero-valued output paired with a real external-scope spend by a builder that
+    /// disables cross-address transfers, which is deliberately randomized.
     pub fn ephemeral_key_and_enc_ciphertext(
         recipient: &[u8; 43],
         value: u64,
@@ -443,10 +443,10 @@ mod tests {
     /// recomputation from the action's note component fields, using `memo` for the
     /// output's note plaintext.
     ///
-    /// Pass `expect_enc_match: false` for the fabricated output paired with a real spend
-    /// in a bundle that disables cross-address transfers: its `enc_ciphertext` is
-    /// deliberately randomized, so `ephemeral_key` must still match but `enc_ciphertext`
-    /// must not.
+    /// Pass `expect_enc_match: false` for the fabricated output paired with a real
+    /// external-scope spend in a bundle that disables cross-address transfers: its
+    /// `enc_ciphertext` is deliberately randomized, so `ephemeral_key` must still match but
+    /// `enc_ciphertext` must not.
     fn assert_action_recomputes(
         action: &crate::pczt::Action,
         memo: &[u8; 512],
@@ -594,17 +594,14 @@ mod tests {
         }
     }
 
-    /// In a bundle that disables cross-address transfers (post-NU6.3 Orchard, V2 notes),
-    /// every derived field recomputes byte-identically, except the `enc_ciphertext` of
-    /// the fabricated output paired with the real spend, which is deliberately randomized
-    /// and must not be reproducible. An explicit padded action covers the all-zero dummy
-    /// memo under V2.
-    #[test]
-    fn recompute_reproduces_restricted_orchard_bundle() {
+    fn assert_restricted_orchard_spend_recomputes(
+        spend_scope: Scope,
+        expect_spend_output_enc_match: bool,
+    ) {
         let mut rng = OsRng;
         let sk = SpendingKey::random(&mut rng);
         let fvk = FullViewingKey::from(&sk);
-        let recipient = fvk.address_at(0u32, Scope::External);
+        let recipient = fvk.address_at(0u32, spend_scope);
         let bundle_version = BundleVersion::orchard_v3();
         let note_version = bundle_version.note_version();
 
@@ -636,7 +633,28 @@ mod tests {
         assert_eq!(bundle.actions().len(), 2);
         for (index, action) in bundle.actions().iter().enumerate() {
             assert_eq!(*action.output().note_version(), NoteVersion::V2);
-            assert_action_recomputes(action, &[0u8; 512], index != spend_index);
+            assert_action_recomputes(
+                action,
+                &[0u8; 512],
+                index != spend_index || expect_spend_output_enc_match,
+            );
         }
+    }
+
+    /// In a bundle that disables cross-address transfers (post-NU6.3 Orchard, V2 notes),
+    /// every derived field recomputes byte-identically, except the `enc_ciphertext` of
+    /// the fabricated output paired with an external-scope real spend, which is deliberately
+    /// randomized and must not be reproducible. An explicit padded action covers the all-zero
+    /// dummy memo under V2.
+    #[test]
+    fn recompute_reproduces_restricted_external_orchard_bundle_except_ciphertext() {
+        assert_restricted_orchard_spend_recomputes(Scope::External, false);
+    }
+
+    /// Internal-scope spends do not have the same external-address exposure, so the fabricated
+    /// zero-valued output paired with the spend remains deterministic and recomputable.
+    #[test]
+    fn recompute_reproduces_restricted_internal_orchard_bundle() {
+        assert_restricted_orchard_spend_recomputes(Scope::Internal, true);
     }
 }


### PR DESCRIPTION
Restrict randomized note ciphertexts for cross-address-disabled fabricated spend outputs to external-scope spends. Internal-scope spends now keep deterministic zero-output encryption, which lets signers recompute the field while preserving the randomized behavior for externally exposed receivers.

Validation:
- cargo fmt --all -- --check
- cargo test -p orchard recompute_reproduces_restricted_ --features circuit
