### PR TITLE
orchard 0.15.4 release: Accelerate batched trial decryption with GLV endomorphism windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- Batched trial decryption (the `zcash_note_encryption::batch` APIs) is
+  significantly faster. Ephemeral keys are now prepared with GLV endomorphism
+  windows built across the whole batch with a single shared normalization, and
+  each viewing key's GLV decomposition is computed once per batch and reused
+  against every ephemeral key. The GLV primitive lives in `pasta_curves::glv`
+  (`Table` / `Decomposed` / `Table::mul_decomposed`); orchard consumes it
+  through the `BatchDomain::batch_ka_agree_dec` hook added in
+  `zcash_note_encryption` 0.4.2. Shared secrets are unchanged (byte-identical
+  to the per-item path), and the per-output decryption entry points are
+  unaffected. Like the existing `group::Wnaf`-based preparation, the new path
+  is variable-time with respect to the (wallet-local) viewing key scalar.
+- MSRV-compatible bump: the minimum `zcash_note_encryption` version is now 0.4.2.
+
 ## [0.15.3] - 2026-07-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.15.4] - 2026-07-23
+
 ### Changed
 - Batched trial decryption (the `zcash_note_encryption::batch` APIs) is
   significantly faster. Ephemeral keys are now prepared with GLV endomorphism
@@ -20,6 +22,8 @@ and this project adheres to Rust's notion of
   unaffected. Like the existing `group::Wnaf`-based preparation, the new path
   is variable-time with respect to the (wallet-local) viewing key scalar.
 - MSRV-compatible bump: the minimum `zcash_note_encryption` version is now 0.4.2.
+- MSRV-compatible bump: the minimum `pasta_curves` version is now 0.5.2, and its
+  `glv` feature is now enabled (providing `pasta_curves::glv`).
 
 ## [0.15.3] - 2026-07-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "pasta_curves"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+checksum = "3437083215c505e867eea5478371feba43d7689d6d15ec0a209eb46fb0d4cda6"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -2560,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_note_encryption"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77efec759c3798b6e4d829fcc762070d9b229b0f13338c40bf993b7b609c2272"
