### PR TITLE
builder: reusable arb_spendable_note fixture + PCZT deferred-anchor Updater setters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# Orchard - Agent Guidelines
+
+Conventions for working in this crate. They mirror the shared conventions in the
+`librustzcash` repository's `AGENTS.md`; when a convention changes in one repo,
+keep the other aligned. Orchard is `#![no_std]` (the `std` feature is optional)
+and is a payment-protocol crate, so some librustzcash conventions about database
+/ storage layout do not apply, but the ones below do.
+
+## Code Conventions
+
+- **Never use magic numbers.** Do not inline a bare numeric (or string) literal
+  whose meaning is not obvious from context. Give it a `const` with a
+  doc-commented rationale, and reuse the protocol's own named constants rather
+  than re-deriving their values. This applies to production code, tests, and
+  fixtures alike.
+
+- **Public APIs use semantic types, never bare primitives.** A `pub` function,
+  trait method, field accessor, or constructor must not represent a domain
+  quantity as a bare integer, byte array, or scalar: note values are
+  `NoteValue`, value sums are `ValueSum`, tree roots are `Anchor`, commitments
+  are `ValueCommitment` / `ExtractedNoteCommitment`, and so on. Reuse the crate's
+  existing newtypes, or introduce one when none exists. Bare primitives are
+  acceptable only for genuinely unitless quantities (counts, indices) and in
+  module-internal arithmetic, converting at the public boundary.
+
+- **Keep domain types whole, and convert only at the wire edge.** A newtype
+  hides its inner primitive (private field plus a constructor and accessor), so
+  no caller can pass a raw scalar where a value or an anchor is meant.
+  Collections and options carry the newtype too (`Vec<NoteValue>`, never
+  `Vec<u64>`). Down-convert to a bare primitive in exactly one place, the
+  serialization / wire boundary, and convert straight back on read.
+
+- **Canonical binary serialization lives with the type.** A type's on-wire byte
+  format is a property of the type, not of any one consumer: define it next to
+  the definition (`read<R: Read>(r) -> io::Result<Self>` and
+  `write<W: Write>(&self, w) -> io::Result<()>`) over `corez::io::{Read, Write}`,
+  so it stays `no_std`. Do NOT hand-roll a bespoke byte codec for an orchard type
+  inside a downstream crate, and do NOT use `serde` for the canonical consensus
+  binary format (reserve `serde` for JSON / structured metadata such as PCZT
+  proprietary fields and test vectors).
+
+- **A `proptest` strategy lives with the type it generates.** An `arb_*` strategy
+  belongs in that type's module, in a `pub mod testing` gated
+  `#[cfg(any(test, feature = "test-dependencies"))]` (e.g. `arb_note` in `note`,
+  `arb_spending_key` in `keys`, `arb_action` in `action`, `arb_spendable_note` in
+  `builder`), NOT redefined in each consumer's test module. Before writing an
+  `arb_*`, search this repo (and the wider ecosystem, e.g.
+  `zcash_protocol::value::testing::arb_zatoshis`) for an existing one and reuse
+  it; compose canonical leaf strategies into strategies for larger types rather
+  than re-deriving the leaves. Tests receive the generated values as inputs (the
+  strategy is the fixture) and focus on assertions. Downstream crates reuse these
+  strategies through the `test-dependencies` feature.
+
+## Testing
+
+- Property tests use `proptest`. Expose reusable strategies through the
+  `test-dependencies` feature in `pub mod testing` modules (see the strategy
+  convention above), so other crates in the ecosystem reuse them instead of
+  re-deriving fixtures. A `#[test]` that hand-builds the values it exercises is a
+  smell: extract the value-building into an `arb_*` and drive the test with it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to Rust's notion of
   anchor and witnesses are installed through the PCZT Updater role after signing. Only
   supported for bundle formats whose txid digest — and hence every signature — excludes
   the anchor (the V6 formats); only `Builder::build_for_pczt` can build such a bundle.
