### PR TITLE
Accelerate batched trial decryption with GLV endomorphism windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Batched trial decryption (the `zcash_note_encryption::batch` APIs) is
+  significantly faster. Ephemeral keys are now prepared with GLV endomorphism
+  windows built across the whole batch with a single shared normalization, and
+  each viewing key's GLV decomposition is computed once per batch via the new
+  `BatchDomain::batch_ka_agree_dec` hook. Shared secrets are unchanged
+  (byte-identical to the per-item path), and the per-output decryption entry
+  points are unaffected. Like the existing `group::Wnaf`-based preparation,
+  the new path is variable-time with respect to the (wallet-local) viewing
+  key scalar.
+- MSRV-compatible bump: the minimum `zcash_note_encryption` version is now
+  0.4.2 (for `BatchDomain::batch_ka_agree_dec`).
+
 ## [0.15.0] 2026-07-09
 
 This release introduces `orchard::bundle::BundleVersion`, the `(value pool, protocol

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,9 +2559,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_note_encryption"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77efec759c3798b6e4d829fcc762070d9b229b0f13338c40bf993b7b609c2272"
+checksum = "e1cb1b9170c94370e3d66c5cc0877661db743337588b64de7711239eed462198"
 dependencies = [
  "chacha20",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ poseidon = { package = "halo2_poseidon", version = "0.1" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 sinsemilla = "0.1"
 subtle = { version = "2.6", default-features = false }
-zcash_note_encryption = "0.4"
+zcash_note_encryption = "0.4.2"
 incrementalmerkletree = "0.8.1"
 zcash_spec = "0.2.1"
 zip32 = { version = "0.2.0", default-features = false }
@@ -70,7 +70,7 @@ criterion = "0.4" # 0.5 depends on clap 4 which has MSRV 1.70
 halo2_gadgets = { version = "0.5", features = ["test-dependencies"] }
 hex = "0.4"
 proptest = ">=1.0.0, <1.7.0"
-zcash_note_encryption = { version = "0.4", features = ["pre-zip-212"] }
+zcash_note_encryption = { version = "0.4.2", features = ["pre-zip-212"] }
 incrementalmerkletree = { version = "0.8.1", features = ["test-dependencies"] }
 shardtree = "0.6"
 

--- a/src/endo.rs
+++ b/src/endo.rs
@@ -1,0 +1,479 @@
+//! GLV endomorphism-accelerated scalar multiplication for batched trial
+//! decryption.
+//!
+//! Pallas carries the cube-root endomorphism φ(x, y) = (ζ_p·x, y), with
+//! φ(P) = λ·P for λ = `Scalar::ZETA` and ζ_p = `Base::ZETA`. A one-time GLV
+//! decomposition splits a 255-bit scalar into two signed halves of at most
+//! 128 bits each, k = k1 + k2·λ (mod r_P), so that `k·P = k1·P + k2·φ(P)`
+//! runs as a Straus ladder with shared doublings: ~128 doublings plus ~52
+//! window-4 additions, instead of the ~255 doublings a full-width walk pays.
+//!
+//! Batched trial decryption multiplies every ephemeral key in a batch by
+//! each of the wallet's incoming viewing keys, which makes both halves of
+//! the work amortizable:
+//!
+//! - [`EndoTable`] is the window for one ephemeral key: the odd multiples
+//!   {1, 3, 5, 7}·P and {1, 3, 5, 7}·φ(P) in affine coordinates. It is built
+//!   once per ephemeral key — [`endo_tables`] normalizes the windows for the
+//!   whole batch with a single shared inversion — and is then reused by every
+//!   viewing key's multiplication against that key.
+//! - [`DecomposedScalar`] is a viewing key's GLV split with both halves
+//!   already wNAF-recoded; it is computed once per (viewing key, batch) and
+//!   consumed read-only by every ladder run.
+//!
+//! Correctness does not rest on how the GLV constants below were derived:
+//! `decompose_reconstructs` re-verifies k1 + k2·λ ≡ k (mod r_P) from scratch
+//! for full-width scalars and edge cases, `endo_map_is_lambda` pins the φ↔λ
+//! pairing on the real curve, and the ladder is tested byte-identical to the
+//! group's own scalar multiplication.
+//!
+//! Like the `group::Wnaf`-based preparation this complements, this path is
+//! variable-time with respect to the scalar. It is used only for trial
+//! decryption with the wallet's own incoming viewing keys, matching the
+//! existing `PreparedNonZeroScalar` usage.
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use ff::{PrimeField, WithSmallOrderMulGroup};
+use group::{prime::PrimeCurveAffine, Curve, Group};
+use pasta_curves::arithmetic::CurveAffine;
+use pasta_curves::pallas;
+
+// GLV constants for the Pallas scalar field. Short lattice basis for
+// {(a, b) : a + b·λ ≡ 0 (mod r_P)}:
+//   v1 = (V1A, −V1B_NEG), v2 = (V2A, V2B)
+// The `decompose_reconstructs` test proves these correct independently of
+// their derivation: wrong constants cannot reconstruct k.
+const V1A: u128 = 0x49e69d1640f049157fcae1c700000001;
+const V1B_NEG: u128 = 0x49e69d1640a899538cb1279300000000;
+const V2A: u128 = 0x49e69d1640a899538cb1279300000000;
+const V2B: u128 = 0x93cd3a2c8198e2690c7c095a00000001;
+// Babai rounding coefficients: g1 = round(2^384·v2.b / r_P),
+// g2 = round(2^384·(−v1.b) / r_P).
+const G1: [u64; 5] = [
+    0x111f686111afc293,
+    0xc35fbd4d086862e0,
+    0x31f0256800000002,
+    0x4f34e8b2066389a4,
+    0x2,
+];
+const G2: [u64; 5] = [
+    0x4a95a2d972171db4,
+    0x61afdea68480fa55,
+    0x32c49e4bffffffff,
+    0x279a745902a2654e,
+    0x1,
+];
+
+/// `round((g · k) / 2^384)` for a 5-limb `g` and 4-limb `k` — the Babai
+/// coefficient. Fits `u128` (at most ~128 bits by construction).
+fn round_mul_shift(g: &[u64; 5], k: &[u64; 4]) -> u128 {
+    let mut prod = [0u64; 9];
+    for (i, &gi) in g.iter().enumerate() {
+        let mut carry = 0u128;
+        for (j, &kj) in k.iter().enumerate() {
+            let t = u128::from(gi) * u128::from(kj) + u128::from(prod[i + j]) + carry;
+            prod[i + j] = t as u64;
+            carry = t >> 64;
+        }
+        prod[i + 4] = prod[i + 4].wrapping_add(carry as u64);
+    }
+    // Bits >= 384 live in limbs 6..; round on bit 383 (top bit of limb 5).
+    let round = prod[5] >> 63;
+    (u128::from(prod[6]) | (u128::from(prod[7]) << 64)).wrapping_add(u128::from(round))
+}
+
+/// 256-bit product of two `u128`s, as little-endian limbs.
+fn mul_u128(a: u128, b: u128) -> [u64; 4] {
+    let (a0, a1) = (a as u64, (a >> 64) as u64);
+    let (b0, b1) = (b as u64, (b >> 64) as u64);
+    let mut out = [0u64; 4];
+    let mut acc = |i: usize, v: u128| {
+        let mut idx = i;
+        let mut carry = v;
+        while carry != 0 {
+            let t = u128::from(out[idx]) + (carry & u128::from(u64::MAX));
+            out[idx] = t as u64;
+            carry = (carry >> 64) + (t >> 64);
+            idx += 1;
+        }
+    };
+    acc(0, u128::from(a0) * u128::from(b0));
+    acc(1, u128::from(a0) * u128::from(b1));
+    acc(1, u128::from(a1) * u128::from(b0));
+    acc(2, u128::from(a1) * u128::from(b1));
+    out
+}
+
+/// 256-bit wrapping subtraction (two's complement).
+fn sub256(a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
+    let mut out = [0u64; 4];
+    let mut borrow = 0u64;
+    for i in 0..4 {
+        let (d, b1) = a[i].overflowing_sub(b[i]);
+        let (d, b2) = d.overflowing_sub(borrow);
+        out[i] = d;
+        borrow = u64::from(b1) + u64::from(b2);
+    }
+    out
+}
+
+/// Interprets a 256-bit two's-complement value with |x| < 2^128 as
+/// (is_negative, |x|).
+fn signed_halves(x: [u64; 4]) -> (bool, u128) {
+    if x[3] >> 63 == 0 {
+        debug_assert!(x[2] == 0 && x[3] == 0, "positive half exceeds 128 bits");
+        (false, u128::from(x[0]) | (u128::from(x[1]) << 64))
+    } else {
+        // Negate: !x + 1.
+        let mut n = [!x[0], !x[1], !x[2], !x[3]];
+        let mut carry = 1u64;
+        for limb in &mut n {
+            let (v, c) = limb.overflowing_add(carry);
+            *limb = v;
+            carry = u64::from(c);
+            if carry == 0 {
+                break;
+            }
+        }
+        debug_assert!(n[2] == 0 && n[3] == 0, "negative half exceeds 128 bits");
+        (true, u128::from(n[0]) | (u128::from(n[1]) << 64))
+    }
+}
+
+/// GLV split: `k = k1 + k2·λ (mod r_P)` with |k1|, |k2| ≤ 2^128, each half
+/// returned as (is_negative, magnitude).
+fn decompose(k: &pallas::Scalar) -> ((bool, u128), (bool, u128)) {
+    let repr = k.to_repr();
+    let bytes: &[u8; 32] = repr.as_ref().try_into().expect("32-byte repr");
+    let mut kl = [0u64; 4];
+    for (i, limb) in kl.iter_mut().enumerate() {
+        *limb = u64::from_le_bytes(bytes[i * 8..(i + 1) * 8].try_into().expect("8 bytes"));
+    }
+    let c1 = round_mul_shift(&G1, &kl);
+    let c2 = round_mul_shift(&G2, &kl);
+    // k1 = k − c1·V1A − c2·V2A   (two's complement over 256 bits)
+    let k1 = sub256(sub256(kl, mul_u128(c1, V1A)), mul_u128(c2, V2A));
+    // k2 = c1·V1B_NEG − c2·V2B   (v1.b = −V1B_NEG, v2.b = +V2B)
+    let k2 = sub256(mul_u128(c1, V1B_NEG), mul_u128(c2, V2B));
+    (signed_halves(k1), signed_halves(k2))
+}
+
+/// φ(P) on affine coordinates: (ζ_p·x, y). The identity maps to the identity.
+fn endo_affine(p: &pallas::Affine) -> pallas::Affine {
+    let coords = p.coordinates();
+    if bool::from(coords.is_none()) {
+        return pallas::Affine::identity();
+    }
+    let c = coords.unwrap();
+    pallas::Affine::from_xy(pallas::Base::ZETA * c.x(), *c.y()).unwrap()
+}
+
+/// The GLV window for one base point: the odd multiples {1, 3, 5, 7}·P and
+/// {1, 3, 5, 7}·φ(P) in affine coordinates.
+///
+/// Built once per ephemeral key ([`endo_tables`] builds a whole batch with
+/// one shared normalization) and reused by every viewing key's
+/// multiplication against it. 512 bytes.
+#[derive(Clone, Debug)]
+pub(crate) struct EndoTable {
+    /// {1, 3, 5, 7}·P
+    t1: [pallas::Affine; 4],
+    /// {1, 3, 5, 7}·φ(P)
+    t2: [pallas::Affine; 4],
+}
+
+#[cfg(test)]
+impl EndoTable {
+    /// The base point P (= t1[0]) back as a projective point.
+    pub(crate) fn point(&self) -> pallas::Point {
+        pallas::Point::from(self.t1[0])
+    }
+
+    /// Builds the window for a single point (one 4-point normalization).
+    pub(crate) fn from_point(p: &pallas::Point) -> Self {
+        endo_tables(core::slice::from_ref(p))
+            .pop()
+            .expect("one table per input point")
+    }
+}
+
+/// Builds [`EndoTable`]s for a batch of non-identity points with one shared
+/// batch normalization across all 4·n odd multiples — a single field
+/// inversion for the whole batch, where building each window individually
+/// pays one inversion per point.
+///
+/// Uses projective group operations only (no hand-rolled affine formulas),
+/// and on a prime-order curve the odd multiples of a non-identity point are
+/// never the identity, so the normalized windows are always well-formed.
+/// Callers guarantee non-identity inputs; ephemeral keys are non-identity by
+/// construction.
+pub(crate) fn endo_tables(points: &[pallas::Point]) -> Vec<EndoTable> {
+    let n = points.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    // Odd multiples per point, projective (cheap additions, no inversions),
+    // interleaved [1·P₀, 3·P₀, 5·P₀, 7·P₀, 1·P₁, ...].
+    let mut proj = Vec::with_capacity(n * 4);
+    for p in points {
+        debug_assert!(
+            !bool::from(p.is_identity()),
+            "endo_tables contract: non-identity points only"
+        );
+        let two_p = p.double();
+        let mut m = *p;
+        proj.push(m);
+        for _ in 1..4 {
+            m += two_p;
+            proj.push(m);
+        }
+    }
+    // One inversion for the whole batch.
+    let mut affine = vec![pallas::Affine::identity(); n * 4];
+    pallas::Point::batch_normalize(&proj, &mut affine);
+    affine
+        .chunks_exact(4)
+        .map(|c| {
+            let t1: [pallas::Affine; 4] = c.try_into().expect("chunks of 4");
+            let t2 = [
+                endo_affine(&t1[0]),
+                endo_affine(&t1[1]),
+                endo_affine(&t1[2]),
+                endo_affine(&t1[3]),
+            ];
+            EndoTable { t1, t2 }
+        })
+        .collect()
+}
+
+/// A scalar in GLV-decomposed, wNAF-recoded form, ready for
+/// [`mul_with_table`].
+///
+/// Batched trial decryption multiplies the same viewing key against every
+/// ephemeral key in the batch; building this once per (viewing key, batch)
+/// hoists the decomposition and digit recoding out of the per-output loop.
+#[derive(Clone, Debug)]
+pub(crate) struct DecomposedScalar {
+    neg1: bool,
+    digits1: [i8; 132],
+    len1: usize,
+    neg2: bool,
+    digits2: [i8; 132],
+    len2: usize,
+}
+
+impl DecomposedScalar {
+    /// Decomposes `k` and recodes both halves as width-4 wNAF digits.
+    pub(crate) fn new(k: &pallas::Scalar) -> Self {
+        let ((neg1, a1), (neg2, a2)) = decompose(k);
+        let (digits1, len1) = wnaf_digits(a1);
+        let (digits2, len2) = wnaf_digits(a2);
+        DecomposedScalar {
+            neg1,
+            digits1,
+            len1,
+            neg2,
+            digits2,
+            len2,
+        }
+    }
+}
+
+/// `k·P` for the P encoded by `table`, via the Straus shared-doubling ladder
+/// over the GLV split. Byte-identical to `P * k` (tested).
+pub(crate) fn mul_with_table(table: &EndoTable, k: &DecomposedScalar) -> pallas::Point {
+    let len = k.len1.max(k.len2);
+    let mut acc = pallas::Point::identity();
+    for i in (0..len).rev() {
+        acc = acc.double();
+        let d = if i < k.len1 { k.digits1[i] } else { 0 };
+        if d != 0 {
+            let mut a = table.t1[(d.unsigned_abs() / 2) as usize];
+            if (d < 0) ^ k.neg1 {
+                a = -a;
+            }
+            acc += a;
+        }
+        let d = if i < k.len2 { k.digits2[i] } else { 0 };
+        if d != 0 {
+            let mut a = table.t2[(d.unsigned_abs() / 2) as usize];
+            if (d < 0) ^ k.neg2 {
+                a = -a;
+            }
+            acc += a;
+        }
+    }
+    acc
+}
+
+/// `k·P` for the P encoded by `table`, decomposing `k` on the spot. Used by
+/// the per-item multiplication against a batch-prepared ephemeral key; the
+/// batched path decomposes once via [`DecomposedScalar`] instead.
+pub(crate) fn mul(table: &EndoTable, k: &pallas::Scalar) -> pallas::Point {
+    mul_with_table(table, &DecomposedScalar::new(k))
+}
+
+/// Width-4 wNAF digits of a u128 magnitude, lowest position first. A
+/// magnitude of at most 2^127 yields at most 129 digits; the array is sized
+/// with headroom.
+fn wnaf_digits(a: u128) -> ([i8; 132], usize) {
+    debug_assert!(a >> 127 == 0, "magnitude must be at most 127 bits");
+    let mut digits = [0i8; 132];
+    let mut n = 0;
+    let mut k = a;
+    while k != 0 {
+        if k & 1 == 1 {
+            let low = (k & 0xF) as i8;
+            let d = if low >= 8 { low - 16 } else { low };
+            digits[n] = d;
+            if d >= 0 {
+                k -= d as u128;
+            } else {
+                k += (-d) as u128;
+            }
+        }
+        n += 1;
+        k >>= 1;
+    }
+    (digits, n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ff::Field;
+
+    /// Deterministic full-width scalars for the known-answer tests.
+    fn scalars(n: u64) -> impl Iterator<Item = pallas::Scalar> {
+        (0..n).map(|i| {
+            (pallas::Scalar::from(0x9E37_79B9_7F4A_7C15u64 + i).square()
+                + pallas::Scalar::from(0x0123_4567_89AB_CDEFu64))
+            .square()
+                + pallas::Scalar::from(i)
+        })
+    }
+
+    /// The φ↔λ pairing on the real curve: (ζ_p·x, y) == λ·P.
+    #[test]
+    fn endo_map_is_lambda() {
+        let g = pallas::Point::generator();
+        for k in scalars(64) {
+            let p = (g * k).to_affine();
+            let via_map = endo_affine(&p);
+            let via_mul = (pallas::Point::from(p) * pallas::Scalar::ZETA).to_affine();
+            assert_eq!(via_map, via_mul, "phi(P) must equal ZETA_scalar * P");
+        }
+    }
+
+    /// The algebraic gate: k1 + k2·λ ≡ k (mod r_P) with both halves at most
+    /// 2^128, for full-width scalars and the edge cases. Wrong GLV constants
+    /// cannot pass this.
+    #[test]
+    fn decompose_reconstructs() {
+        let edges = [
+            pallas::Scalar::ZERO,
+            pallas::Scalar::ONE,
+            -pallas::Scalar::ONE,
+            pallas::Scalar::ZETA,
+            pallas::Scalar::ZETA.square(),
+            pallas::Scalar::from(u64::MAX),
+        ];
+        for k in edges.into_iter().chain(scalars(2_000)) {
+            let ((s1, a1), (s2, a2)) = decompose(&k);
+            assert!(
+                a1 >> 127 == 0 && a2 >> 127 == 0,
+                "halves must be at most 127 bits"
+            );
+            let half = |s: bool, a: u128| {
+                let v = pallas::Scalar::from_u128(a);
+                if s {
+                    -v
+                } else {
+                    v
+                }
+            };
+            let rec = half(s1, a1) + half(s2, a2) * pallas::Scalar::ZETA;
+            assert_eq!(rec, k, "k1 + k2*lambda must reconstruct k");
+        }
+    }
+
+    /// The ladder over batch-built windows equals the curve's own scalar
+    /// multiplication — proves `endo_tables`' odd multiples (φ side
+    /// included) and the digit walk together.
+    #[test]
+    fn tabled_mul_matches_group_mul() {
+        let g = pallas::Point::generator();
+        let points: Vec<pallas::Point> = (0..24u64)
+            .map(|i| g * pallas::Scalar::from(31 + i))
+            .collect();
+        let tables = endo_tables(&points);
+        assert_eq!(tables.len(), points.len());
+        for (i, (p, t)) in points.iter().zip(&tables).enumerate() {
+            assert_eq!(t.point(), *p, "table {i} must round-trip its base point");
+            for k in scalars(12) {
+                assert_eq!(mul(t, &k), p * k, "table {i}");
+            }
+            // Edges per table: 0, ±1, λ.
+            assert_eq!(
+                mul(t, &pallas::Scalar::ZERO),
+                pallas::Point::identity(),
+                "table {i}"
+            );
+            assert_eq!(mul(t, &pallas::Scalar::ONE), *p, "table {i}");
+            assert_eq!(mul(t, &-pallas::Scalar::ONE), -p, "table {i}");
+            assert_eq!(
+                mul(t, &pallas::Scalar::ZETA),
+                p * pallas::Scalar::ZETA,
+                "table {i}"
+            );
+        }
+    }
+
+    /// Batch-built windows equal individually-built windows: the shared
+    /// normalization changes the arithmetic route, not the values.
+    #[test]
+    fn batch_tables_equal_solo_tables() {
+        let g = pallas::Point::generator();
+        let points: Vec<pallas::Point> = (0..32u64)
+            .map(|i| g * pallas::Scalar::from(97 + i))
+            .collect();
+        for (p, batch) in points.iter().zip(endo_tables(&points)) {
+            let solo = EndoTable::from_point(p);
+            assert_eq!(batch.t1, solo.t1);
+            assert_eq!(batch.t2, solo.t2);
+        }
+    }
+
+    /// A precomputed [`DecomposedScalar`] and on-the-spot decomposition run
+    /// the same ladder.
+    #[test]
+    fn decomposed_scalar_reuse_matches_fresh() {
+        let g = pallas::Point::generator();
+        let points: Vec<pallas::Point> = (0..8u64)
+            .map(|i| g * pallas::Scalar::from(211 + i))
+            .collect();
+        let tables = endo_tables(&points);
+        for k in scalars(16) {
+            let decomposed = DecomposedScalar::new(&k);
+            for (p, t) in points.iter().zip(&tables) {
+                assert_eq!(mul_with_table(t, &decomposed), p * k);
+                assert_eq!(mul(t, &k), p * k);
+            }
+        }
+    }
+
+    /// Full-width KAT sweep: byte-identical to the curve's own scalar
+    /// multiplication across many (point, scalar) pairs.
+    #[test]
+    fn mul_matches_group_mul() {
+        let g = pallas::Point::generator();
+        let n = if cfg!(debug_assertions) { 500 } else { 4_000 };
+        for (i, k) in scalars(n).enumerate() {
+            let base = g * pallas::Scalar::from(31 + i as u64);
+            let t = EndoTable::from_point(&base);
+            assert_eq!(mul(&t, &k), base * k, "lane {i}");
+        }
+    }
+}

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,5 +1,6 @@
 //! Key structures for Orchard.
 
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use corez::io::{self, Read, Write};
 
@@ -714,6 +715,12 @@ impl PreparedIncomingViewingKey {
     fn new_inner(ivk: &KeyAgreementPrivateKey) -> Self {
         Self(PreparedNonZeroScalar::new(&ivk.0))
     }
+
+    /// The raw ivk scalar, for the GLV ladder in `crate::endo` (which
+    /// decomposes the scalar rather than consuming the prepared wNAF form).
+    pub(crate) fn raw_scalar(&self) -> pallas::Scalar {
+        self.0.raw_scalar()
+    }
 }
 
 /// A key that provides the capability to recover outgoing transaction information from
@@ -852,17 +859,81 @@ impl EphemeralPublicKey {
     }
 }
 
+/// What a prepared ephemeral key carries.
+///
+/// Individually-prepared keys carry a `group::Wnaf` window table, consumed by
+/// the per-item multiplication. Batch-prepared keys carry a GLV odd-multiples
+/// window instead (see `crate::endo`), which is cheaper to build across a
+/// batch (one shared normalization) and cheaper to multiply against (a
+/// shared-doubling ladder over the endomorphism split). Both produce
+/// identical shared secrets.
+#[derive(Clone, Debug)]
+enum PreparedEpkInner {
+    /// A `group::Wnaf` window table.
+    Wnaf(PreparedNonIdentityBase),
+    /// A GLV odd-multiples window, boxed to keep the enum small (512 bytes,
+    /// the same heap-allocation shape as the wNAF table it replaces).
+    Tabled(Box<crate::endo::EndoTable>),
+}
+
 /// An Orchard ephemeral public key that has been precomputed for trial decryption.
 #[derive(Clone, Debug)]
-pub struct PreparedEphemeralPublicKey(PreparedNonIdentityBase);
+pub struct PreparedEphemeralPublicKey(PreparedEpkInner);
 
 impl PreparedEphemeralPublicKey {
     pub(crate) fn new(epk: EphemeralPublicKey) -> Self {
-        PreparedEphemeralPublicKey(PreparedNonIdentityBase::new(epk.0))
+        PreparedEphemeralPublicKey(PreparedEpkInner::Wnaf(PreparedNonIdentityBase::new(epk.0)))
+    }
+
+    /// Prepares every ephemeral key in a batch by building its GLV window,
+    /// sharing one batch normalization (a single field inversion) across the
+    /// whole set, where individual preparation pays one inversion per key.
+    /// `None` lanes (ephemeral keys that failed to decode) pass through as
+    /// `None`.
+    pub(crate) fn batch_tabled(
+        epks: Vec<Option<EphemeralPublicKey>>,
+    ) -> Vec<Option<PreparedEphemeralPublicKey>> {
+        let live: Vec<pallas::Point> = epks
+            .iter()
+            .filter_map(|e| e.as_ref().map(|e| *e.0))
+            .collect();
+        let mut tables = crate::endo::endo_tables(&live).into_iter();
+        epks.into_iter()
+            .map(|e| {
+                e.map(|_| {
+                    PreparedEphemeralPublicKey(PreparedEpkInner::Tabled(Box::new(
+                        tables.next().expect("one table per live epk"),
+                    )))
+                })
+            })
+            .collect()
     }
 
     pub(crate) fn agree(&self, ivk: &PreparedIncomingViewingKey) -> SharedSecret {
-        SharedSecret(ka_orchard_prepared(&ivk.0, &self.0))
+        match &self.0 {
+            PreparedEpkInner::Wnaf(base) => SharedSecret(ka_orchard_prepared(&ivk.0, base)),
+            // The product of a non-zero scalar and a non-identity point in the
+            // prime-order Pallas group is non-identity.
+            PreparedEpkInner::Tabled(table) => SharedSecret(NonIdentityPallasPoint::guaranteed(
+                crate::endo::mul(table, &ivk.raw_scalar()),
+            )),
+        }
+    }
+
+    /// Like `agree`, but with the viewing key's GLV decomposition
+    /// precomputed. Used by the batched agreement path, which hoists the
+    /// decomposition and digit recoding out of the per-output loop.
+    pub(crate) fn agree_with(
+        &self,
+        ivk: &PreparedIncomingViewingKey,
+        decomposed: &crate::endo::DecomposedScalar,
+    ) -> SharedSecret {
+        match &self.0 {
+            PreparedEpkInner::Wnaf(base) => SharedSecret(ka_orchard_prepared(&ivk.0, base)),
+            PreparedEpkInner::Tabled(table) => SharedSecret(NonIdentityPallasPoint::guaranteed(
+                crate::endo::mul_with_table(table, decomposed),
+            )),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod circuit;
 mod constants;
 #[cfg(feature = "unstable-voting-circuits")]
 pub mod constants;
+mod endo;
 pub mod keys;
 pub mod note;
 pub mod note_encryption;

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -350,6 +350,36 @@ impl<P: DomainPolicy> BatchDomain for NoteEncryptionDomain<P> {
     ) -> Vec<Option<Self::SymmetricKey>> {
         batch_kdf(items)
     }
+
+    fn batch_epk(
+        ephemeral_keys: impl Iterator<Item = EphemeralKeyBytes>,
+    ) -> Vec<(Option<Self::PreparedEphemeralPublicKey>, EphemeralKeyBytes)> {
+        // Prepare the whole batch with GLV windows, sharing one batch
+        // normalization across every key (a single field inversion, where
+        // per-item preparation pays one per key).
+        let (epks, ephemeral_keys): (Vec<_>, Vec<_>) = ephemeral_keys
+            .map(|ephemeral_key| (Self::epk(&ephemeral_key), ephemeral_key))
+            .unzip();
+        PreparedEphemeralPublicKey::batch_tabled(epks)
+            .into_iter()
+            .zip(ephemeral_keys)
+            .collect()
+    }
+
+    fn batch_ka_agree_dec<'a>(
+        ivk: &Self::IncomingViewingKey,
+        epks: impl Iterator<Item = Option<&'a Self::PreparedEphemeralPublicKey>>,
+    ) -> Vec<Option<Self::SharedSecret>>
+    where
+        Self::PreparedEphemeralPublicKey: 'a,
+    {
+        // One GLV decomposition and digit recoding of the viewing key for the
+        // whole batch; each ephemeral key's window is then consumed by a
+        // shared-doubling ladder.
+        let decomposed = crate::endo::DecomposedScalar::new(&ivk.raw_scalar());
+        epks.map(|epk| epk.map(|epk| epk.agree_with(ivk, &decomposed)))
+            .collect()
+    }
 }
 
 fn batch_kdf<'a>(
@@ -548,21 +578,24 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     use rand::rngs::OsRng;
     use zcash_note_encryption::{
-        try_compact_note_decryption, try_note_decryption, try_output_recovery_with_ovk, Domain,
-        EphemeralKeyBytes,
+        batch, try_compact_note_decryption, try_note_decryption, try_output_recovery_with_ovk,
+        BatchDomain, Domain, EphemeralKeyBytes, NoteEncryption,
     };
 
     use super::{
-        prf_ock_orchard, CompactAction, IronwoodDomain, IronwoodNoteEncryption, OrchardDomain,
-        OrchardNoteEncryption,
+        prf_ock_orchard, CompactAction, DomainVersion, IronwoodDomain, IronwoodNoteEncryption,
+        IronwoodVersion, NoteEncryptionDomain, OrchardDomain, OrchardNoteEncryption,
+        OrchardVersion,
     };
     use crate::{
         action::Action,
         keys::{
-            DiversifiedTransmissionKey, Diversifier, EphemeralSecretKey, IncomingViewingKey,
-            OutgoingViewingKey, PreparedIncomingViewingKey, Scope, SpendingKey,
+            DiversifiedTransmissionKey, Diversifier, EphemeralSecretKey, FullViewingKey,
+            IncomingViewingKey, OutgoingViewingKey, PreparedIncomingViewingKey, Scope, SpendingKey,
         },
         note::{
             ExtractedNoteCommitment, NoteVersion, Nullifier, RandomSeed, Rho,
@@ -807,5 +840,185 @@ mod tests {
             try_compact_note_decryption(&domain, &ivk, &compact),
             Some((note, recipient))
         );
+    }
+
+    /// Encrypts a compact output of the domain's note plaintext version to
+    /// `recipient`, using a fresh ephemeral key.
+    fn encrypted_compact_action<V: DomainVersion>(
+        rng: &mut OsRng,
+        recipient: Address,
+    ) -> CompactAction {
+        let nf_old = Nullifier::dummy(rng);
+        let rho = Rho::from_nf_old(nf_old);
+        let note = Note::new(
+            recipient,
+            NoteValue::from_raw(42),
+            rho,
+            V::NOTE_VERSION,
+            rng,
+        );
+        let encryptor = NoteEncryption::<NoteEncryptionDomain<V>>::new(None, note, [0u8; 512]);
+        let ephemeral_key = NoteEncryptionDomain::<V>::epk_bytes(encryptor.epk());
+        let enc_ciphertext = encryptor.encrypt_note_plaintext();
+        CompactAction::from_parts(
+            nf_old,
+            ExtractedNoteCommitment::from(note.commitment()),
+            ephemeral_key,
+            enc_ciphertext.as_ref()[..52].try_into().unwrap(),
+        )
+    }
+
+    /// The batched trial-decryption pipeline (GLV-window preparation and
+    /// per-batch scalar decomposition) must produce exactly the per-item
+    /// results, over hits on multiple viewing keys, misses, and an
+    /// undecodable ephemeral key.
+    fn check_batched_compact_decryption_matches_per_item<V: DomainVersion>() {
+        let mut rng = OsRng;
+
+        // Two accounts with external and internal scope each — the wallet
+        // shape batched trial decryption runs with — plus a foreign account
+        // whose outputs must not decrypt.
+        let our_fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
+        let other_fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
+        let foreign_fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
+        let ivks: Vec<PreparedIncomingViewingKey> = [
+            (&our_fvk, Scope::External),
+            (&our_fvk, Scope::Internal),
+            (&other_fvk, Scope::External),
+            (&other_fvk, Scope::Internal),
+        ]
+        .into_iter()
+        .map(|(fvk, scope)| PreparedIncomingViewingKey::new(&fvk.to_ivk(scope)))
+        .collect();
+
+        let mut actions = vec![
+            encrypted_compact_action::<V>(&mut rng, our_fvk.address_at(0u32, Scope::External)),
+            encrypted_compact_action::<V>(&mut rng, our_fvk.address_at(0u32, Scope::Internal)),
+            encrypted_compact_action::<V>(&mut rng, other_fvk.address_at(0u32, Scope::External)),
+        ];
+        for i in 0..5u32 {
+            actions.push(encrypted_compact_action::<V>(
+                &mut rng,
+                foreign_fvk.address_at(i, Scope::External),
+            ));
+        }
+        // An ephemeral key that decodes to the identity is rejected during
+        // preparation; its lane must pass through as `None`.
+        actions.push(CompactAction::from_parts(
+            Nullifier::dummy(&mut rng),
+            actions[0].cmx(),
+            EphemeralKeyBytes([0u8; 32]),
+            [0u8; 52],
+        ));
+
+        let items: Vec<(NoteEncryptionDomain<V>, CompactAction)> = actions
+            .iter()
+            .map(|a| (NoteEncryptionDomain::<V>::for_compact_action(a), a.clone()))
+            .collect();
+        let batched = batch::try_compact_note_decryption(&ivks, &items);
+
+        let per_item: Vec<Option<((Note, Address), usize)>> = actions
+            .iter()
+            .map(|a| {
+                let domain = NoteEncryptionDomain::<V>::for_compact_action(a);
+                ivks.iter().enumerate().find_map(|(i, ivk)| {
+                    try_compact_note_decryption(&domain, ivk, a).map(|r| (r, i))
+                })
+            })
+            .collect();
+
+        assert_eq!(batched, per_item);
+
+        // The interesting lanes actually decrypted (guards against both
+        // paths failing identically).
+        assert_eq!(batched[0].as_ref().map(|(_, i)| *i), Some(0));
+        assert_eq!(batched[1].as_ref().map(|(_, i)| *i), Some(1));
+        assert_eq!(batched[2].as_ref().map(|(_, i)| *i), Some(2));
+        assert!(batched[3..].iter().all(Option::is_none));
+    }
+
+    #[test]
+    fn batched_compact_decryption_matches_per_item_orchard() {
+        check_batched_compact_decryption_matches_per_item::<OrchardVersion>();
+    }
+
+    #[test]
+    fn batched_compact_decryption_matches_per_item_ironwood() {
+        check_batched_compact_decryption_matches_per_item::<IronwoodVersion>();
+    }
+
+    /// The batched agreement must produce byte-identical shared secrets to
+    /// the per-item path, for both preparation routes (batch-built GLV
+    /// windows and individually-built wNAF tables), on hit and miss lanes
+    /// alike.
+    #[test]
+    fn batched_agreement_matches_per_item() {
+        let mut rng = OsRng;
+
+        let our_fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
+        let foreign_fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
+        let ivks: Vec<PreparedIncomingViewingKey> = [
+            (&our_fvk, Scope::External),
+            (&our_fvk, Scope::Internal),
+            (&foreign_fvk, Scope::External),
+        ]
+        .into_iter()
+        .map(|(fvk, scope)| PreparedIncomingViewingKey::new(&fvk.to_ivk(scope)))
+        .collect();
+
+        // Real ephemeral keys from real encryptions, plus an undecodable lane.
+        let mut keys: Vec<EphemeralKeyBytes> = (0..12u32)
+            .map(|i| {
+                encrypted_compact_action::<OrchardVersion>(
+                    &mut rng,
+                    our_fvk.address_at(i, Scope::External),
+                )
+                .ephemeral_key
+            })
+            .collect();
+        keys.push(EphemeralKeyBytes([0u8; 32]));
+
+        let batch_prepared = <OrchardDomain as BatchDomain>::batch_epk(keys.iter().cloned());
+        // The undecodable lane passes through preparation as `None`.
+        assert!(batch_prepared.last().unwrap().0.is_none());
+        assert!(batch_prepared[..12].iter().all(|(p, _)| p.is_some()));
+
+        let wnaf_prepared: Vec<Option<crate::keys::PreparedEphemeralPublicKey>> = keys
+            .iter()
+            .map(|key| OrchardDomain::epk(key).map(OrchardDomain::prepare_epk))
+            .collect();
+
+        for ivk in &ivks {
+            let expected: Vec<Option<[u8; 32]>> = keys
+                .iter()
+                .map(|key| {
+                    OrchardDomain::epk(key)
+                        .map(OrchardDomain::prepare_epk)
+                        .map(|epk| OrchardDomain::ka_agree_dec(ivk, &epk).to_bytes())
+                })
+                .collect();
+
+            let batched: Vec<Option<[u8; 32]>> =
+                <OrchardDomain as BatchDomain>::batch_ka_agree_dec(
+                    ivk,
+                    batch_prepared.iter().map(|(p, _)| p.as_ref()),
+                )
+                .into_iter()
+                .map(|s| s.map(|s| s.to_bytes()))
+                .collect();
+            assert_eq!(batched, expected);
+
+            // The batched agreement's fallback arm (individually-prepared
+            // inputs) must also match.
+            let batched_wnaf: Vec<Option<[u8; 32]>> =
+                <OrchardDomain as BatchDomain>::batch_ka_agree_dec(
+                    ivk,
+                    wnaf_prepared.iter().map(|p| p.as_ref()),
+                )
+                .into_iter()
+                .map(|s| s.map(|s| s.to_bytes()))
+                .collect();
+            assert_eq!(batched_wnaf, expected);
+        }
     }
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -48,6 +48,18 @@ impl NonIdentityPallasPoint {
         pallas::Point::from_bytes(bytes)
             .and_then(|p| CtOption::new(NonIdentityPallasPoint(p), !p.is_identity()))
     }
+
+    /// Constructs a wrapper for a point that is guaranteed to be non-identity
+    /// (such as the product of a non-zero scalar and a non-identity point in
+    /// the prime-order Pallas group).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `p.is_identity()`.
+    pub(crate) fn guaranteed(p: pallas::Point) -> Self {
+        assert!(!bool::from(p.is_identity()));
+        NonIdentityPallasPoint(p)
+    }
 }
 
 impl Deref for NonIdentityPallasPoint {
@@ -160,7 +172,12 @@ impl PreparedNonIdentityBase {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct PreparedNonZeroScalar(WnafScalar<pallas::Scalar, PREPARED_WINDOW_SIZE>);
+pub(crate) struct PreparedNonZeroScalar(
+    WnafScalar<pallas::Scalar, PREPARED_WINDOW_SIZE>,
+    // The scalar itself, retained for the GLV ladder in `crate::endo`, which
+    // decomposes the scalar rather than consuming the wNAF form.
+    pallas::Scalar,
+);
 
 #[cfg(feature = "std")]
 impl DynamicUsage for PreparedNonZeroScalar {
@@ -175,7 +192,12 @@ impl DynamicUsage for PreparedNonZeroScalar {
 
 impl PreparedNonZeroScalar {
     pub(crate) fn new(scalar: &NonZeroPallasScalar) -> Self {
-        PreparedNonZeroScalar(WnafScalar::new(scalar))
+        PreparedNonZeroScalar(WnafScalar::new(scalar), **scalar)
+    }
+
+    /// The raw scalar, for the GLV ladder in `crate::endo`.
+    pub(crate) fn raw_scalar(&self) -> pallas::Scalar {
+        self.1
     }
 }
 


### PR DESCRIPTION
Batched trial decryption is the hot loop of light-client scanning: every compact output's ephemeral key is multiplied by each of the wallet's incoming viewing keys. This PR accelerates that loop using the Pallas cube-root endomorphism, consuming the `BatchDomain::batch_ka_agree_dec` hook added in zcash/zcash_note_encryption#13 and released in `zcash_note_encryption 0.4.2` (#14).

(Strictly speaking, the GLV paper only mentioned using the Frobenius endomorphism, but the extension to cubic endomorphisms is obvious, and commonly also called GLV.)

## What changes

A new private `endo` module implements GLV decomposition for the Pallas scalar field: k = k1 + k2·λ (mod r_P) with both halves ≤ 2^127, so `[k] P = [k1] P + [k2] φ(P)` runs as a Straus ladder with shared doublings (~128 doublings + ~52 window-4 additions instead of a ~255-doubling full-width walk). The batched pipeline amortizes everything that can be amortized:

- **`batch_epk`** now prepares every ephemeral key in the batch with a GLV odd-multiples window ({1,3,5,7}·P and {1,3,5,7}·φ(P), affine), normalized across the *whole batch* with a single shared inversion — where per-item preparation pays one inversion (or one wNAF table build) per key.
- **`batch_ka_agree_dec`** decomposes and wNAF-recodes the viewing key **once per batch**, then consumes each ephemeral key's window with the shared-doubling ladder. Each window is reused by every viewing key's multiplication against it (wallets scan with at least two ivks — external and internal scope).
- Since the `BatchDomain` impl is generic over the domain policy, `OrchardDomain` and `IronwoodDomain` both get the fast path from one implementation.

The per-output entry points (`try_note_decryption` etc.) are untouched: `prepare_epk` still builds the `group::Wnaf` table and multiplies exactly as before. There are no public API changes; everything new is `pub(crate)`. The minimum `zcash_note_encryption` version becomes 0.4.2 (semver-compatible).

## Correctness

Shared secrets are byte-identical to the per-item path, and the tests pin this from three directions:

- **In-module KATs** (`src/endo.rs`): the GLV constants are re-verified from scratch (`decompose_reconstructs` checks k1 + k2·λ ≡ k and the ≤ 2^127 bound over full-width scalars and edge cases — wrong constants cannot pass); the φ↔λ pairing is checked on the real curve; and the ladder is checked byte-identical to the group's own scalar multiplication over batch-built and individually-built windows, including 0, ±1, and λ.
- **Pipeline equality** (`src/note_encryption.rs`): `batch::try_compact_note_decryption` must produce exactly the per-item results — hits on multiple viewing keys (external + internal scope), misses, and an undecodable ephemeral key lane — for both `OrchardDomain` and `IronwoodDomain`.
- **Agreement equality**: `batch_ka_agree_dec` must produce byte-identical shared secrets to per-item `ka_agree_dec` on hit and miss lanes alike, for both preparation routes (batch-built GLV windows and individually-prepared wNAF inputs, which take a per-item fallback arm).

The full existing suite passes unchanged.

## Timing

Like the existing `group::Wnaf`-based preparation this complements (`PreparedNonZeroScalar` / `PreparedNonIdentityBase`), the new path is variable-time with respect to the scalar. It is used only for trial decryption with the wallet's own incoming viewing keys, so this matches the crate's existing posture for this operation.

## Performance

`cargo bench --bench note_decryption` on an Apple M4 Pro (this branch vs. current `main`, back-to-back runs against a saved criterion baseline; medians):

| benchmark (2 ivks × N outputs) | `main` | this PR | change |
|---|---|---|---|
| `batch-…/compact-invalid/10` | 1.015 ms | 0.628 ms | **−38.2%** |
| `batch-…/compact-invalid/50` | 5.048 ms | 3.092 ms | **−38.7%** |
| `batch-…/compact-invalid/100` | 10.158 ms | 6.133 ms | **−39.6%** |
| `batch-…/invalid/10` | 1.025 ms | 0.630 ms | **−38.4%** |
| `batch-…/invalid/50` | 5.120 ms | 3.079 ms | **−39.9%** |
| `batch-…/invalid/100` | 10.152 ms | 6.185 ms | **−39.1%** |
| `batch-…/valid/{10,50,100}` | | | −5.5% / −4.6% / −3.6% |
| `batch-…/compact-valid/{10,50,100}` | | | −4.9% / −4.3% / −6.7% |

The `invalid` groups are the trial-decryption **miss** path — what a scanning wallet does for essentially every output on chain — and improve by ~1.6×. The `valid` groups fully decrypt every output, where key agreement is a small share of the work next to the note-commitment and esk checks. The per-item groups (`note-decryption/*`, `compact-note-decryption/invalid`) read −2.8% to +1.2% (noise band), as expected — that path is untouched.

The same technique running in a production mobile sync engine (where it was developed and measured first) cut trial-decryption CPU by ~21% and end-to-end scan-call wall time by ~15% on Apple Silicon devices.