+checksum = "e1cb1b9170c94370e3d66c5cc0877661db743337588b64de7711239eed462198"
 dependencies = [
  "chacha20",
  "chacha20poly1305",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,7 +1432,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchard"
-version = "0.15.3"
+version = "0.15.4"
 authors = [
     "Sean Bowe <ewillbefull@gmail.com>",
     "Jack Grigg <thestr4d@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ group = "0.13"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 lazy_static = "1"
 memuse = { version = "0.2.2", default-features = false }
-pasta_curves = "0.5"
+pasta_curves = { version = "0.5.2", features = ["glv"] }
 proptest = { version = ">=1.0.0, <1.7.0", optional = true }
 rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
@@ -42,7 +42,7 @@ poseidon = { package = "halo2_poseidon", version = "0.1" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 sinsemilla = "0.1"
 subtle = { version = "2.6", default-features = false }
-zcash_note_encryption = "0.4"
+zcash_note_encryption = "0.4.2"
 incrementalmerkletree = "0.8.1"
 zcash_spec = "0.2.1"
 zip32 = { version = "0.2.0", default-features = false }
@@ -71,7 +71,7 @@ halo2_gadgets = { version = "0.5", features = ["test-dependencies"] }
 hex = "0.4"
 proptest = ">=1.0.0, <1.7.0"
 rand_chacha = "0.3"
-zcash_note_encryption = { version = "0.4", features = ["pre-zip-212"] }
+zcash_note_encryption = { version = "0.4.2", features = ["pre-zip-212"] }
 incrementalmerkletree = { version = "0.8.1", features = ["test-dependencies"] }
 shardtree = "0.6"
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,5 +1,6 @@
 //! Key structures for Orchard.
 
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use corez::io::{self, Read, Write};
 
@@ -12,6 +13,7 @@ use group::{
     prime::PrimeCurveAffine,
     Curve, GroupEncoding,
 };
+use pasta_curves::glv::{Decomposed, Table};
 use pasta_curves::pallas;
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
@@ -714,6 +716,12 @@ impl PreparedIncomingViewingKey {
     fn new_inner(ivk: &KeyAgreementPrivateKey) -> Self {
         Self(PreparedNonZeroScalar::new(&ivk.0))
     }
+
+    /// The raw ivk scalar, for the GLV ladder in `pasta_curves::glv` (which
+    /// decomposes the scalar rather than consuming the prepared wNAF form).
+    pub(crate) fn raw_scalar(&self) -> pallas::Scalar {
+        self.0.raw_scalar()
+    }
 }
 
 /// A key that provides the capability to recover outgoing transaction information from
@@ -852,17 +860,81 @@ impl EphemeralPublicKey {
     }
 }
 
+/// What a prepared ephemeral key carries.
+///
+/// Individually-prepared keys carry a `group::Wnaf` window table, consumed by
+/// the per-item multiplication. Batch-prepared keys carry a GLV odd-multiples
+/// window instead (see `pasta_curves::glv`), which is cheaper to build across a
+/// batch (one shared normalization) and cheaper to multiply against (a
+/// shared-doubling ladder over the endomorphism split). Both produce
+/// identical shared secrets.
+#[derive(Clone, Debug)]
+enum PreparedEpkInner {
+    /// A `group::Wnaf` window table.
+    Wnaf(PreparedNonIdentityBase),
+    /// A GLV odd-multiples window, boxed to keep the enum small (512 bytes,
+    /// the same heap-allocation shape as the wNAF table it replaces).
+    Tabled(Box<Table<pallas::Point>>),
+}
+
 /// An Orchard ephemeral public key that has been precomputed for trial decryption.
 #[derive(Clone, Debug)]
-pub struct PreparedEphemeralPublicKey(PreparedNonIdentityBase);
+pub struct PreparedEphemeralPublicKey(PreparedEpkInner);
 
 impl PreparedEphemeralPublicKey {
     pub(crate) fn new(epk: EphemeralPublicKey) -> Self {
-        PreparedEphemeralPublicKey(PreparedNonIdentityBase::new(epk.0))
+        PreparedEphemeralPublicKey(PreparedEpkInner::Wnaf(PreparedNonIdentityBase::new(epk.0)))
+    }
+
+    /// Prepares every ephemeral key in a batch by building its GLV window,
+    /// sharing one batch normalization (a single field inversion) across the
+    /// whole set, where individual preparation pays one inversion per key.
+    /// `None` lanes (ephemeral keys that failed to decode) pass through as
+    /// `None`.
+    pub(crate) fn batch_tabled(
+        epks: Vec<Option<EphemeralPublicKey>>,
+    ) -> Vec<Option<PreparedEphemeralPublicKey>> {
+        let live: Vec<pallas::Point> = epks
+            .iter()
+            .filter_map(|e| e.as_ref().map(|e| *e.0))
+            .collect();
+        let mut tables = Table::<pallas::Point>::batch(&live).into_iter();
+        epks.into_iter()
+            .map(|e| {
+                e.map(|_| {
+                    PreparedEphemeralPublicKey(PreparedEpkInner::Tabled(Box::new(
+                        tables.next().expect("one table per live epk"),
+                    )))
+                })
+            })
+            .collect()
     }
 
     pub(crate) fn agree(&self, ivk: &PreparedIncomingViewingKey) -> SharedSecret {
-        SharedSecret(ka_orchard_prepared(&ivk.0, &self.0))
+        match &self.0 {
+            PreparedEpkInner::Wnaf(base) => SharedSecret(ka_orchard_prepared(&ivk.0, base)),
+            // The product of a non-zero scalar and a non-identity point in the
+            // prime-order Pallas group is non-identity.
+            PreparedEpkInner::Tabled(table) => SharedSecret(
+                NonIdentityPallasPoint::expect_non_identity(table.mul(&ivk.raw_scalar())),
+            ),
+        }
+    }
+
+    /// Like `agree`, but with the viewing key's GLV decomposition
+    /// precomputed. Used by the batched agreement path, which hoists the
+    /// decomposition and digit recoding out of the per-output loop.
+    pub(crate) fn agree_with(
+        &self,
+        ivk: &PreparedIncomingViewingKey,
+        decomposed: &Decomposed<pallas::Point>,
+    ) -> SharedSecret {
+        match &self.0 {
+            PreparedEpkInner::Wnaf(base) => SharedSecret(ka_orchard_prepared(&ivk.0, base)),
+            PreparedEpkInner::Tabled(table) => SharedSecret(
+                NonIdentityPallasPoint::expect_non_identity(table.mul_decomposed(decomposed)),
+            ),
+        }
     }
 }
 

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -350,6 +350,37 @@ impl<P: DomainPolicy> BatchDomain for NoteEncryptionDomain<P> {
     ) -> Vec<Option<Self::SymmetricKey>> {
         batch_kdf(items)
     }
+
+    fn batch_epk(
+        ephemeral_keys: impl Iterator<Item = EphemeralKeyBytes>,
+    ) -> Vec<(Option<Self::PreparedEphemeralPublicKey>, EphemeralKeyBytes)> {
+        // Prepare the whole batch with GLV windows, sharing one batch
+        // normalization across every key (a single field inversion, where
+        // per-item preparation pays one per key).
+        let (epks, ephemeral_keys): (Vec<_>, Vec<_>) = ephemeral_keys
+            .map(|ephemeral_key| (Self::epk(&ephemeral_key), ephemeral_key))
+            .unzip();
+        PreparedEphemeralPublicKey::batch_tabled(epks)
+            .into_iter()
+            .zip(ephemeral_keys)
+            .collect()
+    }
+
+    fn batch_ka_agree_dec<'a>(
+        ivk: &Self::IncomingViewingKey,
+        epks: impl Iterator<Item = Option<&'a Self::PreparedEphemeralPublicKey>>,
+    ) -> Vec<Option<Self::SharedSecret>>
+    where
+        Self::PreparedEphemeralPublicKey: 'a,
+    {
+        // One GLV decomposition and digit recoding of the viewing key for the
+        // whole batch; each ephemeral key's window is then consumed by a
+        // shared-doubling ladder.
+        let decomposed =
+            pasta_curves::glv::Decomposed::<pasta_curves::pallas::Point>::new(&ivk.raw_scalar());
+        epks.map(|epk| epk.map(|epk| epk.agree_with(ivk, &decomposed)))
+            .collect()
+    }
 }
 
 fn batch_kdf<'a>(
