### PR TITLE
Release orchard v0.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.15.3] - 2026-07-22
+
+### Changed
+- The `verifier-fingerprint` fixture export now derives each Lean instance
+  commitment from the verifier's public inputs instead of exporting it as an
+  opaque verifying-key field (requires `halo2_proofs 0.3.4`).
+
 ## [0.15.2] - 2026-07-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,7 +1432,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchard"
-version = "0.15.2"
+version = "0.15.3"
 authors = [
     "Sean Bowe <ewillbefull@gmail.com>",
     "Jack Grigg <thestr4d@gmail.com>",


### PR DESCRIPTION
Patch release: the `verifier-fingerprint` fixture export now derives each Lean instance commitment from the verifier's public inputs (via `halo2_proofs 0.3.4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)