### PR TITLE
Pass the consumed proof bytes to the fingerprint fixture exporters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ jobs:
       # type-check it.
       - name: Compile-check the verifier-fingerprint capture module
         run: cargo test --features verifier-fingerprint --no-run --verbose
+      # Every random-capture variant calls the same proof-byte decoder checks. Run the
+      # representative single-action path on Linux so these assertions execute in CI, while the
+      # compile check above continues to cover the full module on every supported host.
+      - name: Run verifier-fingerprint proof-byte regressions
+        if: matrix.os == 'ubuntu-latest'
+        run: >-
+          cargo test --features verifier-fingerprint
+          circuit::fingerprint::fingerprint_capture_random -- --exact
       - name: Verify working directory is clean
         run: git diff --exit-code
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to Rust's notion of
 
 ### Changed
 - The `verifier-fingerprint` capture drivers now hand the proof byte string the
-  verifier consumed to halo2's `dump_vesta_lean_fixture_with_proof_bytes` /
+  verifier consumed to halo2's `dump_vesta_lean_fixture_honest_with_proof_bytes` /
   `dump_vesta_lean_fixture_match_only_with_proof_bytes`, so every exported
   fixture carries it hex-encoded as `capturedProofHex` after the exporter's
   re-serialization check. Requires a `halo2_proofs` release providing those

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to Rust's notion of
   verifier consumed to halo2's `dump_vesta_lean_fixture_honest_with_proof_bytes` /
   `dump_vesta_lean_fixture_match_only_with_proof_bytes`, so every exported
   fixture carries it hex-encoded as `capturedProofHex` after the exporter's
-  re-serialization check. The dependency is temporarily pinned to
+  re-serialization check. The random capture drivers also exercise malformed
+  point and scalar encodings against the deployed reader on those exact bytes.
+  The dependency is temporarily pinned to
   `zcash/halo2#933` until a `halo2_proofs` release provides those exporters.
 
 ## [0.15.5] - 2026-08-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- The `verifier-fingerprint` capture drivers now hand the proof byte string the
+  verifier consumed to halo2's `dump_vesta_lean_fixture_with_proof_bytes` /
+  `dump_vesta_lean_fixture_match_only_with_proof_bytes`, so every exported
+  fixture carries it hex-encoded as `capturedProofHex` after the exporter's
+  re-serialization check. Requires a `halo2_proofs` release providing those
+  exporters.
+
 ## [0.15.5] - 2026-08-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to Rust's notion of
   verifier consumed to halo2's `dump_vesta_lean_fixture_honest_with_proof_bytes` /
   `dump_vesta_lean_fixture_match_only_with_proof_bytes`, so every exported
   fixture carries it hex-encoded as `capturedProofHex` after the exporter's
-  re-serialization check. Requires a `halo2_proofs` release providing those
-  exporters.
+  re-serialization check. The dependency is temporarily pinned to
+  `zcash/halo2#933` until a `halo2_proofs` release provides those exporters.
 
 ## [0.15.5] - 2026-08-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,8 +993,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5aca1c66059a919227dec97444a11a4350d2f9c820ca48690988f0aa0e81cbf"
+source = "git+https://github.com/TalDerei/halo2.git?rev=d9a8c7374192d299d11366ed159bc1b3d1a38902#d9a8c7374192d299d11366ed159bc1b3d1a38902"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,7 +993,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.3.5"
-source = "git+https://github.com/TalDerei/halo2.git?rev=74a5c1fab777a59ab16bcce8cf42714212a6ecac#74a5c1fab777a59ab16bcce8cf42714212a6ecac"
+source = "git+https://github.com/zcash/halo2.git?rev=fbc2dc537c97f70881021b79a686bc6477eca394#fbc2dc537c97f70881021b79a686bc6477eca394"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,7 +993,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.3.5"
-source = "git+https://github.com/TalDerei/halo2.git?rev=d9a8c7374192d299d11366ed159bc1b3d1a38902#d9a8c7374192d299d11366ed159bc1b3d1a38902"
+source = "git+https://github.com/TalDerei/halo2.git?rev=74a5c1fab777a59ab16bcce8cf42714212a6ecac#74a5c1fab777a59ab16bcce8cf42714212a6ecac"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,4 +115,4 @@ debug = true
 
 # Temporary until a halo2_proofs release includes zcash/halo2#933.
 [patch.crates-io]
