### PR TITLE
Add opt-in unpadded transactional bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,11 @@ Existing callers keep the current behavior by constructing bundles with
 - New builder errors:
   - `orchard::builder::BuildError::{CrossAddressDisabled, InvalidNoteVersion, UnrepresentableFlags, CoinbaseSpendsEnabled}`
   - `orchard::builder::OutputError::{SpendsDisabled, CrossAddressDisabled, RecipientNotOwned}`
+- `orchard::builder::BundleType::DEFAULT_UNPADDED`, a transactional bundle type that
+  disables padding for transactions whose shape is already public (e.g. pool
+  migrations).
+- `orchard::builder::Builder::bundle_type`, returning the `BundleType` the builder
+  was constructed with.
 - Ironwood and note-version APIs:
   - `orchard::NoteVersion`, the note plaintext version selector, with variants
     `V2` (the ZIP 212 Orchard note plaintext format) and `V3` (the
@@ -145,6 +150,10 @@ Existing callers keep the current behavior by constructing bundles with
     `BundleVersion`.
   - `orchard::builder::BundleMetadata::output_action_index` now indexes the plain
     outputs first, followed by the wallet-controlled change outputs.
+- `orchard::builder::BundleType::Transactional` now carries a `pad_to_minimum` flag;
+  when `false`, the bundle is not padded to the 2-action minimum and contains exactly
+  the requested actions (at least one, if `bundle_required` is set).
+  `BundleType::DEFAULT` keeps the existing padded behavior.
 - For `BundleVersion::orchard_v3()`, the builder constructs
   withdrawal/change bundles that disable cross-address transfers: every action's
   output is addressed to the expanded receiver of the note it spends. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,9 +80,8 @@ Existing callers keep the current behavior by constructing bundles with
 - New builder errors:
   - `orchard::builder::BuildError::{CrossAddressDisabled, InvalidNoteVersion, UnrepresentableFlags, CoinbaseSpendsEnabled}`
   - `orchard::builder::OutputError::{SpendsDisabled, CrossAddressDisabled, RecipientNotOwned}`
-- `orchard::builder::BundleType::DEFAULT_UNPADDED`, a transactional bundle type that
-  disables padding for transactions whose shape is already public (e.g. pool
-  migrations).
+- `orchard::builder::BundleType::UNPADDED`, a transactional bundle type that disables
+  padding for transactions whose shape is already public (e.g. pool migrations).
 - `orchard::builder::Builder::bundle_type`, returning the `BundleType` the builder
   was constructed with.
 - Ironwood and note-version APIs:
@@ -150,9 +149,12 @@ Existing callers keep the current behavior by constructing bundles with
     `BundleVersion`.
   - `orchard::builder::BundleMetadata::output_action_index` now indexes the plain
     outputs first, followed by the wallet-controlled change outputs.
-- `orchard::builder::BundleType::Transactional` now carries a `pad_to_minimum` flag;
-  when `false`, the bundle is not padded to the 2-action minimum and contains exactly
-  the requested actions (at least one, if `bundle_required` is set).
+- `orchard::builder::BundleType::Transactional` now carries a required
+  `pad_to_minimum: Option<u8>` field, so callers that directly construct or
+  pattern-match this public enum variant must update their code. When set to
+  `Some(1)`, the bundle is not padded to the 2-action minimum and contains
+  exactly the requested actions (at least one, if `bundle_required` is set).
+  When set to `None`, the default 2-action minimum is used.
   `BundleType::DEFAULT` keeps the existing padded behavior.
 - For `BundleVersion::orchard_v3()`, the builder constructs
   withdrawal/change bundles that disable cross-address transfers: every action's

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -34,53 +34,63 @@ use {
     nonempty::NonEmpty,
 };
 
-const MIN_ACTIONS: usize = 2;
+const DEFAULT_MIN_ACTIONS: u8 = 2;
 
 /// An enumeration of rules for Orchard bundle construction.
 ///
-/// This selects only the construction discipline; the bundle's [`Flags`] are supplied separately
-/// to the builder (see [`Builder::new`] and [`BundleVersion::default_flags`]).
+/// This selects only the construction discipline; the bundle's [`Flags`] are
+/// supplied separately to the builder (see [`Builder::new`] and
+/// [`BundleVersion::default_flags`]).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BundleType {
-    /// A transactional bundle is padded, when `pad_to_minimum` is set, to contain at least
-    /// 2 actions, irrespective of whether any genuine actions are required.
+    /// A transactional bundle is padded to contain at least the configured
+    /// `pad_to_minimum` actions, defaulting to 2 actions when
+    /// `pad_to_minimum` is [`None`].
     Transactional {
-        /// A flag that, when set to `true`, indicates that a bundle should be produced even if no
-        /// spends or outputs have been added to the bundle; in such a circumstance, all of the
-        /// actions in the resulting bundle will be dummies.
+        /// A flag that, when set to `true`, indicates that a bundle should be
+        /// produced even if no spends or outputs have been added to the bundle;
+        /// in such a circumstance, all of the actions in the resulting bundle
+        /// will be dummies.
         bundle_required: bool,
-        /// A flag that, when set to `false`, disables padding of the bundle to the 2-action
-        /// minimum: the bundle contains exactly the requested actions (at least one, if
+        /// The minimum number of actions to pad the transaction to.
+        ///
+        /// If this is [`None`], the default 2-action minimum is used. Set this
+        /// to `Some(1)` for transactions whose shape is already public: the
+        /// bundle then contains exactly the requested actions (at least one, if
         /// `bundle_required` is set). One-action bundles are consensus-valid
-        /// ([`BundleType::Coinbase`] bundles are never padded); the minimum exists to improve
-        /// indistinguishability, so disabling it lets the action count reveal the
-        /// transaction shape.
-        pad_to_minimum: bool,
+        /// ([`BundleType::Coinbase`] bundles are never padded); the default minimum
+        /// exists to improve indistinguishability, so reducing it lets the action
+        /// count reveal the transaction shape.
+        pad_to_minimum: Option<u8>,
     },
-    /// A coinbase bundle performs no padding and requires the bundle's flags to disable spends.
+    /// A coinbase bundle performs no padding and requires the bundle's flags to
+    /// disable spends.
     ///
-    /// Since coinbase transactions have `enableSpends = 0`, every spend must be a dummy. Coinbase
-    /// transactions are not otherwise any different wrt cross-address restrictions from other
-    /// transactions that have dummy inputs.
+    /// Since coinbase transactions have `enableSpends = 0`, every spend must be
+    /// a dummy. Coinbase transactions are not otherwise any different wrt
+    /// cross-address restrictions from other transactions that have dummy
+    /// inputs.
     Coinbase,
 }
 
 impl BundleType {
-    /// The default bundle type: a padded transactional bundle that is not required to be
-    /// produced if no spends or outputs have been added.
+    /// The default bundle type: a transactional bundle padded to the default
+    /// minimum action count, and not required to be produced if no spends or
+    /// outputs have been added.
     pub const DEFAULT: BundleType = BundleType::Transactional {
         bundle_required: false,
-        pad_to_minimum: true,
+        pad_to_minimum: Some(DEFAULT_MIN_ACTIONS),
     };
 
-    /// [`BundleType::DEFAULT`] without padding: the bundle contains exactly the requested
-    /// actions. Intended for transactions whose shape is already public — such as pool
-    /// migrations, where the per-pool value balances reveal the transfer — since the
-    /// action count reveals the transaction shape (see
+    /// Unpadded transactional bundle: the bundle is padded only to the
+    /// one-action consensus minimum, so it contains exactly the requested
+    /// actions. Intended for transactions whose shape is already public — such
+    /// as pool migrations, where the per-pool value balances reveal the
+    /// transfer — since the action count reveals the transaction shape (see
     /// [`BundleType::Transactional::pad_to_minimum`]).
-    pub const DEFAULT_UNPADDED: BundleType = BundleType::Transactional {
+    pub const UNPADDED: BundleType = BundleType::Transactional {
         bundle_required: false,
-        pad_to_minimum: false,
+        pad_to_minimum: Some(1),
     };
 
     /// Returns the number of logical actions that the builder will produce in constructing a bundle
@@ -125,7 +135,12 @@ impl BundleType {
                 } else if !flags.outputs_enabled() && num_outputs > 0 {
                     Err("Outputs are disabled, so num_outputs must be zero")
                 } else {
-                    let min_actions = if *pad_to_minimum { MIN_ACTIONS } else { 1 };
+                    let mut min_actions =
+                        usize::from(pad_to_minimum.unwrap_or(DEFAULT_MIN_ACTIONS));
+                    if *bundle_required {
+                        min_actions = core::cmp::max(min_actions, 1);
+                    }
+
                     Ok(if *bundle_required || num_requested_actions > 0 {
                         core::cmp::max(num_requested_actions, min_actions)
                     } else {
@@ -1851,6 +1866,7 @@ mod tests {
 
     use super::{
         bundle, BuildError, Builder, ChangeInfo, MaybeSigned, OutputError, OutputInfo, SpendInfo,
+        DEFAULT_MIN_ACTIONS,
     };
     use crate::{
         builder::BundleType,
@@ -1886,36 +1902,51 @@ mod tests {
     fn transactional(bundle_required: bool) -> BundleType {
         BundleType::Transactional {
             bundle_required,
-            pad_to_minimum: true,
+            pad_to_minimum: None,
         }
     }
 
     #[test]
     fn num_actions_respects_pad_to_minimum() {
         let padded = transactional(false);
+        let explicitly_padded = BundleType::Transactional {
+            bundle_required: false,
+            pad_to_minimum: Some(DEFAULT_MIN_ACTIONS),
+        };
+        let padded_to_three = BundleType::Transactional {
+            bundle_required: false,
+            pad_to_minimum: Some(3),
+        };
         let unpadded = BundleType::Transactional {
             bundle_required: false,
-            pad_to_minimum: false,
+            pad_to_minimum: Some(1),
+        };
+        let required_no_padding = BundleType::Transactional {
+            bundle_required: true,
+            pad_to_minimum: Some(0),
         };
         let required_unpadded = BundleType::Transactional {
             bundle_required: true,
-            pad_to_minimum: false,
+            pad_to_minimum: Some(1),
         };
 
         // Cross-address transfers enabled: requested actions = max(spends, outputs).
         let flags = BundleVersion::ironwood_v3().default_flags();
         assert_eq!(padded.num_actions(flags, 0, 1), Ok(2));
+        assert_eq!(explicitly_padded.num_actions(flags, 0, 1), Ok(2));
+        assert_eq!(padded_to_three.num_actions(flags, 0, 1), Ok(3));
         assert_eq!(unpadded.num_actions(flags, 0, 1), Ok(1));
         assert_eq!(BundleType::DEFAULT.num_actions(flags, 0, 1), Ok(2));
-        assert_eq!(BundleType::DEFAULT_UNPADDED.num_actions(flags, 0, 1), Ok(1));
+        assert_eq!(BundleType::UNPADDED.num_actions(flags, 0, 1), Ok(1));
         assert_eq!(unpadded.num_actions(flags, 2, 3), Ok(3));
         assert_eq!(unpadded.num_actions(flags, 0, 0), Ok(0));
         // `bundle_required` still guarantees a bundle exists: a single all-dummy action.
+        assert_eq!(required_no_padding.num_actions(flags, 0, 0), Ok(1));
         assert_eq!(required_unpadded.num_actions(flags, 0, 0), Ok(1));
 
         let flags = BundleVersion::orchard_v2().default_flags();
         assert_eq!(BundleType::DEFAULT.num_actions(flags, 0, 1), Ok(2));
-        assert_eq!(BundleType::DEFAULT_UNPADDED.num_actions(flags, 0, 1), Ok(1));
+        assert_eq!(BundleType::UNPADDED.num_actions(flags, 0, 1), Ok(1));
 
         // Cross-address transfers disabled: requested actions = spends + outputs.
         let flags = BundleVersion::orchard_v3().default_flags();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -42,13 +42,20 @@ const MIN_ACTIONS: usize = 2;
 /// to the builder (see [`Builder::new`] and [`BundleVersion::default_flags`]).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BundleType {
-    /// A transactional bundle will be padded if necessary to contain at least 2 actions,
-    /// irrespective of whether any genuine actions are required.
+    /// A transactional bundle is padded, when `pad_to_minimum` is set, to contain at least
+    /// 2 actions, irrespective of whether any genuine actions are required.
     Transactional {
         /// A flag that, when set to `true`, indicates that a bundle should be produced even if no
         /// spends or outputs have been added to the bundle; in such a circumstance, all of the
         /// actions in the resulting bundle will be dummies.
         bundle_required: bool,
+        /// A flag that, when set to `false`, disables padding of the bundle to the 2-action
+        /// minimum: the bundle contains exactly the requested actions (at least one, if
+        /// `bundle_required` is set). One-action bundles are consensus-valid
+        /// ([`BundleType::Coinbase`] bundles are never padded); the minimum exists to improve
+        /// indistinguishability, so disabling it lets the action count reveal the
+        /// transaction shape.
+        pad_to_minimum: bool,
     },
     /// A coinbase bundle performs no padding and requires the bundle's flags to disable spends.
     ///
@@ -59,10 +66,21 @@ pub enum BundleType {
 }
 
 impl BundleType {
-    /// The default bundle type: a transactional bundle that is not required to be produced if no
-    /// spends or outputs have been added.
+    /// The default bundle type: a padded transactional bundle that is not required to be
+    /// produced if no spends or outputs have been added.
     pub const DEFAULT: BundleType = BundleType::Transactional {
         bundle_required: false,
+        pad_to_minimum: true,
+    };
+
+    /// [`BundleType::DEFAULT`] without padding: the bundle contains exactly the requested
+    /// actions. Intended for transactions whose shape is already public — such as pool
+    /// migrations, where the per-pool value balances reveal the transfer — since the
+    /// action count reveals the transaction shape (see
+    /// [`BundleType::Transactional::pad_to_minimum`]).
+    pub const DEFAULT_UNPADDED: BundleType = BundleType::Transactional {
+        bundle_required: false,
+        pad_to_minimum: false,
     };
 
     /// Returns the number of logical actions that the builder will produce in constructing a bundle
@@ -86,7 +104,10 @@ impl BundleType {
         num_outputs: usize,
     ) -> Result<usize, &'static str> {
         match self {
-            BundleType::Transactional { bundle_required } => {
+            BundleType::Transactional {
+                bundle_required,
+                pad_to_minimum,
+            } => {
                 // When cross-address transfers are disabled, every action's output is
                 // addressed to the note it spends. For this implementation, a requested
                 // spend and a requested output never share an action: each is paired with
@@ -104,8 +125,9 @@ impl BundleType {
                 } else if !flags.outputs_enabled() && num_outputs > 0 {
                     Err("Outputs are disabled, so num_outputs must be zero")
                 } else {
+                    let min_actions = if *pad_to_minimum { MIN_ACTIONS } else { 1 };
                     Ok(if *bundle_required || num_requested_actions > 0 {
-                        core::cmp::max(num_requested_actions, MIN_ACTIONS)
+                        core::cmp::max(num_requested_actions, min_actions)
                     } else {
                         0
                     })
@@ -775,6 +797,15 @@ impl Builder {
             changes: vec![],
             anchor,
         })
+    }
+
+    /// Returns the bundle type this builder was constructed with.
+    ///
+    /// Lets callers that must predict the builder's action count (e.g. fee
+    /// calculation) read back the exact [`BundleType`] the bundle will be built
+    /// with, so the two cannot drift.
+    pub fn bundle_type(&self) -> BundleType {
+        self.bundle_type
     }
 
     /// Returns the note version associated with this builder's bundle version.
@@ -1853,7 +1884,43 @@ mod tests {
     }
 
     fn transactional(bundle_required: bool) -> BundleType {
-        BundleType::Transactional { bundle_required }
+        BundleType::Transactional {
+            bundle_required,
+            pad_to_minimum: true,
+        }
+    }
+
+    #[test]
+    fn num_actions_respects_pad_to_minimum() {
+        let padded = transactional(false);
+        let unpadded = BundleType::Transactional {
+            bundle_required: false,
+            pad_to_minimum: false,
+        };
+        let required_unpadded = BundleType::Transactional {
+            bundle_required: true,
+            pad_to_minimum: false,
+        };
+
+        // Cross-address transfers enabled: requested actions = max(spends, outputs).
+        let flags = BundleVersion::ironwood_v3().default_flags();
+        assert_eq!(padded.num_actions(flags, 0, 1), Ok(2));
+        assert_eq!(unpadded.num_actions(flags, 0, 1), Ok(1));
+        assert_eq!(BundleType::DEFAULT.num_actions(flags, 0, 1), Ok(2));
+        assert_eq!(BundleType::DEFAULT_UNPADDED.num_actions(flags, 0, 1), Ok(1));
+        assert_eq!(unpadded.num_actions(flags, 2, 3), Ok(3));
+        assert_eq!(unpadded.num_actions(flags, 0, 0), Ok(0));
+        // `bundle_required` still guarantees a bundle exists: a single all-dummy action.
+        assert_eq!(required_unpadded.num_actions(flags, 0, 0), Ok(1));
+
+        let flags = BundleVersion::orchard_v2().default_flags();
+        assert_eq!(BundleType::DEFAULT.num_actions(flags, 0, 1), Ok(2));
+        assert_eq!(BundleType::DEFAULT_UNPADDED.num_actions(flags, 0, 1), Ok(1));
+
+        // Cross-address transfers disabled: requested actions = spends + outputs.
+        let flags = BundleVersion::orchard_v3().default_flags();
+        assert_eq!(unpadded.num_actions(flags, 1, 0), Ok(1));
+        assert_eq!(unpadded.num_actions(flags, 1, 1), Ok(2));
     }
 
     #[test]

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -344,6 +344,40 @@ fn post_nu6_3_coinbase_bundle_proves_and_verifies() {
     verify_bundle(&bundle, &post_nu6_3_vk, TxVersion::V6);
 }
 
+// An explicitly unpadded transactional bundle builds exactly the requested single action
+// instead of padding to the 2-action minimum, and the result proves and verifies on the
+// post-NU6.3 circuit like any other bundle (coinbase bundles already demonstrate that
+// consensus accepts 1-action bundles).
+#[test]
+fn unpadded_ironwood_bundle_builds_single_action_and_verifies() {
+    let mut rng = OsRng;
+    let post_nu6_3_pk = ProvingKey::build(OrchardCircuitVersion::PostNu6_3);
+    let post_nu6_3_vk = VerifyingKey::build(OrchardCircuitVersion::PostNu6_3);
+
+    let sk = SpendingKey::from_bytes([0; 32]).unwrap();
+    let fvk = FullViewingKey::from(&sk);
+    let recipient = fvk.address_at(0u32, Scope::External);
+
+    let builder = output_only_builder(
+        BundleVersion::ironwood_v3(),
+        BundleType::DEFAULT_UNPADDED,
+        recipient,
+    );
+
+    let (unauthorized, bundle_meta) = builder.build::<i64>(&mut rng).unwrap().unwrap();
+    assert_eq!(unauthorized.actions().len(), 1);
+    assert_eq!(bundle_meta.output_action_index(0), Some(0));
+
+    let sighash: [u8; 32] = unauthorized
+        .commitment(TxVersion::V6)
+        .expect("bundle flags are representable in this format")
+        .into();
+    let proven = unauthorized.create_proof(&post_nu6_3_pk, &mut rng).unwrap();
+    let bundle = proven.apply_signatures(rng, sighash, &[]).unwrap();
+
+    verify_bundle(&bundle, &post_nu6_3_vk, TxVersion::V6);
+}
+
 // A post-NU 6.3 restricted bundle chain: an ordinary shielding bundle, followed by a bundle
 // that disables cross-address transfers, withdraws part of the shielded value,
 // and retains the rest as wallet-controlled change.

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -363,6 +363,7 @@ fn unpadded_ironwood_bundle_builds_single_action_and_verifies() {
         BundleType::UNPADDED,
         recipient,
     );
+    assert_eq!(builder.bundle_type(), BundleType::UNPADDED);
 
     let (unauthorized, bundle_meta) = builder.build::<i64>(&mut rng).unwrap().unwrap();
     assert_eq!(unauthorized.actions().len(), 1);

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -360,7 +360,7 @@ fn unpadded_ironwood_bundle_builds_single_action_and_verifies() {
 
     let builder = output_only_builder(
         BundleVersion::ironwood_v3(),
-        BundleType::DEFAULT_UNPADDED,
+        BundleType::UNPADDED,
         recipient,
     );
 


### PR DESCRIPTION
Adds a `pad_to_minimum` flag to `BundleType::Transactional`. `BundleType::DEFAULT` keeps today's padded behavior; the new `BundleType::UNPADDED` builds exactly the requested actions, for transactions whose shape is already public (e.g. pool migrations). Also adds `Builder::bundle_type()` so fee calculation can read back the configured type. A 1-action Ironwood bundle proves and verifies end-to-end.