### PR TITLE
Randomize restricted dummy ciphertexts only for external spends

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -396,8 +396,8 @@ pub struct OutputInfo {
     note_version: NoteVersion,
     /// When set, `build` fills `enc_ciphertext` with random bytes instead of encrypting the
     /// note to `recipient`. This is used only for the zero-valued output that a builder with
-    /// cross-address actions disabled pairs with a real spend, which is addressed to the
-    /// spent note's own receiver. A real ciphertext there would trial-decrypt under that
+    /// cross-address actions disabled pairs with a real external-scope spend, which is addressed
+    /// to the spent note's own receiver. A real ciphertext there would trial-decrypt under that
     /// receiver's incoming viewing key in the same action that carries the spend's nullifier,
     /// letting anyone who holds the ivk -- including a quantum adversary who recovered it from
     /// the published address -- detect the spend. The note and its commitment are unchanged.
@@ -431,16 +431,22 @@ impl OutputInfo {
     /// Constructs the zero-valued output that a builder with cross-address actions
     /// disabled pairs with a real spend.
     ///
-    /// `recipient` is the spent note's own receiver, so the output's `enc_ciphertext` is
-    /// randomized rather than encrypted to it (see the `randomized_ciphertext` field).
-    fn fabricated_for_spend(note_version: NoteVersion, recipient: Address) -> Self {
+    /// `recipient` is the spent note's own receiver. For external-scope spends, the output's
+    /// `enc_ciphertext` is randomized rather than encrypted to it (see the
+    /// `randomized_ciphertext` field). Internal-scope spends do not have the same external-address
+    /// exposure, so the deterministic ciphertext remains decryptable.
+    fn fabricated_for_spend(
+        note_version: NoteVersion,
+        recipient: Address,
+        spent_scope: Scope,
+    ) -> Self {
         Self {
             ovk: None,
             recipient,
             value: NoteValue::ZERO,
             memo: [0u8; 512],
             note_version,
-            randomized_ciphertext: true,
+            randomized_ciphertext: matches!(spent_scope, Scope::External),
         }
     }
 
@@ -787,11 +793,12 @@ impl Builder {
     /// the given note.
     ///
     /// In a bundle that disables cross-address transfers, each spend is paired with a
-    /// fabricated zero-valued output addressed to the spent note's own receiver. That output's
-    /// note ciphertext is randomized rather than encrypted to the receiver, so it is
-    /// undecryptable: the owning wallet does not see it when scanning, and no holder of the
-    /// receiver's incoming viewing key -- including a quantum adversary who recovered it from
-    /// the published address -- can use it to detect the spend.
+    /// fabricated zero-valued output addressed to the spent note's own receiver. For
+    /// external-scope spends, that output's note ciphertext is randomized rather than encrypted
+    /// to the receiver, so it is undecryptable: the owning wallet does not see it when scanning,
+    /// and no holder of the receiver's incoming viewing key -- including a quantum adversary who
+    /// recovered it from the published address -- can use it to detect the spend. Internal-scope
+    /// spends do not need this randomization.
     ///
     /// [`MerkleHashOrchard`]: crate::tree::MerkleHashOrchard
     pub fn add_spend(
@@ -1197,7 +1204,8 @@ fn build_bundle<B, R: RngCore>(
         let mut pairs = Vec::with_capacity(num_actions);
 
         for (spend_idx, spend) in spends.into_iter().enumerate() {
-            let output = OutputInfo::fabricated_for_spend(note_version, spend.note.recipient());
+            let output =
+                OutputInfo::fabricated_for_spend(note_version, spend.note.recipient(), spend.scope);
             pairs.push((Some(spend_idx), None, spend, output));
         }
 
@@ -1818,13 +1826,17 @@ mod tests {
         bundle::{Authorized, Bundle, BundleVersion, Flags},
         circuit::{OrchardCircuitVersion, ProvingKey},
         constants::MERKLE_DEPTH_ORCHARD,
-        keys::{FullViewingKey, Scope, SpendAuthorizingKey, SpendingKey},
+        keys::{
+            FullViewingKey, PreparedIncomingViewingKey, Scope, SpendAuthorizingKey, SpendingKey,
+        },
         note::{NoteVersion, Nullifier, Rho},
+        note_encryption::OrchardDomain,
         pczt::{ProverError, VerifyError},
         tree::{MerklePath, EMPTY_ROOTS},
         value::NoteValue,
         Address, Anchor, Note,
     };
+    use zcash_note_encryption::try_note_decryption;
 
     fn note_with_path(
         rng: &mut impl RngCore,
@@ -2137,6 +2149,44 @@ mod tests {
                 .unwrap()
                 .same_expanded_receiver(action.output.recipient.as_ref().unwrap()));
         }
+    }
+
+    #[test]
+    fn cross_address_disabled_spend_output_randomization_depends_on_scope() {
+        fn spend_paired_output_decrypts(spend_scope: Scope) -> bool {
+            let mut rng = OsRng;
+            let spend_sk = SpendingKey::random(&mut rng);
+            let spend_fvk = FullViewingKey::from(&spend_sk);
+            let spend_recipient = spend_fvk.address_at(0u32, spend_scope);
+            let bundle_version = BundleVersion::orchard_v3();
+            let (note, merkle_path, anchor) = note_with_path(
+                &mut rng,
+                spend_recipient,
+                NoteValue::from_raw(15_000),
+                bundle_version.note_version(),
+            );
+
+            let mut builder = Builder::new(
+                transactional(true),
+                bundle_version,
+                bundle_version.default_flags(),
+                anchor,
+            )
+            .unwrap();
+            builder
+                .add_spend(spend_fvk.clone(), note, merkle_path)
+                .unwrap();
+
+            let (pczt_bundle, bundle_meta) = builder.build_for_pczt(&mut rng).unwrap();
+            let spend_action = &pczt_bundle.actions()[bundle_meta.spend_action_index(0).unwrap()];
+            let domain = OrchardDomain::for_pczt_action(spend_action);
+
+            let ivk = PreparedIncomingViewingKey::new(&spend_fvk.to_ivk(spend_scope));
+            try_note_decryption(&domain, &ivk, spend_action).is_some()
+        }
+
+        assert!(!spend_paired_output_decrypts(Scope::External));
+        assert!(spend_paired_output_decrypts(Scope::Internal));
     }
 
     #[test]

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -262,8 +262,9 @@ pub struct Output {
     /// - The Signer can use `recipient` and `rseed` (if present) to verify that
     ///   `enc_ciphertext` is correctly encrypted (and contains a note plaintext matching
     ///   the public commitments), and to confirm the value of the memo. This does not apply
-    ///   to the restricted builder's zero-valued output paired with a real spend, whose
-    ///   `enc_ciphertext` is deliberately randomized; its note commitment remains verifiable.
+    ///   to the restricted builder's zero-valued output paired with a real external-scope spend,
+    ///   whose `enc_ciphertext` is deliberately randomized; its note commitment remains
+    ///   verifiable.
     pub(crate) recipient: Option<Address>,
 
     /// The value of the output.
@@ -282,8 +283,9 @@ pub struct Output {
     /// - The Signer can use `recipient` and `rseed` (if present) to verify that
     ///   `enc_ciphertext` is correctly encrypted (and contains a note plaintext matching
     ///   the public commitments), and to confirm the value of the memo. This does not apply
-    ///   to the restricted builder's zero-valued output paired with a real spend, whose
-    ///   `enc_ciphertext` is deliberately randomized; its note commitment remains verifiable.
+    ///   to the restricted builder's zero-valued output paired with a real external-scope spend,
+    ///   whose `enc_ciphertext` is deliberately randomized; its note commitment remains
+    ///   verifiable.
     pub(crate) rseed: Option<RandomSeed>,
 
     /// The `ock` value used to encrypt `out_ciphertext`.


### PR DESCRIPTION
## Summary

This PR updates the randomization of output ciphertexts, to only occur for notes decryptable the external viewing key. We added the randomization to protect against a quantum adversary being able to identify a tx-splitting attack for Orchard -> Ironwood migration, but this is only needed for notes paid to one's _external viewing key_. The quantum risk does not apply for the internal case, as the adversary does not learn the user's internal ivk address.



## Validation

- cargo fmt --all -- --check
- cargo test -p orchard cross_address_disabled_spend_output_randomization_depends_on_scope --features circuit
- cargo test -p orchard cross_address_disabled --features circuit