-halo2_proofs = { git = "https://github.com/TalDerei/halo2.git", rev = "74a5c1fab777a59ab16bcce8cf42714212a6ecac" }
+halo2_proofs = { git = "https://github.com/zcash/halo2.git", rev = "fbc2dc537c97f70881021b79a686bc6477eca394" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,4 +115,4 @@ debug = true
 
 # Temporary until a halo2_proofs release includes zcash/halo2#933.
 [patch.crates-io]
-halo2_proofs = { git = "https://github.com/TalDerei/halo2.git", rev = "d9a8c7374192d299d11366ed159bc1b3d1a38902" }
+halo2_proofs = { git = "https://github.com/TalDerei/halo2.git", rev = "74a5c1fab777a59ab16bcce8cf42714212a6ecac" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,3 +112,7 @@ debug = true
 
 [profile.bench]
 debug = true
+
+# Temporary until a halo2_proofs release includes zcash/halo2#933.
+[patch.crates-io]
+halo2_proofs = { git = "https://github.com/TalDerei/halo2.git", rev = "d9a8c7374192d299d11366ed159bc1b3d1a38902" }

--- a/src/circuit/fingerprint/mod.rs
+++ b/src/circuit/fingerprint/mod.rs
@@ -139,13 +139,17 @@ fn capture_fixture(seed: u8, num_actions: u8, namespace: &str, output_var: &str)
         transcript.challenges.len(),
     );
 
-    let fixture = vk.vk.dump_vesta_lean_fixture(
+    // The proof bytes the verifier consumed are handed to the exporter, which checks that the
+    // recorded reads re-serialize to exactly them and carries them in the fixture as
+    // `capturedProofHex`, so a consumer can check its proof-string decoder against them.
+    let fixture = vk.vk.dump_vesta_lean_fixture_with_proof_bytes(
         namespace,
         "PostNu6_3",
         K,
         &raw_instance_refs,
         &transcript,
         &msm,
+        &proof.0,
     );
     if let Some(path) = std::env::var_os(output_var) {
         std::fs::write(std::path::PathBuf::from(path), fixture).unwrap();

--- a/src/circuit/fingerprint/mod.rs
+++ b/src/circuit/fingerprint/mod.rs
@@ -142,7 +142,7 @@ fn capture_fixture(seed: u8, num_actions: u8, namespace: &str, output_var: &str)
     // The proof bytes the verifier consumed are handed to the exporter, which checks that the
     // recorded reads re-serialize to exactly them and carries them in the fixture as
     // `capturedProofHex`, so a consumer can check its proof-string decoder against them.
-    let fixture = vk.vk.dump_vesta_lean_fixture_with_proof_bytes(
+    let fixture = vk.vk.dump_vesta_lean_fixture_honest_with_proof_bytes(
         namespace,
         "PostNu6_3",
         K,

--- a/src/circuit/fingerprint/random.rs
+++ b/src/circuit/fingerprint/random.rs
@@ -239,13 +239,16 @@ pub(super) fn capture_random_fixture(
         proof_bytes.len(),
     );
 
-    let fixture = vk.vk.dump_vesta_lean_fixture_match_only(
+    // The fabricated proof bytes — exactly what the replay consumed — go to the exporter, which
+    // checks that the replay's reads re-serialize to them and carries them as `capturedProofHex`.
+    let fixture = vk.vk.dump_vesta_lean_fixture_match_only_with_proof_bytes(
         namespace,
         "PostNu6_3",
         K,
         &raw_instance_refs,
         &replay,
         &msm,
+        &proof_bytes,
     );
     if let Some(path) = std::env::var_os(fixture_output_var) {
         std::fs::write(std::path::PathBuf::from(path), fixture).unwrap();

--- a/src/circuit/fingerprint/random.rs
+++ b/src/circuit/fingerprint/random.rs
@@ -31,6 +31,9 @@
 //!   is straight-line in proof values post-decode; the only panics on it are challenge-degenerate
 //!   inversions, so a panic here is a model-breaking discovery, not noise.
 //! * Replay challenges and transcript events equal their fabrication counterparts.
+//! * On the exact replayed proof string, the deployed `Blake2bRead` rejects truncation,
+//!   non-canonical scalars, identity points, out-of-range coordinates, and non-residue
+//!   coordinates, while a flipped point-sign bit decodes to the negated point.
 //! * The captured MSM does **not** evaluate to the identity (a random proof string accepting
 //!   would be its own discovery), asserted on both passes; the match-only exporter re-asserts it.
 //! * The pinned verifying-key description and all of the honest exporter's structural guards
@@ -44,13 +47,14 @@
 use alloc::vec::Vec;
 use std::io;
 
-use ff::Field;
-use group::{Curve, Group};
+use ff::{Field, PrimeField};
+use group::{Curve, Group, GroupEncoding};
 use halo2_proofs::plonk::fingerprint::{
     capture_proof_fingerprint, ChallengeRecorder, TranscriptEvent,
 };
 use halo2_proofs::transcript::{
-    Blake2bWrite, Challenge255, EncodedChallenge, Transcript, TranscriptRead, TranscriptWrite,
+    Blake2bRead, Blake2bWrite, Challenge255, EncodedChallenge, Transcript, TranscriptRead,
+    TranscriptWrite,
 };
 use pasta_curves::vesta;
 use rand_chacha::ChaCha20Rng;
@@ -61,6 +65,12 @@ use super::{assert_pinned_verifying_key, fixture_rng, raw_instance_refs};
 /// Public-instance rows per action for the pinned Post-NU6.3 circuit
 /// (`Instance::to_halo2_instance` returns one column of ten rows).
 const INSTANCE_ROWS: usize = 10;
+
+/// Compressed Vesta points and scalar-field elements both occupy 32 bytes in Halo2 proofs.
+const ENCODED_ELEMENT_BYTES: usize = 32;
+
+/// The high bit of the last byte selects the compressed point's `y` sign.
+const COMPRESSED_POINT_SIGN_MASK: u8 = 0x80;
 
 /// A transcript-read fabricator: samples a fresh random canonical value at each proof read,
 /// absorbs and buffers it through an inner `Blake2bWrite`, and records the event stream and
@@ -174,6 +184,144 @@ fn assert_transcript_events_eq(
     }
 }
 
+/// Return the canonical field modulus in the same little-endian byte order as `PrimeField::Repr`.
+/// It is derived from the canonical representation of `-1`, rather than duplicating Pasta's
+/// modulus as a byte literal in this test.
+fn field_modulus_bytes<F: PrimeField>() -> Vec<u8> {
+    let mut modulus = (-F::ONE).to_repr().as_ref().to_vec();
+    let mut carry = 1u16;
+    for byte in &mut modulus {
+        let sum = u16::from(*byte) + carry;
+        *byte = sum as u8;
+        carry = sum >> 8;
+        if carry == 0 {
+            break;
+        }
+    }
+    assert_eq!(carry, 0, "field modulus must fit in its representation");
+    modulus
+}
+
+/// Add equal-length little-endian integers, asserting that the sum fits in the same width.
+fn add_le_bytes(lhs: &[u8], rhs: &[u8]) -> Vec<u8> {
+    assert_eq!(lhs.len(), rhs.len());
+    let mut sum = Vec::with_capacity(lhs.len());
+    let mut carry = 0u16;
+    for (&lhs_byte, &rhs_byte) in lhs.iter().zip(rhs) {
+        let limb = u16::from(lhs_byte) + u16::from(rhs_byte) + carry;
+        sum.push(limb as u8);
+        carry = limb >> 8;
+    }
+    assert_eq!(carry, 0, "little-endian sum must fit in its encoding");
+    sum
+}
+
+fn deployed_read_first_point(proof_bytes: &[u8]) -> io::Result<vesta::Affine> {
+    let mut transcript =
+        Blake2bRead::<_, vesta::Affine, Challenge255<vesta::Affine>>::init(proof_bytes);
+    transcript.read_point()
+}
+
+fn deployed_read_scalar(encoded_scalar: &[u8]) -> io::Result<vesta::Scalar> {
+    let mut transcript =
+        Blake2bRead::<_, vesta::Affine, Challenge255<vesta::Affine>>::init(encoded_scalar);
+    transcript.read_scalar()
+}
+
+/// Exercise the byte-decoding cases mirrored by Ironwood on the exact random proof string that
+/// this driver exports. The successful replay above supplies the typed values at both edited
+/// locations, which binds the offsets and mutations to the verifier's actual read schedule.
+fn assert_deployed_decoder_cases(
+    proof_bytes: &[u8],
+    first_point: vesta::Affine,
+    final_scalar: vesta::Scalar,
+) {
+    assert!(proof_bytes.len() >= 2 * ENCODED_ELEMENT_BYTES);
+
+    let encoded_first_point = first_point.to_bytes();
+    assert_eq!(
+        &proof_bytes[..ENCODED_ELEMENT_BYTES],
+        encoded_first_point.as_ref(),
+        "the proof string must begin with the replay's first point"
+    );
+    assert_eq!(
+        deployed_read_first_point(proof_bytes).unwrap(),
+        first_point,
+        "the deployed reader must recover the replay's first point"
+    );
+
+    let final_scalar_offset = proof_bytes.len() - ENCODED_ELEMENT_BYTES;
+    let encoded_final_scalar = final_scalar.to_repr();
+    assert_eq!(
+        &proof_bytes[final_scalar_offset..],
+        encoded_final_scalar.as_ref(),
+        "the proof string must end with the replay's final scalar"
+    );
+    assert_eq!(
+        deployed_read_scalar(&proof_bytes[final_scalar_offset..]).unwrap(),
+        final_scalar,
+        "the deployed reader must recover the replay's final scalar"
+    );
+
+    let mut truncated = proof_bytes.to_vec();
+    truncated.pop().unwrap();
+    assert!(
+        deployed_read_scalar(&truncated[final_scalar_offset..]).is_err(),
+        "the deployed reader must reject a truncated final scalar"
+    );
+
+    // Re-encode the final scalar as the same integer plus the scalar-field modulus. The value is
+    // congruent modulo the field but its proof encoding is non-canonical.
+    let scalar_modulus = field_modulus_bytes::<vesta::Scalar>();
+    assert_eq!(scalar_modulus.len(), ENCODED_ELEMENT_BYTES);
+    let non_canonical_scalar = add_le_bytes(encoded_final_scalar.as_ref(), &scalar_modulus);
+    let mut non_canonical = proof_bytes.to_vec();
+    non_canonical[final_scalar_offset..].copy_from_slice(&non_canonical_scalar);
+    assert!(
+        deployed_read_scalar(&non_canonical[final_scalar_offset..]).is_err(),
+        "the deployed reader must reject a scalar encoded as value + modulus"
+    );
+
+    let mut identity = proof_bytes.to_vec();
+    identity[..ENCODED_ELEMENT_BYTES].fill(0);
+    assert!(
+        deployed_read_first_point(&identity).is_err(),
+        "the deployed transcript must reject the identity point"
+    );
+
+    // Vesta's base field is the Pallas scalar field. Its modulus is just outside the canonical
+    // coordinate range, so this is not a valid compressed point encoding.
+    let base_modulus = field_modulus_bytes::<vesta::Base>();
+    assert_eq!(base_modulus.len(), ENCODED_ELEMENT_BYTES);
+    let mut out_of_range = proof_bytes.to_vec();
+    out_of_range[..ENCODED_ELEMENT_BYTES].copy_from_slice(&base_modulus);
+    assert!(
+        deployed_read_first_point(&out_of_range).is_err(),
+        "the deployed reader must reject x equal to the base-field modulus"
+    );
+
+    // With the sign bit clear, x = 2 has curve-equation radicand 2^3 + 5 = 13, a non-residue in
+    // the Vesta base field.
+    let mut non_residue_encoding = [0u8; ENCODED_ELEMENT_BYTES];
+    non_residue_encoding[0] = 2;
+    let mut non_residue = proof_bytes.to_vec();
+    non_residue[..ENCODED_ELEMENT_BYTES].copy_from_slice(&non_residue_encoding);
+    assert!(
+        deployed_read_first_point(&non_residue).is_err(),
+        "the deployed reader must reject a compressed x with no curve point"
+    );
+
+    let mut flipped_sign = proof_bytes.to_vec();
+    flipped_sign[ENCODED_ELEMENT_BYTES - 1] ^= COMPRESSED_POINT_SIGN_MASK;
+    let decoded_flipped = deployed_read_first_point(&flipped_sign)
+        .expect("flipping only the sign bit must remain a canonical point encoding");
+    assert_eq!(
+        decoded_flipped,
+        (-vesta::Point::from(first_point)).to_affine(),
+        "the compressed sign bit must select the negated point"
+    );
+}
+
 /// Shared driver for the random match-only captures: fabricate a random proof string against the
 /// deployed verifier's own read schedule, replay it through the honest capture pipeline, and
 /// export a match-only fixture (see module docs for the assertion inventory).
@@ -231,6 +379,18 @@ pub(super) fn capture_random_fixture(
     assert!(
         !msm.clone().eval(),
         "replayed random capture must not assemble the identity MSM"
+    );
+
+    assert_deployed_decoder_cases(
+        &proof_bytes,
+        *replay
+            .points
+            .first()
+            .expect("the deployed verifier must read at least one proof point"),
+        *replay
+            .scalars
+            .last()
+            .expect("the deployed verifier must read at least one proof scalar"),
     );
 
     std::eprintln!(


### PR DESCRIPTION
Related to https://github.com/zcash/halo2/pull/933 and consumed in https://github.com/zcash/ironwood/pull/215.

This passes those proof bytes from Orchard’s capture drivers into the new halo2 exporters and negative test coverage so there's parity with the coverage Lean claims Orchard has. Still needs to be tagged against https://github.com/zcash/halo2/pull/933. 