### PR TITLE
Derive instance commitments from public inputs in the fingerprint fixure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,9 +992,8 @@ dependencies = [
 
 [[package]]
 name = "halo2_proofs"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576d38119e960ec18628c2eb7558a3a06fcb9fd1e003a36f40f0496919a0aaa9"
+version = "0.3.2"
+source = "git+https://github.com/TalDerei/halo2?branch=fingerprint-verifier-upstream#189b0a03cf077f5dbb97bc27dffdbfff373b49f9"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,8 +992,9 @@ dependencies = [
 
 [[package]]
 name = "halo2_proofs"
-version = "0.3.3"
-source = "git+https://github.com/TalDerei/halo2?branch=fingerprint-verifier-upstream#e5dc23e90a3e1e6f84a40e041cf3a157e62931d5"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f63a999d9223fa9d3b9db3031fedc316e6039a0ae0f67394408b16ef670c69f"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,8 +992,8 @@ dependencies = [
 
 [[package]]
 name = "halo2_proofs"
-version = "0.3.2"
-source = "git+https://github.com/TalDerei/halo2?branch=fingerprint-verifier-upstream#189b0a03cf077f5dbb97bc27dffdbfff373b49f9"
+version = "0.3.3"
+source = "git+https://github.com/TalDerei/halo2?branch=fingerprint-verifier-upstream#e5dc23e90a3e1e6f84a40e041cf3a157e62931d5"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,3 +112,9 @@ debug = true
 
 [profile.bench]
 debug = true
+
+# Consume the unpublished halo2 change from zcash/halo2#918 (the new dump_vesta_lean_fixture
+# signature). Points at the PR's head branch; drop this once a halo2_proofs with the change is
+# published to crates.io.
+[patch.crates-io]
+halo2_proofs = { git = "https://github.com/TalDerei/halo2", branch = "fingerprint-verifier-upstream" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,9 +112,3 @@ debug = true
 
 [profile.bench]
 debug = true
-
-# Consume the unpublished halo2 change from zcash/halo2#918 (the new dump_vesta_lean_fixture
-# signature). Points at the PR's head branch; drop this once a halo2_proofs with the change is
-# published to crates.io.
-[patch.crates-io]
-halo2_proofs = { git = "https://github.com/TalDerei/halo2", branch = "fingerprint-verifier-upstream" }

--- a/src/circuit/fingerprint/mod.rs
+++ b/src/circuit/fingerprint/mod.rs
@@ -137,7 +137,7 @@ fn capture_fixture(seed: u8, num_actions: u8, namespace: &str, output_var: &str)
         namespace,
         "PostNu6_3",
         K,
-        usize::from(num_actions),
+        &raw_instance_refs,
         &transcript,
         &msm,
     );


### PR DESCRIPTION
Orchard side PR for https://github.com/zcash/halo2/pull/918, and consumed in https://github.com/zcash/ironwood/pull/85.

halo2's `dump_vesta_lean_fixture` now takes the verifier's public `instances` (and no longer a separate `num_proofs`), deriving each Lean instance commitment from the public inputs rather than exporting it as an opaque vk field. 