@@ -548,21 +579,24 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     use rand::rngs::OsRng;
     use zcash_note_encryption::{
-        try_compact_note_decryption, try_note_decryption, try_output_recovery_with_ovk, Domain,
-        EphemeralKeyBytes,
+        batch, try_compact_note_decryption, try_note_decryption, try_output_recovery_with_ovk,
+        BatchDomain, Domain, EphemeralKeyBytes, NoteEncryption,
     };
 
     use super::{
-        prf_ock_orchard, CompactAction, IronwoodDomain, IronwoodNoteEncryption, OrchardDomain,
-        OrchardNoteEncryption,
+        prf_ock_orchard, CompactAction, DomainVersion, IronwoodDomain, IronwoodNoteEncryption,
+        IronwoodVersion, NoteEncryptionDomain, OrchardDomain, OrchardNoteEncryption,
+        OrchardVersion,
     };
     use crate::{
         action::Action,
         keys::{
-            DiversifiedTransmissionKey, Diversifier, EphemeralSecretKey, IncomingViewingKey,
-            OutgoingViewingKey, PreparedIncomingViewingKey, Scope, SpendingKey,
+            DiversifiedTransmissionKey, Diversifier, EphemeralSecretKey, FullViewingKey,
+            IncomingViewingKey, OutgoingViewingKey, PreparedIncomingViewingKey, Scope, SpendingKey,
         },
         note::{
             ExtractedNoteCommitment, NoteVersion, Nullifier, RandomSeed, Rho,
@@ -807,5 +841,185 @@ mod tests {
             try_compact_note_decryption(&domain, &ivk, &compact),
             Some((note, recipient))
         );
+    }
+
+    /// Encrypts a compact output of the domain's note plaintext version to
+    /// `recipient`, using a fresh ephemeral key.
+    fn encrypted_compact_action<V: DomainVersion>(
+        rng: &mut OsRng,
+        recipient: Address,
+    ) -> CompactAction {
+        let nf_old = Nullifier::dummy(rng);
+        let rho = Rho::from_nf_old(nf_old);
+        let note = Note::new(
+            recipient,
+            NoteValue::from_raw(42),
+            rho,
+            V::NOTE_VERSION,
+            rng,
+        );
+        let encryptor = NoteEncryption::<NoteEncryptionDomain<V>>::new(None, note, [0u8; 512]);
+        let ephemeral_key = NoteEncryptionDomain::<V>::epk_bytes(encryptor.epk());
+        let enc_ciphertext = encryptor.encrypt_note_plaintext();
+        CompactAction::from_parts(
+            nf_old,
+            ExtractedNoteCommitment::from(note.commitment()),
+            ephemeral_key,
+            enc_ciphertext.as_ref()[..52].try_into().unwrap(),
+        )
+    }
+
+    /// The batched trial-decryption pipeline (GLV-window preparation and
+    /// per-batch scalar decomposition) must produce exactly the per-item
+    /// results, over hits on multiple viewing keys, misses, and an
+    /// undecodable ephemeral key.
+    fn check_batched_compact_decryption_matches_per_item<V: DomainVersion>() {
+        let mut rng = OsRng;
+
+        // Two accounts with external and internal scope each — the wallet
+        // shape batched trial decryption runs with — plus a foreign account
+        // whose outputs must not decrypt.
+        let our_fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
+        let other_fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
+        let foreign_fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
+        let ivks: Vec<PreparedIncomingViewingKey> = [
+            (&our_fvk, Scope::External),
+            (&our_fvk, Scope::Internal),
+            (&other_fvk, Scope::External),
+            (&other_fvk, Scope::Internal),
+        ]
+        .into_iter()
+        .map(|(fvk, scope)| PreparedIncomingViewingKey::new(&fvk.to_ivk(scope)))
+        .collect();
+
+        let mut actions = vec![
+            encrypted_compact_action::<V>(&mut rng, our_fvk.address_at(0u32, Scope::External)),
+            encrypted_compact_action::<V>(&mut rng, our_fvk.address_at(0u32, Scope::Internal)),
+            encrypted_compact_action::<V>(&mut rng, other_fvk.address_at(0u32, Scope::External)),
+        ];
+        for i in 0..5u32 {
+            actions.push(encrypted_compact_action::<V>(
+                &mut rng,
+                foreign_fvk.address_at(i, Scope::External),
+            ));
+        }
+        // An ephemeral key that decodes to the identity is rejected during
+        // preparation; its lane must pass through as `None`.
+        actions.push(CompactAction::from_parts(
+            Nullifier::dummy(&mut rng),
+            actions[0].cmx(),
+            EphemeralKeyBytes([0u8; 32]),
+            [0u8; 52],
+        ));
+
+        let items: Vec<(NoteEncryptionDomain<V>, CompactAction)> = actions
+            .iter()
+            .map(|a| (NoteEncryptionDomain::<V>::for_compact_action(a), a.clone()))
+            .collect();
+        let batched = batch::try_compact_note_decryption(&ivks, &items);
+
+        let per_item: Vec<Option<((Note, Address), usize)>> = actions
+            .iter()
+            .map(|a| {
+                let domain = NoteEncryptionDomain::<V>::for_compact_action(a);
+                ivks.iter().enumerate().find_map(|(i, ivk)| {
+                    try_compact_note_decryption(&domain, ivk, a).map(|r| (r, i))
+                })
+            })
+            .collect();
+
+        assert_eq!(batched, per_item);
+
+        // The interesting lanes actually decrypted (guards against both
+        // paths failing identically).
+        assert_eq!(batched[0].as_ref().map(|(_, i)| *i), Some(0));
+        assert_eq!(batched[1].as_ref().map(|(_, i)| *i), Some(1));
+        assert_eq!(batched[2].as_ref().map(|(_, i)| *i), Some(2));
+        assert!(batched[3..].iter().all(Option::is_none));
+    }
+
+    #[test]
+    fn batched_compact_decryption_matches_per_item_orchard() {
+        check_batched_compact_decryption_matches_per_item::<OrchardVersion>();
+    }
+
+    #[test]
+    fn batched_compact_decryption_matches_per_item_ironwood() {
+        check_batched_compact_decryption_matches_per_item::<IronwoodVersion>();
+    }
+
+    /// The batched agreement must produce byte-identical shared secrets to
+    /// the per-item path, for both preparation routes (batch-built GLV
+    /// windows and individually-built wNAF tables), on hit and miss lanes
+    /// alike.
+    #[test]
+    fn batched_agreement_matches_per_item() {
+        let mut rng = OsRng;
+
+        let our_fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
+        let foreign_fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
+        let ivks: Vec<PreparedIncomingViewingKey> = [
+            (&our_fvk, Scope::External),
+            (&our_fvk, Scope::Internal),
+            (&foreign_fvk, Scope::External),
+        ]
+        .into_iter()
+        .map(|(fvk, scope)| PreparedIncomingViewingKey::new(&fvk.to_ivk(scope)))
+        .collect();
+
+        // Real ephemeral keys from real encryptions, plus an undecodable lane.
+        let mut keys: Vec<EphemeralKeyBytes> = (0..12u32)
+            .map(|i| {
+                encrypted_compact_action::<OrchardVersion>(
+                    &mut rng,
+                    our_fvk.address_at(i, Scope::External),
+                )
+                .ephemeral_key
+            })
+            .collect();
+        keys.push(EphemeralKeyBytes([0u8; 32]));
+
+        let batch_prepared = <OrchardDomain as BatchDomain>::batch_epk(keys.iter().cloned());
+        // The undecodable lane passes through preparation as `None`.
+        assert!(batch_prepared.last().unwrap().0.is_none());
+        assert!(batch_prepared[..12].iter().all(|(p, _)| p.is_some()));
+
+        let wnaf_prepared: Vec<Option<crate::keys::PreparedEphemeralPublicKey>> = keys
+            .iter()
+            .map(|key| OrchardDomain::epk(key).map(OrchardDomain::prepare_epk))
+            .collect();
+
+        for ivk in &ivks {
+            let expected: Vec<Option<[u8; 32]>> = keys
+                .iter()
+                .map(|key| {
+                    OrchardDomain::epk(key)
+                        .map(OrchardDomain::prepare_epk)
+                        .map(|epk| OrchardDomain::ka_agree_dec(ivk, &epk).to_bytes())
+                })
+                .collect();
+
+            let batched: Vec<Option<[u8; 32]>> =
+                <OrchardDomain as BatchDomain>::batch_ka_agree_dec(
+                    ivk,
+                    batch_prepared.iter().map(|(p, _)| p.as_ref()),
+                )
+                .into_iter()
+                .map(|s| s.map(|s| s.to_bytes()))
+                .collect();
+            assert_eq!(batched, expected);
+
+            // The batched agreement's fallback arm (individually-prepared
+            // inputs) must also match.
+            let batched_wnaf: Vec<Option<[u8; 32]>> =
+                <OrchardDomain as BatchDomain>::batch_ka_agree_dec(
+                    ivk,
+                    wnaf_prepared.iter().map(|p| p.as_ref()),
+                )
+                .into_iter()
+                .map(|s| s.map(|s| s.to_bytes()))
+                .collect();
+            assert_eq!(batched_wnaf, expected);
+        }
     }
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -48,6 +48,18 @@ impl NonIdentityPallasPoint {
         pallas::Point::from_bytes(bytes)
             .and_then(|p| CtOption::new(NonIdentityPallasPoint(p), !p.is_identity()))
     }
+
+    /// Constructs a wrapper for a point that is guaranteed to be non-identity
+    /// (such as the product of a non-zero scalar and a non-identity point in
+    /// the prime-order Pallas group).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `p.is_identity()`.
+    pub(crate) fn expect_non_identity(p: pallas::Point) -> Self {
+        assert!(!bool::from(p.is_identity()));
+        NonIdentityPallasPoint(p)
+    }
 }
 
 impl Deref for NonIdentityPallasPoint {
@@ -160,7 +172,12 @@ impl PreparedNonIdentityBase {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct PreparedNonZeroScalar(WnafScalar<pallas::Scalar, PREPARED_WINDOW_SIZE>);
+pub(crate) struct PreparedNonZeroScalar(
+    WnafScalar<pallas::Scalar, PREPARED_WINDOW_SIZE>,
+    // The scalar itself, retained for the GLV ladder in `pasta_curves::glv`, which
+    // decomposes the scalar rather than consuming the wNAF form.
+    pallas::Scalar,
+);
 
 #[cfg(feature = "std")]
 impl DynamicUsage for PreparedNonZeroScalar {
@@ -175,7 +192,12 @@ impl DynamicUsage for PreparedNonZeroScalar {
 
 impl PreparedNonZeroScalar {
     pub(crate) fn new(scalar: &NonZeroPallasScalar) -> Self {
-        PreparedNonZeroScalar(WnafScalar::new(scalar))
+        PreparedNonZeroScalar(WnafScalar::new(scalar), **scalar)
+    }
+
+    /// The raw scalar, for the GLV ladder in `pasta_curves::glv`.
+    pub(crate) fn raw_scalar(&self) -> pallas::Scalar {
+        self.1
     }
 }
 


### PR DESCRIPTION
Supersedes #530: rebased onto `main` (0.15.3) and reworked to consume the GLV primitive from zcash/pasta_curves#93 (`pasta_curves::glv`) instead of a self-contained inline `endo` module. Same feature and the same byte-exact results — cleaner layering, with GLV living in `pasta_curves` and orchard as a thin consumer.

## What changes

The GLV primitive — batched odd-multiples windows built with a single shared inversion, per-scalar decomposition + wNAF recoding, and the shared-doubling Straus ladder — now lives in `pasta_curves::glv` (`Table` / `Decomposed` / `Table::mul_decomposed`). orchard consumes it in the batched pipeline:

- `PreparedEphemeralPublicKey::batch_tabled` builds every ephemeral key's window via `Table::batch` (one shared normalization across the whole batch).
- `batch_ka_agree_dec` decomposes each viewing key once via `Decomposed::new` and reuses it against every ephemeral key's window, through the `BatchDomain::batch_ka_agree_dec` hook added in `zcash_note_encryption` 0.4.2.

The per-output entry points (`try_note_decryption` etc.) are untouched. There are no public API changes; `src/endo.rs` is removed (its GLV moved to `pasta_curves`).

## Correctness

Shared secrets are byte-identical to the per-item path. `note_encryption`'s `batched_agreement_matches_per_item` and `batched_compact_decryption_matches_per_item_{orchard,ironwood}` pin this for both `OrchardDomain` and `IronwoodDomain` over hit / miss / undecodable lanes; the full existing suite passes. The GLV KATs and proptests now live in `pasta_curves::glv`.

## Stack

- **pasta_curves 0.5.2** (the `glv` module) 
- **zcash_note_encryption 0.4.2** — `batch_ka_agree_dec`

Original work by @LukasKorba (#530).

---
Filed with [Claude Code](https://claude.com/claude-code) assistance.