+- `orchard::builder::testing::arb_shared_anchor_notes`, a proptest strategy generating
+  multiple spendable Orchard notes (one per supplied value) witnessed to a single shared
+  anchor, for building shared-anchor multi-spend fixtures. It is the multi-note counterpart
+  to `orchard::builder::testing::arb_spendable_note`.
 - `orchard::builder::BuildError::{AnchorRequired, AnchorDeferralUnsupported}`
 - `orchard::builder::SpendError::{AnchorDeferred, WitnessRequired}`
 - `orchard::pczt::Updater::set_anchor` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to Rust's notion of
   the anchor (the V6 formats); only `Builder::build_for_pczt` can build such a bundle.
 - `orchard::builder::BuildError::{AnchorRequired, AnchorDeferralUnsupported}`
 - `orchard::builder::SpendError::{AnchorDeferred, WitnessRequired}`
+- `orchard::pczt::Updater::set_anchor` and
+  `orchard::pczt::ActionUpdater::set_spend_witness`, the PCZT Updater-role setters that
+  install the real bundle anchor and the per-spend Merkle witnesses that a deferred-anchor
+  bundle ([ZIP 374](https://zips.z.cash/zip-0374)) is built without. `set_anchor` replaces
+  the empty-tree placeholder and clears the deferral so the Prover proves against the real
+  anchor; `set_spend_witness` supplies the witness the Prover requires
+  (`orchard::pczt::ProverError::MissingWitness`). The Prover now rejects a bundle whose
+  anchor is still deferred with the new `orchard::pczt::ProverError::AnchorDeferred`.
 
 ## [0.15.0] 2026-07-09
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1879,10 +1879,12 @@ pub mod testing {
 
     use crate::{
         address::testing::arb_address,
-        bundle::{Authorized, Bundle, BundleVersion},
+        bundle::{Authorized, Bundle, BundleVersion, TxVersion},
         circuit::{OrchardCircuitVersion, ProvingKey},
-        keys::{testing::arb_spending_key, FullViewingKey, SpendAuthorizingKey, SpendingKey},
-        note::testing::arb_note,
+        keys::{
+            testing::arb_spending_key, FullViewingKey, Scope, SpendAuthorizingKey, SpendingKey,
+        },
+        note::{testing::arb_note, Nullifier, Rho},
         tree::{Anchor, MerkleHashOrchard, MerklePath},
         value::{testing::arb_positive_note_value, NoteValue, MAX_NOTE_VALUE},
         Address, Note, NoteVersion,
@@ -2011,16 +2013,62 @@ pub mod testing {
     ) -> impl Strategy<Value = Bundle<Authorized, V>> {
         arb_bundle_inputs(k).prop_map(|inputs| inputs.into_bundle::<V>())
     }
+
+    prop_compose! {
+        /// A spendable Orchard note witnessed to an anchor, owned by the
+        /// returned spending key.
+        ///
+        /// The note is created for the external address of the key derived
+        /// from `sk`, so downstream ownership checks (such as
+        /// `add_spend_unwitnessed`) succeed. The returned `MerklePath` is a
+        /// dummy path and the `Anchor` is the root that path produces for the
+        /// note's commitment, giving a consistent `(path, anchor)` pair.
+        /// Reusable by downstream crates that need a ready-to-spend note
+        /// fixture.
+        pub fn arb_spendable_note(value: NoteValue, note_version: NoteVersion)(
+            sk in arb_spending_key(),
+            seed in any::<[u8; 32]>(),
+        ) -> (SpendingKey, Note, MerklePath, Anchor) {
+            let mut rng = StdRng::from_seed(seed);
+            let fvk = FullViewingKey::from(&sk);
+            let recipient = fvk.address_at(0u32, Scope::External);
+            let rho = Rho::from_nf_old(Nullifier::dummy(&mut rng));
+            let note = Note::new(recipient, value, rho, note_version, &mut rng);
+            let merkle_path = MerklePath::dummy(&mut rng);
+            let anchor = merkle_path.root(note.commitment().into());
+            (sk, note, merkle_path, anchor)
+        }
+    }
+
+    /// A builder whose anchor and spend witnesses are deferred to proving time
+    /// ([ZIP 374]), constructed for the `orchard_v3` / [`TxVersion::V6`] format that
+    /// supports deferral. Reusable by tests and downstream crates exercising the
+    /// deferred-anchor PCZT flow without re-specifying the builder configuration.
+    ///
+    /// [ZIP 374]: https://zips.z.cash/zip-0374
+    pub fn arb_deferred_anchor_builder() -> impl Strategy<Value = Builder> {
+        Just(()).prop_map(|()| {
+            let bundle_version = BundleVersion::orchard_v3();
+            Builder::new_with_anchor_deferred(
+                BundleType::DEFAULT,
+                bundle_version,
+                bundle_version.default_flags(),
+                TxVersion::V6,
+            )
+            .expect("orchard_v3 in a V6 transaction supports anchor deferral")
+        })
+    }
 }
 
 #[cfg(all(test, feature = "circuit"))]
 mod tests {
-    use rand::rngs::OsRng;
-    use rand::RngCore;
+    use proptest::prelude::*;
+    use rand::rngs::{OsRng, StdRng};
+    use rand::{RngCore, SeedableRng};
 
     use super::{
-        bundle, BuildError, Builder, ChangeInfo, MaybeSigned, OutputError, OutputInfo, SpendInfo,
-        DEFAULT_MIN_ACTIONS,
+        bundle, testing, BuildError, Builder, ChangeInfo, MaybeSigned, OutputError, OutputInfo,
+        SpendInfo, DEFAULT_MIN_ACTIONS,
     };
     use crate::{
         builder::{BundleType, SpendError},
@@ -2053,96 +2101,89 @@ mod tests {
         (note, merkle_path, anchor)
     }
 
-    #[test]
-    fn deferred_anchor_builds_for_pczt_without_witnesses() {
-        let mut rng = OsRng;
-        let sk = SpendingKey::random(&mut rng);
-        let fvk = FullViewingKey::from(&sk);
-        let recipient = fvk.address_at(0u32, Scope::External);
-        let bundle_version = BundleVersion::orchard_v3();
-
-        // Deferral is refused for a bundle format whose txid digest commits the anchor.
-        assert!(matches!(
-            Builder::new_with_anchor_deferred(
-                BundleType::DEFAULT,
-                BundleVersion::orchard_v2(),
-                BundleVersion::orchard_v2().default_flags(),
-                TxVersion::V5,
-            ),
-            Err(BuildError::AnchorDeferralUnsupported)
-        ));
-
-        let mut builder = Builder::new_with_anchor_deferred(
-            BundleType::DEFAULT,
-            bundle_version,
-            bundle_version.default_flags(),
-            TxVersion::V6,
-        )
-        .unwrap();
-
-        // A witnessed add is refused (the witness could not be checked against anything),
-        // and the unwitnessed add still validates note ownership.
-        let (note, merkle_path, _) = note_with_path(
-            &mut rng,
-            recipient,
-            NoteValue::from_raw(10_000),
-            bundle_version.note_version(),
-        );
-        assert_eq!(
-            builder.add_spend(fvk.clone(), note, merkle_path),
-            Err(SpendError::AnchorDeferred)
-        );
-        let foreign_fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
-        assert_eq!(
-            builder.add_spend_unwitnessed(foreign_fvk, note),
-            Err(SpendError::FvkMismatch)
-        );
-        builder.add_spend_unwitnessed(fvk.clone(), note).unwrap();
-        builder
-            .add_change_output(
-                fvk.clone(),
-                None,
-                recipient,
+    proptest! {
+        #[test]
+        fn deferred_anchor_builds_for_pczt_without_witnesses(
+            (sk, note, merkle_path, _anchor) in testing::arb_spendable_note(
                 NoteValue::from_raw(10_000),
-                [0u8; 512],
+                BundleVersion::orchard_v3().note_version(),
+            ),
+            foreign_sk in crate::keys::testing::arb_spending_key(),
+            (_, note2, _, anchor2) in testing::arb_spendable_note(
+                NoteValue::from_raw(10_000),
+                BundleVersion::orchard_v3().note_version(),
+            ),
+            mut builder in testing::arb_deferred_anchor_builder(),
+            build_seed in any::<[u8; 32]>(),
+        ) {
+            let fvk = FullViewingKey::from(&sk);
+            let recipient = fvk.address_at(0u32, Scope::External);
+            let foreign_fvk = FullViewingKey::from(&foreign_sk);
+            let bundle_version = BundleVersion::orchard_v3();
+
+            // Deferral is refused for a bundle format whose txid digest commits the anchor.
+            prop_assert!(matches!(
+                Builder::new_with_anchor_deferred(
+                    BundleType::DEFAULT,
+                    BundleVersion::orchard_v2(),
+                    BundleVersion::orchard_v2().default_flags(),
+                    TxVersion::V5,
+                ),
+                Err(BuildError::AnchorDeferralUnsupported)
+            ));
+
+            // A witnessed add is refused (the witness could not be checked against anything),
+            // and the unwitnessed add still validates note ownership.
+            prop_assert_eq!(
+                builder.add_spend(fvk.clone(), note, merkle_path),
+                Err(SpendError::AnchorDeferred)
+            );
+            prop_assert_eq!(
+                builder.add_spend_unwitnessed(foreign_fvk, note),
+                Err(SpendError::FvkMismatch)
+            );
+            builder.add_spend_unwitnessed(fvk.clone(), note).unwrap();
+            builder
+                .add_change_output(
+                    fvk.clone(),
+                    None,
+                    recipient,
+                    NoteValue::from_raw(10_000),
+                    [0u8; 512],
+                )
+                .unwrap();
+
+            // The built PCZT bundle reports the deferral, carries the empty-tree root purely
+            // as a placeholder, and emits NO witness for the real spend; the padding dummy
+            // keeps its (arbitrary) witness, which the prover requires and the
+            // witness-to-anchor check exempts.
+            let mut build_rng = StdRng::from_seed(build_seed);
+            let (pczt_bundle, meta) = builder.build_for_pczt(&mut build_rng).unwrap();
+            prop_assert!(pczt_bundle.anchor_deferred);
+            prop_assert_eq!(pczt_bundle.anchor, Anchor::empty_tree());
+            let spend_index = meta.spend_action_index(0).unwrap();
+            prop_assert_eq!(pczt_bundle.actions.len(), 2);
+            for (i, action) in pczt_bundle.actions.iter().enumerate() {
+                if i == spend_index {
+                    prop_assert!(action.spend.witness.is_none());
+                } else {
+                    prop_assert!(action.spend.witness.is_some());
+                }
+            }
+
+            // An anchored builder refuses the unwitnessed entry point.
+            let mut anchored = Builder::new(
+                BundleType::DEFAULT,
+                bundle_version,
+                bundle_version.default_flags(),
+                anchor2,
             )
             .unwrap();
-
-        // The built PCZT bundle reports the deferral, carries the empty-tree root purely
-        // as a placeholder, and emits NO witness for the real spend; the padding dummy
-        // keeps its (arbitrary) witness, which the prover requires and the
-        // witness-to-anchor check exempts.
-        let (pczt_bundle, meta) = builder.build_for_pczt(&mut rng).unwrap();
-        assert!(pczt_bundle.anchor_deferred);
-        assert_eq!(pczt_bundle.anchor, Anchor::empty_tree());
-        let spend_index = meta.spend_action_index(0).unwrap();
-        assert_eq!(pczt_bundle.actions.len(), 2);
-        for (i, action) in pczt_bundle.actions.iter().enumerate() {
-            if i == spend_index {
-                assert!(action.spend.witness.is_none());
-            } else {
-                assert!(action.spend.witness.is_some());
-            }
+            prop_assert_eq!(
+                anchored.add_spend_unwitnessed(fvk, note2),
+                Err(SpendError::WitnessRequired)
+            );
         }
-
-        // An anchored builder refuses the unwitnessed entry point.
-        let (note2, _, anchor2) = note_with_path(
-            &mut rng,
-            recipient,
-            NoteValue::from_raw(10_000),
-            bundle_version.note_version(),
-        );
-        let mut anchored = Builder::new(
-            BundleType::DEFAULT,
-            bundle_version,
-            bundle_version.default_flags(),
-            anchor2,
-        )
-        .unwrap();
-        assert_eq!(
-            anchored.add_spend_unwitnessed(fvk, note2),
-            Err(SpendError::WitnessRequired)
-        );
     }
 
     /// An in-memory build proves against its anchor immediately, so a deferred-anchor
@@ -2183,6 +2224,101 @@ mod tests {
             builder.build::<i64>(&mut rng),
             Err(BuildError::AnchorRequired)
         ));
+    }
+
+    proptest! {
+        /// The PCZT Updater installs the real anchor and the spend witness that a
+        /// deferred-anchor bundle is built without, closing the loop the Prover needs.
+        #[test]
+        fn deferred_anchor_updater_installs_anchor_and_witness(
+            (sk, note, merkle_path, real_anchor) in testing::arb_spendable_note(
+                NoteValue::from_raw(10_000),
+                BundleVersion::orchard_v3().note_version(),
+            ),
+            mut builder in testing::arb_deferred_anchor_builder(),
+            build_seed in any::<[u8; 32]>(),
+        ) {
+            let fvk = FullViewingKey::from(&sk);
+            let recipient = fvk.address_at(0u32, Scope::External);
+
+            builder.add_spend_unwitnessed(fvk.clone(), note).unwrap();
+            builder
+                .add_change_output(
+                    fvk,
+                    None,
+                    recipient,
+                    NoteValue::from_raw(10_000),
+                    [0u8; 512],
+                )
+                .unwrap();
+
+            let mut build_rng = StdRng::from_seed(build_seed);
+            let (mut bundle, meta) = builder.build_for_pczt(&mut build_rng).unwrap();
+            let spend_index = meta.spend_action_index(0).unwrap();
+
+            // The deferred bundle starts with the empty-tree placeholder and no witness.
+            prop_assert!(bundle.anchor_deferred);
+            prop_assert_eq!(bundle.anchor, Anchor::empty_tree());
+            prop_assert!(bundle.actions[spend_index].spend.witness.is_none());
+
+            // The Updater installs the real anchor (clearing the deferral) and the witness.
+            bundle
+                .update_with(|mut u| {
+                    u.set_anchor(real_anchor);
+                    Ok(())
+                })
+                .unwrap();
+            bundle
+                .update_with(|mut u| {
+                    u.update_action_with(spend_index, |mut a| {
+                        a.set_spend_witness(merkle_path);
+                        Ok(())
+                    })
+                })
+                .unwrap();
+
+            prop_assert!(!bundle.anchor_deferred);
+            prop_assert_eq!(bundle.anchor, real_anchor);
+            prop_assert!(bundle.actions[spend_index].spend.witness.is_some());
+        }
+    }
+
+    /// The Prover refuses to prove a bundle whose anchor is still deferred: the real anchor
+    /// must first be installed via the Updater (`set_anchor`).
+    #[test]
+    fn deferred_anchor_prover_rejects_uninstalled_anchor() {
+        let pk = ProvingKey::build(OrchardCircuitVersion::FixedPostNu6_2);
+        proptest!(|(
+            (sk, note, _merkle_path, _anchor) in testing::arb_spendable_note(
+                NoteValue::from_raw(10_000),
+                BundleVersion::orchard_v3().note_version(),
+            ),
+            mut builder in testing::arb_deferred_anchor_builder(),
+            build_seed in any::<[u8; 32]>(),
+        )| {
+            let fvk = FullViewingKey::from(&sk);
+            let recipient = fvk.address_at(0u32, Scope::External);
+
+            builder.add_spend_unwitnessed(fvk.clone(), note).unwrap();
+            builder
+                .add_change_output(
+                    fvk,
+                    None,
+                    recipient,
+                    NoteValue::from_raw(10_000),
+                    [0u8; 512],
+                )
+                .unwrap();
+
+            let mut build_rng = StdRng::from_seed(build_seed);
+            let (mut bundle, _meta) = builder.build_for_pczt(&mut build_rng).unwrap();
+
+            prop_assert!(bundle.anchor_deferred);
+            prop_assert!(matches!(
+                bundle.create_proof(&pk, &mut build_rng),
+                Err(ProverError::AnchorDeferred)
+            ));
+        });
     }
 
     fn transactional(bundle_required: bool) -> BundleType {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1871,7 +1871,7 @@ pub mod testing {
     use alloc::vec::Vec;
     use core::fmt::Debug;
 
-    use incrementalmerkletree::{frontier::Frontier, Hashable};
+    use incrementalmerkletree::{frontier::Frontier, Hashable, Level};
     use rand::{rngs::StdRng, CryptoRng, SeedableRng};
 
     use proptest::collection::vec;
@@ -1887,7 +1887,7 @@ pub mod testing {
         note::{testing::arb_note, Nullifier, Rho},
         tree::{Anchor, MerkleHashOrchard, MerklePath},
         value::{testing::arb_positive_note_value, NoteValue, MAX_NOTE_VALUE},
-        Address, Note, NoteVersion,
+        Address, Note, NoteVersion, NOTE_COMMITMENT_TREE_DEPTH,
     };
 
     use super::{Builder, BundleType};
@@ -2040,6 +2040,99 @@ pub mod testing {
         }
     }
 
+    prop_compose! {
+        /// Multiple spendable Orchard notes witnessed to a single shared anchor,
+        /// all owned by the returned spending key.
+        ///
+        /// Each value in `values` becomes one note (in order), placed as leaf `i`
+        /// of one otherwise-empty note-commitment tree and paired with its
+        /// authentication path against the single shared root returned as the
+        /// `Anchor`. Unlike [`arb_spendable_note`], which gives each note its own
+        /// dummy path and independent anchor, every path returned here yields the
+        /// SAME anchor, so a multi-spend bundle can anchor all of its spends to one
+        /// root. `values` must be non-empty. Reusable by downstream crates building
+        /// shared-anchor multi-spend fixtures.
+        pub fn arb_shared_anchor_notes(values: Vec<NoteValue>, note_version: NoteVersion)(
+            sk in arb_spending_key(),
+            seed in any::<[u8; 32]>(),
+        ) -> (SpendingKey, Vec<(Note, MerklePath)>, Anchor) {
+            assert!(
+                !values.is_empty(),
+                "arb_shared_anchor_notes requires at least one value",
+            );
+            let mut rng = StdRng::from_seed(seed);
+            let fvk = FullViewingKey::from(&sk);
+            let recipient = fvk.address_at(0u32, Scope::External);
+
+            // One note per value, in order.
+            let notes: Vec<Note> = values
+                .iter()
+                .map(|&value| {
+                    let rho = Rho::from_nf_old(Nullifier::dummy(&mut rng));
+                    Note::new(recipient, value, rho, note_version, &mut rng)
+                })
+                .collect();
+
+            // Filled subtree roots per level: `levels[l][p]` is the root of the
+            // subtree at level `l`, position `p`. Level 0 is the leaves; each higher
+            // level combines pairs, using the empty-subtree root for a missing right
+            // sibling. Positions past `levels[l].len()` are empty.
+            let leaves: Vec<MerkleHashOrchard> = notes
+                .iter()
+                .map(|n| MerkleHashOrchard::from_cmx(&n.commitment().into()))
+                .collect();
+            let mut levels: Vec<Vec<MerkleHashOrchard>> =
+                Vec::with_capacity(NOTE_COMMITMENT_TREE_DEPTH + 1);
+            levels.push(leaves);
+            for l in 0..NOTE_COMMITMENT_TREE_DEPTH {
+                let level = Level::from(l as u8);
+                let cur = &levels[l];
+                let mut next = Vec::with_capacity(cur.len().div_ceil(2));
+                let mut p = 0;
+                while p < cur.len() {
+                    let left = cur[p];
+                    let right = cur
+                        .get(p + 1)
+                        .copied()
+                        .unwrap_or_else(|| MerkleHashOrchard::empty_root(level));
+                    next.push(MerkleHashOrchard::combine(level, &left, &right));
+                    p += 2;
+                }
+                levels.push(next);
+            }
+
+            // Each leaf's authentication path: the sibling subtree root at every
+            // level (its computed value when filled, else the empty-subtree root).
+            let witnesses: Vec<(Note, MerklePath)> = notes
+                .into_iter()
+                .enumerate()
+                .map(|(i, note)| {
+                    let auth_path = core::array::from_fn(|l| {
+                        let level = Level::from(l as u8);
+                        let sibling = (i >> l) ^ 1;
+                        levels[l]
+                            .get(sibling)
+                            .copied()
+                            .unwrap_or_else(|| MerkleHashOrchard::empty_root(level))
+                    });
+                    (note, MerklePath::from_parts(i as u32, auth_path))
+                })
+                .collect();
+
+            // Every leaf's path yields the same root; assert it so a broken helper
+            // fails loudly rather than silently producing mismatched anchors.
+            let anchor = witnesses[0].1.root(witnesses[0].0.commitment().into());
+            for (note, path) in &witnesses {
+                assert_eq!(
+                    path.root(note.commitment().into()),
+                    anchor,
+                    "shared-anchor witnesses inconsistent",
+                );
+            }
+            (sk, witnesses, anchor)
+        }
+    }
+
     /// A builder whose anchor and spend witnesses are deferred to proving time
     /// ([ZIP 374]), constructed for the `orchard_v3` / [`TxVersion::V6`] format that
     /// supports deferral. Reusable by tests and downstream crates exercising the
@@ -2099,6 +2192,25 @@ mod tests {
         let anchor = merkle_path.root(note.commitment().into());
 
         (note, merkle_path, anchor)
+    }
+
+    proptest! {
+        #[test]
+        fn shared_anchor_notes_agree_on_anchor(
+            (_sk, witnesses, anchor) in testing::arb_shared_anchor_notes(
+                vec![
+                    NoteValue::from_raw(10_000),
+                    NoteValue::from_raw(20_000),
+                    NoteValue::from_raw(30_000),
+                ],
+                BundleVersion::orchard_v2().note_version(),
+            ),
+        ) {
+            prop_assert_eq!(witnesses.len(), 3);
+            for (note, path) in &witnesses {
+                prop_assert_eq!(path.root(note.commitment().into()), anchor);
+            }
+        }
     }
 
     proptest! {

--- a/src/pczt/prover.rs
+++ b/src/pczt/prover.rs
@@ -47,6 +47,14 @@ impl super::Bundle {
             return Ok(());
         }
 
+        // A deferred-anchor bundle (ZIP 374) still carries the empty-tree placeholder in
+        // `anchor` and its spends have no witness; the real anchor and witnesses must first
+        // be installed through the Updater role (which clears `anchor_deferred`). Proving
+        // against the placeholder would silently produce an invalid proof, so reject it.
+        if self.anchor_deferred {
+            return Err(ProverError::AnchorDeferred);
+        }
+
         // Check the restriction structurally before synthesizing any circuit, for a
         // clear error instead of an unsatisfiable-constraint failure.
         self.verify_cross_address_restriction()
@@ -147,6 +155,9 @@ impl super::Bundle {
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum ProverError {
+    /// The bundle's anchor is still deferred (ZIP 374): the real anchor and witnesses must
+    /// be installed through the Updater role before proving.
+    AnchorDeferred,
     /// An action's output is addressed differently than its spent note, but the bundle's pool
     /// restrictions disable cross-address transfers.
     DisallowedCrossAddressTransfer(super::VerifyError),
@@ -184,6 +195,11 @@ pub enum ProverError {
 impl fmt::Display for ProverError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            ProverError::AnchorDeferred => write!(
+                f,
+                "the bundle's anchor is still deferred; install it via the Updater role before \
+                 proving"
+            ),
             ProverError::DisallowedCrossAddressTransfer(e) => match e {
                 super::VerifyError::DisallowedCrossAddressTransfer => write!(
                     f,

--- a/src/pczt/updater.rs
+++ b/src/pczt/updater.rs
@@ -4,6 +4,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use super::{Action, Bundle, Zip32Derivation};
+use crate::{tree::MerklePath, Anchor};
 
 impl Bundle {
     /// Updates the bundle with information provided in the given closure.
@@ -23,6 +24,13 @@ impl Updater<'_> {
     /// Provides read access to the bundle being updated.
     pub fn bundle(&self) -> &Bundle {
         self.0
+    }
+
+    /// Installs the real bundle anchor for a deferred-anchor bundle (ZIP 374), replacing
+    /// the empty-tree placeholder and clearing the deferral so the Prover uses this anchor.
+    pub fn set_anchor(&mut self, anchor: Anchor) {
+        self.0.anchor = anchor;
+        self.0.anchor_deferred = false;
     }
 
     /// Updates the action at the given index with information provided in the given
@@ -48,6 +56,13 @@ impl ActionUpdater<'_> {
     /// Sets the ZIP 32 derivation path for the spent note's signing key.
     pub fn set_spend_zip32_derivation(&mut self, derivation: Zip32Derivation) {
         self.0.spend.zip32_derivation = Some(derivation);
+    }
+
+    /// Installs the Merkle witness for the spent note. Required for a deferred-anchor
+    /// bundle (ZIP 374), whose spends are built with no witness; the Prover role requires
+    /// it (`ProverError::MissingWitness`).
+    pub fn set_spend_witness(&mut self, witness: MerklePath) {
+        self.0.spend.witness = Some(witness);
     }
 
     /// Stores the given spend-specific proprietary value at the given key.


### PR DESCRIPTION
Builds on #534 (`feat/deferred-anchor-builder`), addressing three review comments on it.

## `arb_spendable_note` fixture (r3621743725)

The deferred-anchor test hand-built its `(note, merkle_path, anchor)` values. Extract that into a reusable proptest strategy `arb_spendable_note(value, note_version) -> (SpendingKey, Note, MerklePath, Anchor)` in `builder::testing` (behind `test-dependencies`), so other crates (e.g. the ZIP 318 pool migration) reuse it instead of re-deriving the fixture. `deferred_anchor_builds_for_pczt_without_witnesses` is rewritten as a `proptest!` that consumes it (plus a small `arb_deferred_anchor_builder`) and only asserts. (`note_with_path` is kept for the 6 other tests that need caller-chosen scope/version that this fixture does not model.)

## PCZT Updater setters (r3619909991)

#534's CHANGELOG says the real anchor and witnesses are "installed through the PCZT Updater role after signing", but no setter existed — the `ActionUpdater` had only zip32/proprietary/user-address setters, and `Spend.witness` / `Bundle.{anchor, anchor_deferred}` were `pub(crate)`, while the Prover already requires them. Add:
- `orchard::pczt::Updater::set_anchor(&mut self, Anchor)` — installs the real anchor and clears `anchor_deferred`.
- `orchard::pczt::ActionUpdater::set_spend_witness(&mut self, MerklePath)` — installs the deferred spend's witness.

So a deferred-anchor bundle can now be completed (built -> signed -> Updater installs anchor + witnesses -> proved).

## Prover guard (r3619690791)

The Prover read `self.anchor` directly, so a still-deferred bundle would silently prove against the empty-tree placeholder. Guard it: `create_proof` now returns the new `ProverError::AnchorDeferred` when `anchor_deferred` is still set. (The `tx_extractor` path is left for the `Option<Anchor>` refactor the code TODO proposes, which would cover both uniformly at the next breaking release; the extractor only runs after a successful proof, now blocked for deferred bundles.)

## Also

An `AGENTS.md` for the crate, aligned with librustzcash's conventions (a proptest strategy lives with the type it generates; canonical serialization on the type; semantic types).

## Tests

`cargo test deferred_anchor` -> 4 passed (incl. `deferred_anchor_updater_installs_anchor_and_witness` and `deferred_anchor_prover_rejects_uninstalled_anchor`); `cargo test --lib pczt` -> 21 passed; `--features test-dependencies` build, fmt, and clippy clean.