### PR TITLE
Add Post-NU6.3 verifier fingerprint fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Generate coverage report
-        run: cargo tarpaulin --engine llvm --all-features --release --timeout 600 --out xml
+        # Enable every feature except `verifier-fingerprint`: it is opt-in capture tooling whose
+        # tests build the k=11 proving key and generate real proofs, which are far too heavy to run
+        # under coverage instrumentation on every PR. Run those manually per the docs in
+        # `src/circuit/fingerprint/mod.rs`.
+        run: cargo tarpaulin --engine llvm --features "dev-graph unstable-frost unstable-voting-circuits test-dependencies" --release --timeout 600 --out xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run tests
         run: cargo test --verbose
+      # verifier-fingerprint capture tests build the k=11 proving key and run real proofs, too
+      # heavy for every PR (regenerate the fixtures manually per the docs in
+      # src/circuit/fingerprint/mod.rs). Compile them so the cfg(test) module can't rot unnoticed:
+      # `cargo test` (default features) and `cargo build --all-features` (skips cfg(test)) never
+      # type-check it.
+      - name: Compile-check the verifier-fingerprint capture module
+        run: cargo test --features verifier-fingerprint --no-run --verbose
       - name: Verify working directory is clean
         run: git diff --exit-code
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,7 +993,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.3.2"
-source = "git+https://github.com/zcash/halo2?rev=cd63cdf3826d2b274810b6c314950cccaa4139d3#cd63cdf3826d2b274810b6c314950cccaa4139d3"
+source = "git+https://github.com/zcash/halo2?rev=4789f7ebc7ceefc6c13d6a24e633b54291c1eeaf#4789f7ebc7ceefc6c13d6a24e633b54291c1eeaf"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,8 +992,9 @@ dependencies = [
 
 [[package]]
 name = "halo2_proofs"
-version = "0.3.2"
-source = "git+https://github.com/zcash/halo2?rev=70121ee2ec52b0c5478f3630ffba24b7fad79a3d#70121ee2ec52b0c5478f3630ffba24b7fad79a3d"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576d38119e960ec18628c2eb7558a3a06fcb9fd1e003a36f40f0496919a0aaa9"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,8 +993,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05713f117155643ce10975e0bee44a274bcda2f4bb5ef29a999ad67c1fa8d4d3"
+source = "git+https://github.com/zcash/halo2?rev=cd63cdf3826d2b274810b6c314950cccaa4139d3#cd63cdf3826d2b274810b6c314950cccaa4139d3"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -1458,6 +1457,7 @@ dependencies = [
  "pprof",
  "proptest",
  "rand",
+ "rand_chacha",
  "rand_core",
  "reddsa",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,7 +993,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.3.2"
-source = "git+https://github.com/zcash/halo2?rev=4789f7ebc7ceefc6c13d6a24e633b54291c1eeaf#4789f7ebc7ceefc6c13d6a24e633b54291c1eeaf"
+source = "git+https://github.com/zcash/halo2?rev=70121ee2ec52b0c5478f3630ffba24b7fad79a3d#70121ee2ec52b0c5478f3630ffba24b7fad79a3d"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ criterion = "0.4" # 0.5 depends on clap 4 which has MSRV 1.70
 halo2_gadgets = { version = "0.5", features = ["test-dependencies"] }
 hex = "0.4"
 proptest = ">=1.0.0, <1.7.0"
+rand_chacha = "0.3"
 zcash_note_encryption = { version = "0.4", features = ["pre-zip-212"] }
 incrementalmerkletree = { version = "0.8.1", features = ["test-dependencies"] }
 shardtree = "0.6"
@@ -89,6 +90,7 @@ unstable-frost = []
 unstable-voting-circuits = []
 multicore = ["halo2_proofs?/multicore"]
 dev-graph = ["halo2_proofs?/dev-graph", "image", "plotters"]
+verifier-fingerprint = ["circuit", "halo2_proofs/verifier-fingerprint"]
 test-dependencies = ["proptest", "rand/std"]
 
 [[bench]]
@@ -110,3 +112,9 @@ debug = true
 
 [profile.bench]
 debug = true
+
+[patch.crates-io]
+# All builds in this checkout resolve Halo2 to the helper fork. Only Orchard's opt-in
+# `verifier-fingerprint` feature enables its capture tooling; downstream users do not inherit a
+# package's root-level patch.
+halo2_proofs = { git = "https://github.com/zcash/halo2", rev = "cd63cdf3826d2b274810b6c314950cccaa4139d3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ keywords = ["zcash"]
 
 [package.metadata.docs.rs]
 # We intentionally do not use `all-features = true`: that would enable `verifier-fingerprint`, which
-# requires the `halo2_proofs/verifier-fingerprint` feature that lives only in the git fork pinned
+# requires the `halo2_proofs/unstable-verifier-fingerprint` feature that lives only in the git fork pinned
 # via the patch section below. On docs.rs the crate is built as published, where the patch is
 # stripped and `halo2_proofs` resolves from crates.io without that feature, so the docs build would
 # fail to resolve. Documenting every feature except `verifier-fingerprint` preserves the previous
@@ -128,9 +128,9 @@ debug = true
 # PRE-PUBLISH REQUIREMENT: this patch (and the git `rev` below) must be removed before any
 # `cargo publish` of Orchard, and `verifier-fingerprint` must resolve without it. The sequence is:
 #   1. merge https://github.com/zcash/halo2/pull/914,
-#   2. release `halo2_proofs` 0.3.3 with the `verifier-fingerprint` feature,
+#   2. release `halo2_proofs` 0.3.3 with the `unstable-verifier-fingerprint` feature,
 #   3. drop this `[patch.crates-io]` section (the `version = "0.3"` dep then resolves 0.3.3),
 #   4. restore `all-features = true` under `[package.metadata.docs.rs]`.
 # The `rev` currently pins the *unmerged* head of PR #914; repin to the merged commit once it lands
 # so a rebase of that branch cannot orphan it.
-halo2_proofs = { git = "https://github.com/zcash/halo2", rev = "4789f7ebc7ceefc6c13d6a24e633b54291c1eeaf" }
+halo2_proofs = { git = "https://github.com/zcash/halo2", rev = "70121ee2ec52b0c5478f3630ffba24b7fad79a3d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,14 @@ categories = ["cryptography::cryptocurrencies"]
 keywords = ["zcash"]
 
 [package.metadata.docs.rs]
-all-features = true
+# We intentionally do not use `all-features = true`: that would enable `verifier-fingerprint`, which
+# requires the `halo2_proofs/verifier-fingerprint` feature that lives only in the git fork pinned
+# via the patch section below. On docs.rs the crate is built as published, where the patch is
+# stripped and `halo2_proofs` resolves from crates.io without that feature, so the docs build would
+# fail to resolve. Documenting every feature except `verifier-fingerprint` preserves the previous
+# coverage (its Orchard module is `cfg(test)` and never documented anyway). Once `halo2_proofs`
+# 0.3.3 ships the feature and the patch below is dropped, this can return to `all-features = true`.
+features = ["dev-graph", "unstable-frost", "unstable-voting-circuits", "test-dependencies"]
 rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "katex-header.html"]
 
 [dependencies]
@@ -90,7 +97,7 @@ unstable-frost = []
 unstable-voting-circuits = []
 multicore = ["halo2_proofs?/multicore"]
 dev-graph = ["halo2_proofs?/dev-graph", "image", "plotters"]
-verifier-fingerprint = ["circuit", "halo2_proofs/verifier-fingerprint"]
+verifier-fingerprint = ["circuit", "halo2_proofs/unstable-verifier-fingerprint"]
 test-dependencies = ["proptest", "rand/std"]
 
 [[bench]]
@@ -117,4 +124,13 @@ debug = true
 # All builds in this checkout resolve Halo2 to the helper fork. Only Orchard's opt-in
 # `verifier-fingerprint` feature enables its capture tooling; downstream users do not inherit a
 # package's root-level patch.
-halo2_proofs = { git = "https://github.com/zcash/halo2", rev = "cd63cdf3826d2b274810b6c314950cccaa4139d3" }
+#
+# PRE-PUBLISH REQUIREMENT: this patch (and the git `rev` below) must be removed before any
+# `cargo publish` of Orchard, and `verifier-fingerprint` must resolve without it. The sequence is:
+#   1. merge https://github.com/zcash/halo2/pull/914,
+#   2. release `halo2_proofs` 0.3.3 with the `verifier-fingerprint` feature,
+#   3. drop this `[patch.crates-io]` section (the `version = "0.3"` dep then resolves 0.3.3),
+#   4. restore `all-features = true` under `[package.metadata.docs.rs]`.
+# The `rev` currently pins the *unmerged* head of PR #914; repin to the merged commit once it lands
+# so a rebase of that branch cannot orphan it.
+halo2_proofs = { git = "https://github.com/zcash/halo2", rev = "4789f7ebc7ceefc6c13d6a24e633b54291c1eeaf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,7 @@ categories = ["cryptography::cryptocurrencies"]
 keywords = ["zcash"]
 
 [package.metadata.docs.rs]
-# We intentionally do not use `all-features = true`: that would enable `verifier-fingerprint`, which
-# requires the `halo2_proofs/unstable-verifier-fingerprint` feature that lives only in the git fork pinned
-# via the patch section below. On docs.rs the crate is built as published, where the patch is
-# stripped and `halo2_proofs` resolves from crates.io without that feature, so the docs build would
-# fail to resolve. Documenting every feature except `verifier-fingerprint` preserves the previous
-# coverage (its Orchard module is `cfg(test)` and never documented anyway). Once `halo2_proofs`
-# 0.3.3 ships the feature and the patch below is dropped, this can return to `all-features = true`.
-features = ["dev-graph", "unstable-frost", "unstable-voting-circuits", "test-dependencies"]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "katex-header.html"]
 
 [dependencies]
@@ -119,18 +112,3 @@ debug = true
 
 [profile.bench]
 debug = true
-
-[patch.crates-io]
-# All builds in this checkout resolve Halo2 to the helper fork. Only Orchard's opt-in
-# `verifier-fingerprint` feature enables its capture tooling; downstream users do not inherit a
-# package's root-level patch.
-#
-# PRE-PUBLISH REQUIREMENT: this patch (and the git `rev` below) must be removed before any
-# `cargo publish` of Orchard, and `verifier-fingerprint` must resolve without it. The sequence is:
-#   1. merge https://github.com/zcash/halo2/pull/914,
-#   2. release `halo2_proofs` 0.3.3 with the `unstable-verifier-fingerprint` feature,
-#   3. drop this `[patch.crates-io]` section (the `version = "0.3"` dep then resolves 0.3.3),
-#   4. restore `all-features = true` under `[package.metadata.docs.rs]`.
-# The `rev` currently pins the *unmerged* head of PR #914; repin to the merged commit once it lands
-# so a rebase of that branch cannot orphan it.
-halo2_proofs = { git = "https://github.com/zcash/halo2", rev = "70121ee2ec52b0c5478f3630ffba24b7fad79a3d" }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -1389,6 +1389,9 @@ impl Proof {
     }
 }
 
+#[cfg(all(test, feature = "verifier-fingerprint"))]
+mod fingerprint;
+
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;

--- a/src/circuit/fingerprint/mod.rs
+++ b/src/circuit/fingerprint/mod.rs
@@ -10,11 +10,12 @@
 //!
 //! * **Only accepting runs are exported to Lean.** The negative captures in `rejected` confirm in
 //!   Rust that a tampered/short/desynchronized proof assembles a non-identity MSM and is rejected by
-//!   the deployed verifier, but they are never handed to Lean. The Lean `MsmMatch` theorem is only
-//!   ever checked against *identity* (accepting) runs, so a Lean `assemble` that trivially accepts
-//!   would still pass every exported fixture. Extending the cross-check to a rejecting run needs a
-//!   Halo2 dumper variant that emits `capturedMsm.evalNat capturedURS ≠ 0` instead of the hardcoded
-//!   `= 0` (tracked upstream against the `dump_vesta_lean_fixture` tooling).
+//!   the deployed verifier, but they are never handed to Lean. `MsmMatch` pins the full coefficient
+//!   structure of accepting runs — not merely acceptance — so a trivially-accepting Lean `assemble`
+//!   would already fail it; the narrower unchecked residual is a Lean `assemble` that agrees on
+//!   accepting runs yet mismodels the rejection paths. This is by design: the Halo2 exporter fails
+//!   fast on a non-identity capture rather than emitting a rejecting fixture, so negative-path
+//!   coverage stays in Rust.
 //! * **The exported Fiat–Shamir schedule is not injective with respect to real transcripts.** The
 //!   dumper models each squeeze by appending the challenge as a `TranscriptElt.scalar`, the same
 //!   constructor used for proof-read scalars, whereas the deployed Blake2b transcript uses a

--- a/src/circuit/fingerprint/mod.rs
+++ b/src/circuit/fingerprint/mod.rs
@@ -17,6 +17,8 @@ use crate::{
     tree::MerkleHashOrchard,
 };
 
+mod rejected;
+
 fn fixture_rng(seed: u8) -> ChaCha20Rng {
     ChaCha20Rng::from_seed([seed; 32])
 }

--- a/src/circuit/fingerprint/mod.rs
+++ b/src/circuit/fingerprint/mod.rs
@@ -1,0 +1,164 @@
+//! Feature-gated Orchard fixtures for Halo2 verifier fingerprints.
+
+use alloc::vec::Vec;
+
+use halo2_proofs::plonk::fingerprint::{capture_proof_fingerprint, ChallengeRecorder};
+use halo2_proofs::transcript::Challenge255;
+use incrementalmerkletree::Hashable;
+use pasta_curves::vesta;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+
+use super::{OrchardCircuitVersion, ProvingKey, VerifyingKey, K};
+use crate::{
+    builder::{Builder, BundleType},
+    bundle::BundleVersion,
+    constants::MERKLE_DEPTH_ORCHARD,
+    tree::MerkleHashOrchard,
+};
+
+fn fixture_rng(seed: u8) -> ChaCha20Rng {
+    ChaCha20Rng::from_seed([seed; 32])
+}
+
+fn build_fixture_bundle(
+    rng: &mut ChaCha20Rng,
+    pk: &ProvingKey,
+    num_actions: u8,
+) -> crate::Bundle<crate::bundle::Authorized, i64> {
+    let bundle_version = BundleVersion::orchard_v3();
+    let builder = Builder::new(
+        BundleType::Transactional {
+            bundle_required: true,
+            pad_to_minimum: Some(num_actions),
+        },
+        bundle_version,
+        bundle_version.default_flags(),
+        MerkleHashOrchard::empty_root((MERKLE_DEPTH_ORCHARD as u8).into()).into(),
+    )
+    .unwrap();
+    let bundle = builder.build::<i64>(&mut *rng).unwrap().unwrap().0;
+    assert_eq!(bundle.actions().len(), usize::from(num_actions));
+    assert!(!bundle.flags().cross_address_enabled());
+
+    bundle
+        .create_proof(pk, &mut *rng)
+        .unwrap()
+        .apply_signatures(&mut *rng, [0; 32], &[])
+        .unwrap()
+}
+
+fn raw_instances(instances: &[super::Instance]) -> Vec<Vec<Vec<vesta::Scalar>>> {
+    instances
+        .iter()
+        .map(|instance| {
+            instance
+                .to_halo2_instance()
+                .iter()
+                .map(|column| column.to_vec())
+                .collect()
+        })
+        .collect()
+}
+
+fn raw_instance_refs(raw_instances: &[Vec<Vec<vesta::Scalar>>]) -> Vec<Vec<&[vesta::Scalar]>> {
+    raw_instances
+        .iter()
+        .map(|instance| instance.iter().map(|column| &column[..]).collect())
+        .collect()
+}
+
+fn assert_pinned_verifying_key(vk: &VerifyingKey) {
+    assert_eq!(
+        format!("{:#?}\n", vk.vk.pinned()),
+        include_str!("../../circuit_data/circuit_description_post_nu6_3").replace("\r\n", "\n")
+    );
+}
+
+fn capture_fixture(seed: u8, num_actions: u8, namespace: &str, output_var: &str) {
+    let mut rng = fixture_rng(seed);
+    let pk = ProvingKey::build(OrchardCircuitVersion::PostNu6_3);
+    let vk = VerifyingKey::build(OrchardCircuitVersion::PostNu6_3);
+    assert!(vk.supports_cross_address_restriction());
+    assert_pinned_verifying_key(&vk);
+
+    let bundle = build_fixture_bundle(&mut rng, &pk, num_actions);
+    let instances = bundle.to_instances();
+    let proof = bundle.authorization().proof().clone();
+    assert!(bundle.verify_proof(&vk).is_ok());
+
+    let raw_instances = raw_instances(&instances);
+    let raw_instance_refs = raw_instance_refs(&raw_instances);
+    let raw_instance_refs: Vec<_> = raw_instance_refs
+        .iter()
+        .map(|instance| &instance[..])
+        .collect();
+
+    let mut transcript = ChallengeRecorder::<_, _, Challenge255<_>>::init(&proof.0[..]);
+    let msm =
+        capture_proof_fingerprint(&vk.params, &vk.vk, &raw_instance_refs, &mut transcript).unwrap();
+
+    assert!(!transcript.challenges.is_empty());
+    assert!(
+        msm.clone().eval(),
+        "captured Orchard fingerprint must be the identity for a valid proof"
+    );
+    std::eprintln!(
+        "Captured {num_actions}-action Orchard verifier fingerprint at k={} with {} challenges",
+        K,
+        transcript.challenges.len(),
+    );
+
+    let fixture = vk.vk.dump_vesta_lean_fixture(
+        namespace,
+        "PostNu6_3",
+        K,
+        usize::from(num_actions),
+        &transcript.common_points,
+        &transcript.points,
+        &transcript.scalars,
+        &transcript.challenges,
+        &transcript.events,
+        &msm,
+    );
+    if let Some(path) = std::env::var_os(output_var) {
+        std::fs::write(std::path::PathBuf::from(path), fixture).unwrap();
+    }
+}
+
+/// Regenerate the deterministic checked-in single-action Ironwood fixture with:
+///
+/// ```text
+/// ORCHARD_LEAN_SINGLE_FIXTURE_OUT=/path/to/ironwood/Zcash/Snark/Fixtures/SingleAction/Fixture.lean \
+///   cargo test --features verifier-fingerprint circuit::fingerprint::fingerprint_capture -- --exact
+/// ```
+#[test]
+fn fingerprint_capture() {
+    capture_fixture(
+        0x53,
+        1,
+        "Zcash.Snark.Fixture",
+        "ORCHARD_LEAN_SINGLE_FIXTURE_OUT",
+    );
+}
+
+/// Regenerate the deterministic checked-in two-action Ironwood fixture with:
+///
+/// ```text
+/// ORCHARD_LEAN_MULTI_FIXTURE_OUT=/path/to/ironwood/Zcash/Snark/Fixtures/MultiAction/Fixture.lean \
+///   cargo test --features verifier-fingerprint \
+///     circuit::fingerprint::fingerprint_capture_two_actions -- --exact
+/// ```
+///
+/// The real two-action bundle exercises the verifier's per-sub-proof read schedule, expression
+/// folds, and query wiring that a single-action capture never reaches. See
+/// https://github.com/zcash/ironwood/issues/17.
+#[test]
+fn fingerprint_capture_two_actions() {
+    capture_fixture(
+        0x4d,
+        2,
+        "Zcash.Snark.Fixture2",
+        "ORCHARD_LEAN_MULTI_FIXTURE_OUT",
+    );
+}

--- a/src/circuit/fingerprint/mod.rs
+++ b/src/circuit/fingerprint/mod.rs
@@ -1,4 +1,25 @@
 //! Feature-gated Orchard fixtures for Halo2 verifier fingerprints.
+//!
+//! # What these fixtures do and do not establish
+//!
+//! Each capture runs the deployed verifier once and exports the assembled MSM, transcript, and
+//! challenges as a Lean fixture. This checks that Ironwood's Lean model reproduces one *concrete*
+//! Rust verifier run; it is not a verifier soundness proof.
+//!
+//! Two limitations are load-bearing for anyone consuming the exported fixtures:
+//!
+//! * **Only accepting runs are exported to Lean.** The negative captures in `rejected` confirm in
+//!   Rust that a tampered/short/desynchronized proof assembles a non-identity MSM and is rejected by
+//!   the deployed verifier, but they are never handed to Lean. The Lean `MsmMatch` theorem is only
+//!   ever checked against *identity* (accepting) runs, so a Lean `assemble` that trivially accepts
+//!   would still pass every exported fixture. Extending the cross-check to a rejecting run needs a
+//!   Halo2 dumper variant that emits `capturedMsm.evalNat capturedURS ≠ 0` instead of the hardcoded
+//!   `= 0` (tracked upstream against the `dump_vesta_lean_fixture` tooling).
+//! * **The exported Fiat–Shamir schedule is not injective with respect to real transcripts.** The
+//!   dumper models each squeeze by appending the challenge as a `TranscriptElt.scalar`, the same
+//!   constructor used for proof-read scalars, whereas the deployed Blake2b transcript uses a
+//!   domain-separator byte and never absorbs the challenge. The schedule faithfully pins one
+//!   concrete run but must not be relied on downstream as a transcript-binding / uniqueness model.
 
 use alloc::vec::Vec;
 
@@ -116,11 +137,7 @@ fn capture_fixture(seed: u8, num_actions: u8, namespace: &str, output_var: &str)
         "PostNu6_3",
         K,
         usize::from(num_actions),
-        &transcript.common_points,
-        &transcript.points,
-        &transcript.scalars,
-        &transcript.challenges,
-        &transcript.events,
+        &transcript,
         &msm,
     );
     if let Some(path) = std::env::var_os(output_var) {

--- a/src/circuit/fingerprint/rejected.rs
+++ b/src/circuit/fingerprint/rejected.rs
@@ -129,28 +129,36 @@ fn fingerprint_rejected_capture_two_actions() {
         Err(halo2_proofs::plonk::Error::ConstraintSystemFailure)
     ));
 
-    // These are the Orchard action-circuit shape counts emitted by the Lean fixture dumper
-    // (`shape` in `Fixture2.lean`). Keeping them explicit avoids reaching into Halo2's private
-    // verifying-key internals from this crate-local negative capture test. They are pinned to the
-    // circuit asserted above by `assert_pinned_verifying_key`, so they cannot drift silently; the
-    // `assert_eq!(n_multiopen_u, 5)` below is the cross-check that catches any arithmetic error in
-    // the derived offsets that does not happen to cancel out.
+    // The multiopen u-evaluations are exactly the ReadScalars between the x3 and x4 squeezes, so
+    // recover their offset and count from the recorded event stream rather than re-deriving them
+    // from the circuit's shape counts. Squeeze order: theta, beta, gamma, y, x, x1, x2, x3, x4, ...
+    // The `== 5` below pins the count to the circuit asserted by `assert_pinned_verifying_key`.
+    let scalars_before_squeeze = |squeeze_index: usize| -> usize {
+        let (mut squeezes, mut scalars) = (0usize, 0usize);
+        for event in &transcript.events {
+            match event {
+                TranscriptEvent::ReadScalar(_) => scalars += 1,
+                TranscriptEvent::Squeeze(_) => {
+                    if squeezes == squeeze_index {
+                        break;
+                    }
+                    squeezes += 1;
+                }
+                _ => {}
+            }
+        }
+        scalars
+    };
+    let first_multiopen_u = scalars_before_squeeze(7); // ReadScalars before the x3 squeeze
+    let n_multiopen_u = scalars_before_squeeze(8) - first_multiopen_u; // x3 -> x4
+    assert_eq!(n_multiopen_u, 5);
+
+    // The permutation-set evaluations sit inside the post-`x` scalar block, which no squeeze
+    // subdivides, so their offset is still derived from the pinned circuit's shape counts (emitted
+    // as `shape` in `Fixture2.lean`); `assert_pinned_verifying_key` above keeps them from drifting.
     let n_advice_queries = 25;
     let n_fixed_evals = 29;
     let n_permutation_common_evals = 15;
-    let n_permutation_sets = 3;
-    let n_lookups = 3;
-    let n_permutation_set_evals = instances.len() * (3 * n_permutation_sets - 1);
-    let n_lookup_evals = instances.len() * n_lookups * 5;
-    let first_multiopen_u = n_instance_evals
-        + instances.len() * n_advice_queries
-        + n_fixed_evals
-        + 1
-        + n_permutation_common_evals
-        + n_permutation_set_evals
-        + n_lookup_evals;
-    let n_multiopen_u = transcript.scalars.len() - first_multiopen_u - 2;
-    assert_eq!(n_multiopen_u, 5);
 
     // Truncate the proof just before its final multiopen evaluation. The stream is now one scalar
     // short, so the verifier exhausts the transcript mid-multiopen and halo2 surfaces `Error::Opening`

--- a/src/circuit/fingerprint/rejected.rs
+++ b/src/circuit/fingerprint/rejected.rs
@@ -81,7 +81,14 @@ fn fingerprint_rejected_capture_two_actions() {
         "captured read events should reserialize the original proof exactly"
     );
 
+    // Instance evaluations are read first. `instances.len()` is the number of instance-eval scalars
+    // only because the pinned Post-NU6.3 key has exactly one instance query per proof
+    // (`num_instance_columns == 1`, locked by `assert_pinned_verifying_key` above); a key with more
+    // instance queries would break this identity.
     let n_instance_evals = instances.len();
+    // Add one to the first advice evaluation. Every proof byte is still present and well-formed, so
+    // the verifier parses the whole stream and rejects only at the final MSM identity check. This is
+    // the one genuinely semantic rejection here (contrast the truncated/desynced cases below).
     let first_advice_eval = n_instance_evals;
     let tampered_proof = proof_from_read_events(&transcript.events, |idx, scalar| {
         ScalarEventEdit::Write(if idx == first_advice_eval {
@@ -100,6 +107,9 @@ fn fingerprint_rejected_capture_two_actions() {
         &mut tampered_transcript,
     )
     .unwrap();
+    // This non-identity MSM is only checked here in Rust; it is not exported to Lean, so the Lean
+    // model is never cross-checked against a rejecting run. See the trust-boundary note in the
+    // module docs (`super`) for the Halo2-side follow-up needed to close that gap.
     assert!(
         !tampered_msm.eval(),
         "tampered advice-eval capture should assemble a non-identity fingerprint"
@@ -121,7 +131,10 @@ fn fingerprint_rejected_capture_two_actions() {
 
     // These are the Orchard action-circuit shape counts emitted by the Lean fixture dumper
     // (`shape` in `Fixture2.lean`). Keeping them explicit avoids reaching into Halo2's private
-    // verifying-key internals from this crate-local negative capture test.
+    // verifying-key internals from this crate-local negative capture test. They are pinned to the
+    // circuit asserted above by `assert_pinned_verifying_key`, so they cannot drift silently; the
+    // `assert_eq!(n_multiopen_u, 5)` below is the cross-check that catches any arithmetic error in
+    // the derived offsets that does not happen to cancel out.
     let n_advice_queries = 25;
     let n_fixed_evals = 29;
     let n_permutation_common_evals = 15;
@@ -139,6 +152,11 @@ fn fingerprint_rejected_capture_two_actions() {
     let n_multiopen_u = transcript.scalars.len() - first_multiopen_u - 2;
     assert_eq!(n_multiopen_u, 5);
 
+    // Truncate the proof just before its final multiopen evaluation. The stream is now one scalar
+    // short, so the verifier exhausts the transcript mid-multiopen and halo2 surfaces `Error::Opening`
+    // (every multiopen error is mapped to `Opening` in `plonk::verify_proof`). This exercises a
+    // short/malformed stream, not a failed polynomial-opening check; we only assert that the deployed
+    // verifier reaches the multiopen stage (>= 8 challenges: through the `x3` squeeze) and rejects.
     let truncated_u_proof = proof_from_read_events(&transcript.events, |idx, scalar| {
         if idx + 1 == first_multiopen_u + n_multiopen_u {
             ScalarEventEdit::Stop
@@ -164,6 +182,10 @@ fn fingerprint_rejected_capture_two_actions() {
         "malformed-u capture should reach the multiopen x3 challenge before rejection"
     );
 
+    // Drop one permutation-set evaluation from the middle of the read-scalar stream. Skipping a
+    // scalar desynchronizes every later read and leaves the stream one element short, so rejection
+    // follows from the misaligned/exhausted transcript rather than from a permutation-specific
+    // consistency check. We therefore assert only that the deployed verifier fails (`is_err()`).
     let first_permutation_set_eval = n_instance_evals
         + instances.len() * n_advice_queries
         + n_fixed_evals

--- a/src/circuit/fingerprint/rejected.rs
+++ b/src/circuit/fingerprint/rejected.rs
@@ -1,0 +1,208 @@
+//! Rejected and adversarial verifier-fingerprint captures.
+
+use alloc::vec::Vec;
+
+use ff::Field;
+use halo2_proofs::plonk::fingerprint::{
+    capture_proof_fingerprint, ChallengeRecorder, TranscriptEvent,
+};
+use halo2_proofs::plonk::{verify_proof, SingleVerifier};
+use halo2_proofs::transcript::{Blake2bWrite, Challenge255, TranscriptWrite};
+use pasta_curves::vesta;
+
+use super::{
+    assert_pinned_verifying_key, build_fixture_bundle, fixture_rng, raw_instance_refs,
+    raw_instances,
+};
+use crate::circuit::{OrchardCircuitVersion, ProvingKey, VerifyingKey};
+
+enum ScalarEventEdit {
+    Write(vesta::Scalar),
+    Skip,
+    Stop,
+}
+
+fn proof_from_read_events(
+    events: &[TranscriptEvent<vesta::Affine>],
+    mut scalar_mutation: impl FnMut(usize, vesta::Scalar) -> ScalarEventEdit,
+) -> Vec<u8> {
+    let mut transcript = Blake2bWrite::<_, vesta::Affine, Challenge255<_>>::init(vec![]);
+    let mut scalar_idx = 0usize;
+    for event in events {
+        match event {
+            TranscriptEvent::ReadPoint(point) => transcript.write_point(*point).unwrap(),
+            TranscriptEvent::ReadScalar(scalar) => {
+                match scalar_mutation(scalar_idx, *scalar) {
+                    ScalarEventEdit::Write(scalar) => transcript.write_scalar(scalar).unwrap(),
+                    ScalarEventEdit::Skip => {}
+                    ScalarEventEdit::Stop => break,
+                }
+                scalar_idx += 1;
+            }
+            TranscriptEvent::CommonPoint(_)
+            | TranscriptEvent::CommonScalar(_)
+            | TranscriptEvent::Squeeze(_) => {}
+        }
+    }
+    transcript.finalize()
+}
+
+/// Drives the deployed verifier on malformed versions of the real two-action fixture proof while
+/// recording the transcript prefix consumed before rejection.
+#[test]
+fn fingerprint_rejected_capture_two_actions() {
+    let mut rng = fixture_rng(0x4e);
+    let pk = ProvingKey::build(OrchardCircuitVersion::PostNu6_3);
+    let vk = VerifyingKey::build(OrchardCircuitVersion::PostNu6_3);
+    assert!(vk.supports_cross_address_restriction());
+    assert_pinned_verifying_key(&vk);
+
+    let bundle = build_fixture_bundle(&mut rng, &pk, 2);
+    let instances = bundle.to_instances();
+    let proof = bundle.authorization().proof().clone();
+    assert!(bundle.verify_proof(&vk).is_ok());
+
+    let raw_instances = raw_instances(&instances);
+    let raw_instance_refs = raw_instance_refs(&raw_instances);
+    let raw_instance_refs: Vec<_> = raw_instance_refs
+        .iter()
+        .map(|instance| &instance[..])
+        .collect();
+
+    let mut transcript = ChallengeRecorder::<_, _, Challenge255<_>>::init(&proof.0[..]);
+    let valid_msm =
+        capture_proof_fingerprint(&vk.params, &vk.vk, &raw_instance_refs, &mut transcript).unwrap();
+    assert!(valid_msm.eval());
+    assert_eq!(
+        proof_from_read_events(&transcript.events, |_, scalar| ScalarEventEdit::Write(
+            scalar
+        )),
+        proof.0,
+        "captured read events should reserialize the original proof exactly"
+    );
+
+    let n_instance_evals = instances.len();
+    let first_advice_eval = n_instance_evals;
+    let tampered_proof = proof_from_read_events(&transcript.events, |idx, scalar| {
+        ScalarEventEdit::Write(if idx == first_advice_eval {
+            scalar + vesta::Scalar::ONE
+        } else {
+            scalar
+        })
+    });
+
+    let mut tampered_transcript =
+        ChallengeRecorder::<_, _, Challenge255<_>>::init(&tampered_proof[..]);
+    let tampered_msm = capture_proof_fingerprint(
+        &vk.params,
+        &vk.vk,
+        &raw_instance_refs,
+        &mut tampered_transcript,
+    )
+    .unwrap();
+    assert!(
+        !tampered_msm.eval(),
+        "tampered advice-eval capture should assemble a non-identity fingerprint"
+    );
+
+    let strategy = SingleVerifier::new(&vk.params);
+    let mut tampered_reject_transcript =
+        ChallengeRecorder::<_, _, Challenge255<_>>::init(&tampered_proof[..]);
+    assert!(matches!(
+        verify_proof(
+            &vk.params,
+            &vk.vk,
+            strategy,
+            &raw_instance_refs,
+            &mut tampered_reject_transcript,
+        ),
+        Err(halo2_proofs::plonk::Error::ConstraintSystemFailure)
+    ));
+
+    // These are the Orchard action-circuit shape counts emitted by the Lean fixture dumper
+    // (`shape` in `Fixture2.lean`). Keeping them explicit avoids reaching into Halo2's private
+    // verifying-key internals from this crate-local negative capture test.
+    let n_advice_queries = 25;
+    let n_fixed_evals = 29;
+    let n_permutation_common_evals = 15;
+    let n_permutation_sets = 3;
+    let n_lookups = 3;
+    let n_permutation_set_evals = instances.len() * (3 * n_permutation_sets - 1);
+    let n_lookup_evals = instances.len() * n_lookups * 5;
+    let first_multiopen_u = n_instance_evals
+        + instances.len() * n_advice_queries
+        + n_fixed_evals
+        + 1
+        + n_permutation_common_evals
+        + n_permutation_set_evals
+        + n_lookup_evals;
+    let n_multiopen_u = transcript.scalars.len() - first_multiopen_u - 2;
+    assert_eq!(n_multiopen_u, 5);
+
+    let truncated_u_proof = proof_from_read_events(&transcript.events, |idx, scalar| {
+        if idx + 1 == first_multiopen_u + n_multiopen_u {
+            ScalarEventEdit::Stop
+        } else {
+            ScalarEventEdit::Write(scalar)
+        }
+    });
+    let strategy = SingleVerifier::new(&vk.params);
+    let mut truncated_u_transcript =
+        ChallengeRecorder::<_, _, Challenge255<_>>::init(&truncated_u_proof[..]);
+    assert!(matches!(
+        verify_proof(
+            &vk.params,
+            &vk.vk,
+            strategy,
+            &raw_instance_refs,
+            &mut truncated_u_transcript,
+        ),
+        Err(halo2_proofs::plonk::Error::Opening)
+    ));
+    assert!(
+        truncated_u_transcript.challenges.len() >= 8,
+        "malformed-u capture should reach the multiopen x3 challenge before rejection"
+    );
+
+    let first_permutation_set_eval = n_instance_evals
+        + instances.len() * n_advice_queries
+        + n_fixed_evals
+        + 1
+        + n_permutation_common_evals;
+    let first_nonlast_permutation_last_eval = first_permutation_set_eval + 2;
+    let missing_permutation_last_eval_proof =
+        proof_from_read_events(&transcript.events, |idx, scalar| {
+            if idx == first_nonlast_permutation_last_eval {
+                ScalarEventEdit::Skip
+            } else {
+                ScalarEventEdit::Write(scalar)
+            }
+        });
+    let strategy = SingleVerifier::new(&vk.params);
+    let mut missing_permutation_last_eval_transcript =
+        ChallengeRecorder::<_, _, Challenge255<_>>::init(&missing_permutation_last_eval_proof[..]);
+    assert!(verify_proof(
+        &vk.params,
+        &vk.vk,
+        strategy,
+        &raw_instance_refs,
+        &mut missing_permutation_last_eval_transcript,
+    )
+    .is_err());
+
+    std::eprintln!(
+        "Orchard negative captures: tampered advice eval events={} challenges={} scalars={} points={}; truncated-u events={} challenges={} scalars={} points={}; missing permutation last-eval events={} challenges={} scalars={} points={}",
+        tampered_reject_transcript.events.len(),
+        tampered_reject_transcript.challenges.len(),
+        tampered_reject_transcript.scalars.len(),
+        tampered_reject_transcript.points.len(),
+        truncated_u_transcript.events.len(),
+        truncated_u_transcript.challenges.len(),
+        truncated_u_transcript.scalars.len(),
+        truncated_u_transcript.points.len(),
+        missing_permutation_last_eval_transcript.events.len(),
+        missing_permutation_last_eval_transcript.challenges.len(),
+        missing_permutation_last_eval_transcript.scalars.len(),
+        missing_permutation_last_eval_transcript.points.len(),
+    );
+}


### PR DESCRIPTION
**Human Summary:**

Orchard side PR for https://github.com/zcash/halo2/pull/914, and consumed in https://github.com/zcash/ironwood/pull/57. See the generated fixture in https://github.com/zcash/ironwood/blob/main/Zcash/Snark/Fixtures/MultiAction/Fixture.lean.

This adds Orchard capture tests for Post-NU6.3 verifier fixtures. The tests build real bundles, compare the generated verifying key with Orchard's `PinnedVerificationKey` (closes zcash/ironwood#52) , and then emits deterministic fixtures for Ironwood.

Concretely,
  - Generates real single/two-action Post-NU6.3 proofs,
  - Confirms their verifying key matches Orchard’s canonical pinned key,
  - Captures the verifier MSM and Fiat–Shamir transcript, then exports concrete Vesta Lean fixtures for Ironwood,
  - Tests tampered and malformed proofs,

Open to organizational / feature gating preferences.

----------

**AI Summary:**

This PR adds an opt-in Orchard `verifier-fingerprint` fixture module that builds deterministic real Post-NU6.3 bundles, pins their verifying key to Orchard's canonical checked-in key, and exports normal verifier runs as concrete Lean fixtures. It does not change proof acceptance.

## What Is Added

- `src/circuit/fingerprint/` contains the single- and two-action captures plus separate rejection cases, and is compiled only with Orchard's `verifier-fingerprint` feature.
- Each capture checks the exact `PinnedVerificationKey`, verifies normally, and exports the resulting transcript and assembled MSM.
- Fixed RNG seeds and separate opt-in output paths make regeneration byte-for-byte deterministic and race-free.
- Rejection tests cover a tampered advice evaluation, truncated multiopen data, and a missing permutation evaluation.
- The checkout patch pins the helper PR head from the canonical `zcash/halo2` repository so Orchard and `halo2_gadgets` use one `halo2_proofs` package; the capture API remains feature-gated.

## Remaining Floor

These fixtures compare Ironwood against concrete Rust verifier runs; they are not a verifier soundness proof. Regeneration still trusts Orchard's canonical-key comparison and Halo2's pinned-key serialization and Blake2b transcript derivation, and the exact cross-repository comparison is not yet automated in CI.