### PR TITLE
Add ActionBytes and BundleBytes types which skip curve artihmetic for SerDe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,30 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
-### Changed
-- MSRV is now 1.88
+### Added
+- A parse tier holding an Action description with `cv_net`, `rk` and `epk` left
+  compressed, so reading actions from the wire or from disk costs no curve
+  arithmetic:
+  - `ActionBytes` and `BundleBytes`, mirroring `Action` and `Bundle`, with
+    `ActionBytes::{to_bytes, from_bytes}` and `ACTION_DESCRIPTION_SIZE`.
+  - `decompress` on both, recovering the point tier, plus `ActionParseError`,
+    `DecompressionError` and `bundle::BundleDecompressionError`.
+  - `value::ValueCommitmentBytes` and
+    `primitives::redpallas::VerificationKeyBytes`, the compressed forms it holds,
+    plus `primitives::InvalidPoint`, their leaf `decompress` error.
+  - `Action::compress` and `Bundle::compress`, dropping to the encoded tier.
+    Infallible: neither can hold a point that fails to encode.
+
+`decompress` is the only way from a compressed type to its recovered one, and the
+wire (`from_bytes`) and `compress` are the only ways into the encoded tier.
+  - `ActionBytes` implements `ShieldedOutput` and converts into `CompactAction`,
+    and `OrchardDomain::for_action_bytes` builds its trial-decryption domain, so a
+    wallet scans — including via `zcash_note_encryption::batch` — without
+    decompressing. Ovk recovery still needs a `ValueCommitment`, so it is unchanged.
+
+`Action` and `Bundle` are unchanged. `ActionBytes::decompress` delegates to
+`Action::from_parts`, so the identity-`rk` and `epk` rules keep one
+implementation and no consensus rule moves.
 
 ## [0.15.5] - 2026-08-02
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -12,6 +12,9 @@ use crate::{
     value::ValueCommitment,
 };
 
+mod bytes;
+pub use bytes::{ActionBytes, ActionParseError, DecompressionError, ACTION_DESCRIPTION_SIZE};
+
 /// An action applied to the global ledger.
 ///
 /// This both creates a note (adding a commitment to the global ledger), and consumes

--- a/src/action/bytes.rs
+++ b/src/action/bytes.rs
@@ -1,0 +1,488 @@
+use core::{fmt, ops::Range};
+
+use memuse::DynamicUsage;
+
+use crate::{
+    note::{ExtractedNoteCommitment, Nullifier, Rho, TransmittedNoteCiphertext},
+    primitives::redpallas::{self, SpendAuth},
+    value::ValueCommitmentBytes,
+};
+
+use super::{Action, ActionFromPartsError};
+
+/// Byte length of an Action description, per [Action Encoding and Consensus][actionenc].
+///
+/// [actionenc]: https://zips.z.cash/protocol/protocol.pdf#actionencodingandconsensus
+pub const ACTION_DESCRIPTION_SIZE: usize = 820;
+
+// Field offsets within an Action description. Ordering is consensus-critical.
+const CV_NET: Range<usize> = 0..32;
+const NULLIFIER: Range<usize> = 32..64;
+const RK: Range<usize> = 64..96;
+const CMX: Range<usize> = 96..128;
+const EPK: Range<usize> = 128..160;
+const ENC_CIPHERTEXT: Range<usize> = 160..740;
+const OUT_CIPHERTEXT: Range<usize> = 740..ACTION_DESCRIPTION_SIZE;
+
+/// An [`Action`] with `cv_net`, `rk` and `epk` left compressed.
+///
+/// Building, encoding, hashing and trial-decrypting one costs no curve arithmetic.
+/// [`Self::decompress`] is the only way from here to an [`Action`].
+#[derive(Clone, Debug)]
+pub struct ActionBytes<A> {
+    nf: Nullifier,
+    rk: redpallas::VerificationKeyBytes<SpendAuth>,
+    cmx: ExtractedNoteCommitment,
+    encrypted_note: TransmittedNoteCiphertext,
+    cv_net: ValueCommitmentBytes,
+    authorization: A,
+}
+
+impl<A> ActionBytes<A> {
+    /// Returns the nullifier of the note being spent.
+    pub fn nullifier(&self) -> &Nullifier {
+        &self.nf
+    }
+
+    /// Returns the encoded randomized verification key for the note being spent.
+    pub fn rk(&self) -> &redpallas::VerificationKeyBytes<SpendAuth> {
+        &self.rk
+    }
+
+    /// Returns the commitment to the new note being created.
+    pub fn cmx(&self) -> &ExtractedNoteCommitment {
+        &self.cmx
+    }
+
+    /// Returns the encrypted note ciphertext.
+    pub fn encrypted_note(&self) -> &TransmittedNoteCiphertext {
+        &self.encrypted_note
+    }
+
+    /// Obtains the [`Rho`] value that was used to construct the new note being created.
+    pub fn rho(&self) -> Rho {
+        Rho::from_nf_old(self.nf)
+    }
+
+    /// Returns the encoded commitment to the net value created or consumed by this action.
+    pub fn cv_net(&self) -> &ValueCommitmentBytes {
+        &self.cv_net
+    }
+
+    /// Returns the authorization for this action.
+    pub fn authorization(&self) -> &A {
+        &self.authorization
+    }
+
+    /// Attaches the authorization a transaction carries outside the Action description.
+    pub fn with_authorization<U>(self, authorization: U) -> ActionBytes<U> {
+        ActionBytes {
+            nf: self.nf,
+            rk: self.rk,
+            cmx: self.cmx,
+            encrypted_note: self.encrypted_note,
+            cv_net: self.cv_net,
+            authorization,
+        }
+    }
+
+    /// Recovers the [`Action`]. 3 sqrt.
+    ///
+    /// # Errors
+    ///
+    /// First point rule this action breaks. The identity-`rk` and `epk` rules are
+    /// [`Action::from_parts`]'s, so they keep exactly one implementation.
+    pub fn decompress(self) -> Result<Action<A>, DecompressionError> {
+        let cv_net = self
+            .cv_net
+            .decompress()
+            .map_err(|_| DecompressionError::NonCanonicalValueCommitment)?;
+        let rk = self
+            .rk
+            .decompress()
+            .map_err(|_| DecompressionError::NonCanonicalRandomizedKey)?;
+
+        Ok(Action::from_parts(
+            self.nf,
+            rk,
+            self.cmx,
+            self.encrypted_note,
+            cv_net,
+            self.authorization,
+        )?)
+    }
+
+    /// Encodes this Action description.
+    ///
+    /// `A` is not written: the transaction format carries every action's signature in a
+    /// separate array.
+    pub fn to_bytes(&self) -> [u8; ACTION_DESCRIPTION_SIZE] {
+        let mut bytes = [0u8; ACTION_DESCRIPTION_SIZE];
+
+        bytes[CV_NET].copy_from_slice(&self.cv_net.to_bytes());
+        bytes[NULLIFIER].copy_from_slice(&self.nf.to_bytes());
+        bytes[RK].copy_from_slice(&self.rk.to_bytes());
+        bytes[CMX].copy_from_slice(&self.cmx.to_bytes());
+        bytes[EPK].copy_from_slice(&self.encrypted_note.epk_bytes);
+        bytes[ENC_CIPHERTEXT].copy_from_slice(&self.encrypted_note.enc_ciphertext);
+        bytes[OUT_CIPHERTEXT].copy_from_slice(&self.encrypted_note.out_ciphertext);
+
+        bytes
+    }
+}
+
+impl ActionBytes<()> {
+    /// Decodes an Action description, checking the `nullifier` and `cmx` encodings.
+    ///
+    /// Unauthorized: the transaction carries every action's signature in a separate array, so
+    /// the caller pairs one back on with [`ActionBytes::with_authorization`].
+    ///
+    /// # Errors
+    ///
+    /// First field that is not a canonical field-element encoding.
+    pub fn from_bytes(bytes: &[u8; ACTION_DESCRIPTION_SIZE]) -> Result<Self, ActionParseError> {
+        let field = |range: Range<usize>| -> [u8; 32] {
+            bytes[range]
+                .try_into()
+                .expect("every field range above is 32 bytes")
+        };
+
+        let nf = Option::from(Nullifier::from_bytes(&field(NULLIFIER)))
+            .ok_or(ActionParseError::NonCanonicalNullifier)?;
+        let cmx = Option::from(ExtractedNoteCommitment::from_bytes(&field(CMX)))
+            .ok_or(ActionParseError::NonCanonicalExtractedNoteCommitment)?;
+
+        Ok(ActionBytes {
+            nf,
+            rk: redpallas::VerificationKeyBytes::from(field(RK)),
+            cmx,
+            encrypted_note: TransmittedNoteCiphertext {
+                epk_bytes: field(EPK),
+                enc_ciphertext: bytes[ENC_CIPHERTEXT]
+                    .try_into()
+                    .expect("the enc_ciphertext range is 580 bytes"),
+                out_ciphertext: bytes[OUT_CIPHERTEXT]
+                    .try_into()
+                    .expect("the out_ciphertext range is 80 bytes"),
+            },
+            cv_net: ValueCommitmentBytes::from(field(CV_NET)),
+            authorization: (),
+        })
+    }
+}
+
+impl<A> Action<A> {
+    /// Drops to the encoded tier.
+    ///
+    /// Infallible: an [`Action`] cannot hold a point that fails to encode.
+    pub fn compress(self) -> ActionBytes<A> {
+        ActionBytes {
+            nf: self.nf,
+            rk: redpallas::VerificationKeyBytes::from(&self.rk),
+            cmx: self.cmx,
+            encrypted_note: self.encrypted_note,
+            cv_net: ValueCommitmentBytes::from(&self.cv_net),
+            authorization: self.authorization,
+        }
+    }
+}
+
+// Slots into `zcash_client_backend`'s full-ciphertext batch scanner, which bounds its queue by
+// `Output: DynamicUsage` and adds that to `size_of_val`. Every field here is fixed-size, so the
+// whole 888 bytes are already covered by `size_of` and nothing is on the heap.
+memuse::impl_no_dynamic_usage!(ActionBytes<redpallas::Signature<SpendAuth>>);
+
+/// An Action description field that is not a valid encoding of its type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ActionParseError {
+    /// `nullifier` is not a canonical Pallas base field element encoding.
+    NonCanonicalNullifier,
+    /// `cmx` is not a canonical Pallas base field element encoding.
+    NonCanonicalExtractedNoteCommitment,
+}
+
+impl fmt::Display for ActionParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ActionParseError::NonCanonicalNullifier => {
+                write!(f, "`nullifier` is not a canonical field element encoding")
+            }
+            ActionParseError::NonCanonicalExtractedNoteCommitment => {
+                write!(f, "`cmx` is not a canonical field element encoding")
+            }
+        }
+    }
+}
+
+impl core::error::Error for ActionParseError {}
+
+/// An Action description field carrying a point no valid Action description may carry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DecompressionError {
+    /// `cv_net` is not a canonical point encoding.
+    NonCanonicalValueCommitment,
+    /// `rk` is not a canonical point encoding.
+    NonCanonicalRandomizedKey,
+    /// The recovered points do not make a valid [`Action`].
+    Action(ActionFromPartsError),
+}
+
+impl From<ActionFromPartsError> for DecompressionError {
+    fn from(e: ActionFromPartsError) -> Self {
+        DecompressionError::Action(e)
+    }
+}
+
+impl fmt::Display for DecompressionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DecompressionError::NonCanonicalValueCommitment => {
+                write!(f, "`cv_net` is not a canonical point encoding")
+            }
+            DecompressionError::NonCanonicalRandomizedKey => {
+                write!(f, "`rk` is not a canonical point encoding")
+            }
+            DecompressionError::Action(e) => e.fmt(f),
+        }
+    }
+}
+
+impl core::error::Error for DecompressionError {}
+
+#[cfg(test)]
+mod tests {
+    use group::{
+        ff::{Field as _, PrimeField as _},
+        Group as _, GroupEncoding as _,
+    };
+    use pasta_curves::pallas;
+
+    use super::{
+        ActionBytes, ActionFromPartsError, ActionParseError, DecompressionError,
+        ACTION_DESCRIPTION_SIZE, CMX, CV_NET, ENC_CIPHERTEXT, EPK, NULLIFIER, OUT_CIPHERTEXT, RK,
+    };
+    use alloc::vec::Vec;
+
+    use crate::{
+        note::{ExtractedNoteCommitment, Nullifier},
+        primitives::redpallas::{self, SpendAuth},
+        value::{ValueCommitTrapdoor, ValueCommitment, ValueSum},
+    };
+
+    // Not a canonical encoding of any Pallas point, nor of any Pallas base field element
+    const NON_CANONICAL: [u8; 32] = [0xff; 32];
+    // The identity is the one point the `rk` rule forbids outright
+    const IDENTITY: [u8; 32] = [0u8; 32];
+
+    /// The key for scalar 1 is the SpendAuthSig basepoint, which is not the identity.
+    fn non_identity_rk() -> [u8; 32] {
+        let sk = redpallas::SigningKey::<SpendAuth>::try_from(pallas::Scalar::ONE.to_repr())
+            .expect("1 is a valid scalar");
+        redpallas::VerificationKeyBytes::from(&redpallas::VerificationKey::<SpendAuth>::from(&sk))
+            .to_bytes()
+    }
+
+    fn valid_cv_net() -> [u8; 32] {
+        ValueCommitment::derive(ValueSum::from_raw(42), ValueCommitTrapdoor::zero()).to_bytes()
+    }
+
+    /// Every field but the ones named is valid, so only the field under test is ever at fault.
+    fn action(rk: [u8; 32], cv_net: [u8; 32], epk_bytes: [u8; 32]) -> ActionBytes<()> {
+        let mut bytes = [0u8; ACTION_DESCRIPTION_SIZE];
+        bytes[CV_NET].copy_from_slice(&cv_net);
+        bytes[NULLIFIER].fill(1);
+        bytes[RK].copy_from_slice(&rk);
+        bytes[CMX].fill(2);
+        bytes[EPK].copy_from_slice(&epk_bytes);
+        bytes[ENC_CIPHERTEXT].fill(4);
+        bytes[OUT_CIPHERTEXT].fill(5);
+
+        ActionBytes::from_bytes(&bytes).expect("`nf` and `cmx` are canonical")
+    }
+
+    fn valid_action() -> ActionBytes<()> {
+        action(
+            non_identity_rk(),
+            valid_cv_net(),
+            pallas::Point::generator().to_bytes(),
+        )
+    }
+
+    #[test]
+    fn decompress_enforces_the_point_rules() {
+        let generator = pallas::Point::generator().to_bytes();
+
+        assert!(valid_action().decompress().is_ok());
+
+        for (action, expected) in [
+            (
+                action(non_identity_rk(), NON_CANONICAL, generator),
+                DecompressionError::NonCanonicalValueCommitment,
+            ),
+            (
+                action(NON_CANONICAL, valid_cv_net(), generator),
+                DecompressionError::NonCanonicalRandomizedKey,
+            ),
+            (
+                action(IDENTITY, valid_cv_net(), generator),
+                DecompressionError::Action(ActionFromPartsError::IdentityRk),
+            ),
+            // Identity and undecodable are both invalid `epk`s
+            (
+                action(non_identity_rk(), valid_cv_net(), IDENTITY),
+                DecompressionError::Action(ActionFromPartsError::InvalidEpk),
+            ),
+            (
+                action(non_identity_rk(), valid_cv_net(), NON_CANONICAL),
+                DecompressionError::Action(ActionFromPartsError::InvalidEpk),
+            ),
+        ] {
+            assert_eq!(action.decompress().unwrap_err(), expected);
+        }
+    }
+
+    /// Scanning goes through `ShieldedOutput`, so it must succeed on actions whose every point
+    /// is garbage — and batched, which is how a wallet actually scans.
+    #[test]
+    fn scanning_needs_no_decompression() {
+        use rand::rngs::OsRng;
+        use zcash_note_encryption::{batch, Domain as _};
+
+        use crate::{
+            keys::{FullViewingKey, PreparedIncomingViewingKey, Scope, SpendingKey},
+            note::Rho,
+            note_encryption::{OrchardDomain, OrchardNoteEncryption},
+            value::NoteValue,
+            Note, NoteVersion,
+        };
+
+        let mut rng = OsRng;
+        let fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
+        let recipient = fvk.address_at(0u32, Scope::External);
+        let ivk = PreparedIncomingViewingKey::new(&fvk.to_ivk(Scope::External));
+        let memo = [9u8; 512];
+
+        let actions: Vec<ActionBytes<()>> = (0..3u64)
+            .map(|i| {
+                let nf = Nullifier::dummy(&mut rng);
+                let note = Note::new(
+                    recipient,
+                    NoteValue::from_raw(i + 1),
+                    Rho::from_nf_old(nf),
+                    NoteVersion::V2,
+                    &mut rng,
+                );
+                let cmx = ExtractedNoteCommitment::from(note.commitment());
+                let encryptor = OrchardNoteEncryption::new(None, note, memo);
+                let out_ciphertext = encryptor.encrypt_outgoing_plaintext(
+                    &ValueCommitment::derive(ValueSum::from_raw(1), ValueCommitTrapdoor::zero()),
+                    &cmx,
+                    &mut rng,
+                );
+
+                // Both points undecodable
+                let mut bytes = [0u8; ACTION_DESCRIPTION_SIZE];
+                bytes[CV_NET].copy_from_slice(&NON_CANONICAL);
+                bytes[NULLIFIER].copy_from_slice(&nf.to_bytes());
+                bytes[RK].copy_from_slice(&NON_CANONICAL);
+                bytes[CMX].copy_from_slice(&cmx.to_bytes());
+                bytes[EPK].copy_from_slice(&OrchardDomain::epk_bytes(encryptor.epk()).0);
+                bytes[ENC_CIPHERTEXT].copy_from_slice(&encryptor.encrypt_note_plaintext());
+                bytes[OUT_CIPHERTEXT].copy_from_slice(&out_ciphertext);
+
+                ActionBytes::from_bytes(&bytes).expect("`nf` and `cmx` are canonical")
+            })
+            .collect();
+
+        for action in &actions {
+            assert!(action.clone().decompress().is_err());
+        }
+
+        let items: Vec<_> = actions
+            .iter()
+            .map(|a| (OrchardDomain::for_action_bytes(a), a.clone()))
+            .collect();
+
+        for (i, found) in batch::try_note_decryption(&[ivk], &items)
+            .into_iter()
+            .enumerate()
+        {
+            let ((note, _, found_memo), _) = found.expect("every action pays this ivk");
+            assert_eq!(note.value().inner(), i as u64 + 1);
+            assert_eq!(found_memo, memo);
+        }
+    }
+
+    /// Field order is consensus-critical, so pin each offset rather than only round-tripping.
+    #[test]
+    fn to_bytes_matches_the_consensus_field_order() {
+        let action = valid_action();
+        let bytes = action.to_bytes();
+
+        assert_eq!(bytes.len(), ACTION_DESCRIPTION_SIZE);
+        assert_eq!(&bytes[0..32], &action.cv_net().to_bytes());
+        assert_eq!(&bytes[32..64], &action.nullifier().to_bytes());
+        assert_eq!(&bytes[64..96], &action.rk().to_bytes());
+        assert_eq!(&bytes[96..128], &action.cmx().to_bytes());
+        assert_eq!(&bytes[128..160], &action.encrypted_note().epk_bytes);
+        assert_eq!(&bytes[160..740], &action.encrypted_note().enc_ciphertext);
+        assert_eq!(&bytes[740..820], &action.encrypted_note().out_ciphertext);
+    }
+
+    /// The wire and the point tier are the only two ways in, and they must agree.
+    #[test]
+    fn round_trips_through_the_encoding_and_the_point_tier() {
+        let bytes = valid_action().to_bytes();
+
+        assert_eq!(
+            ActionBytes::from_bytes(&bytes)
+                .expect("a written description reads back")
+                .to_bytes(),
+            bytes,
+        );
+
+        let action = valid_action().decompress().expect("every field is valid");
+        assert_eq!(action.compress().to_bytes(), bytes);
+    }
+
+    /// The point rules are `decompress`'s, not the codec's, so a peer's action is readable
+    /// before any curve arithmetic runs.
+    #[test]
+    fn from_bytes_defers_the_point_rules_to_decompress() {
+        // cv_net, rk, epk
+        for range in [0..32, 64..96, 128..160] {
+            let mut bytes = valid_action().to_bytes();
+            bytes[range].copy_from_slice(&NON_CANONICAL);
+            let decoded = ActionBytes::from_bytes(&bytes).expect("point rules are not the codec's");
+            assert!(decoded.decompress().is_err());
+        }
+    }
+
+    /// The signature array is read after the actions, so a decoded action is paired with its
+    /// signature afterwards and must survive the round trip unchanged.
+    #[test]
+    fn with_authorization_preserves_the_description() {
+        let action = valid_action();
+        let signed = action.clone().with_authorization(7u8);
+
+        assert_eq!(signed.to_bytes(), action.to_bytes());
+        assert_eq!(*signed.authorization(), 7u8);
+    }
+
+    #[test]
+    fn from_bytes_rejects_non_canonical_field_elements() {
+        for (range, expected) in [
+            (32..64, ActionParseError::NonCanonicalNullifier),
+            (
+                96..128,
+                ActionParseError::NonCanonicalExtractedNoteCommitment,
+            ),
+        ] {
+            let mut bytes = valid_action().to_bytes();
+            bytes[range].copy_from_slice(&NON_CANONICAL);
+            assert_eq!(ActionBytes::from_bytes(&bytes).unwrap_err(), expected);
+        }
+    }
+}

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -4,6 +4,9 @@ use alloc::vec::Vec;
 
 pub mod commitments;
 
+mod bytes;
+pub use bytes::{BundleBytes, BundleDecompressionError};
+
 #[cfg(feature = "circuit")]
 mod batch;
 #[cfg(feature = "circuit")]

--- a/src/bundle/bytes.rs
+++ b/src/bundle/bytes.rs
@@ -1,0 +1,330 @@
+use alloc::vec::Vec;
+use core::fmt;
+
+use nonempty::NonEmpty;
+
+use crate::{
+    action::{Action, ActionBytes, DecompressionError},
+    bundle::{
+        validate_flags, validate_proof_size, Authorization, Authorized, Bundle, BundleError,
+        BundleVersion, Flags,
+    },
+    tree::Anchor,
+};
+
+/// A [`Bundle`] whose actions are still encoded.
+///
+/// Upholds every rule a [`Bundle`] does except those needing a point, which
+/// [`Self::decompress`] discharges.
+#[derive(Clone)]
+pub struct BundleBytes<T: Authorization, V> {
+    actions: NonEmpty<ActionBytes<T::SpendAuth>>,
+    flags: Flags,
+    value_balance: V,
+    anchor: Anchor,
+    authorization: T,
+    bundle_version: BundleVersion,
+}
+
+impl<T: Authorization, V: fmt::Debug> fmt::Debug for BundleBytes<T, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        struct Actions<'a, T>(&'a NonEmpty<ActionBytes<T>>);
+        impl<T: fmt::Debug> fmt::Debug for Actions<'_, T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_list().entries(self.0.iter()).finish()
+            }
+        }
+
+        f.debug_struct("BundleBytes")
+            .field("actions", &Actions(&self.actions))
+            .field("flags", &self.flags)
+            .field("value_balance", &self.value_balance)
+            .field("anchor", &self.anchor)
+            .field("authorization", &self.authorization)
+            .field("bundle_version", &self.bundle_version)
+            .finish()
+    }
+}
+
+impl<T: Authorization, V> BundleBytes<T, V> {
+    /// Carries the same obligations as [`Bundle::from_parts_unchecked`].
+    pub(crate) fn from_parts_unchecked(
+        actions: NonEmpty<ActionBytes<T::SpendAuth>>,
+        flags: Flags,
+        value_balance: V,
+        anchor: Anchor,
+        authorization: T,
+        bundle_version: BundleVersion,
+    ) -> Self {
+        debug_assert!(flags.to_byte(bundle_version).is_some());
+        BundleBytes {
+            actions,
+            flags,
+            value_balance,
+            anchor,
+            authorization,
+            bundle_version,
+        }
+    }
+
+    /// Returns the encoded actions that make up this bundle.
+    pub fn actions(&self) -> &NonEmpty<ActionBytes<T::SpendAuth>> {
+        &self.actions
+    }
+
+    /// Returns the Orchard-specific transaction-level flags for this bundle.
+    pub fn flags(&self) -> &Flags {
+        &self.flags
+    }
+
+    /// Returns the net value moved into or out of the Orchard shielded pool.
+    pub fn value_balance(&self) -> &V {
+        &self.value_balance
+    }
+
+    /// Returns the root of the Orchard commitment tree that this bundle commits to.
+    pub fn anchor(&self) -> &Anchor {
+        &self.anchor
+    }
+
+    /// Returns the authorization for this bundle.
+    pub fn authorization(&self) -> &T {
+        &self.authorization
+    }
+
+    /// Returns the [`BundleVersion`] this bundle is encoded under.
+    pub fn bundle_version(&self) -> BundleVersion {
+        self.bundle_version
+    }
+
+    /// Returns this bundle's flag byte, as [`Bundle::flag_byte`] does.
+    pub fn flag_byte(&self) -> u8 {
+        self.flags
+            .to_byte(self.bundle_version)
+            .expect("flags are validated against the bundle version at construction")
+    }
+
+    /// Recovers the [`Bundle`]. 3 sqrt per action.
+    ///
+    /// # Errors
+    ///
+    /// First action that breaks a point rule.
+    pub fn decompress(self) -> Result<Bundle<T, V>, BundleDecompressionError> {
+        let actions = self
+            .actions
+            .into_iter()
+            .enumerate()
+            .map(|(action, a)| {
+                a.decompress()
+                    .map_err(|error| BundleDecompressionError { action, error })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Bundle::from_parts_unchecked(
+            NonEmpty::from_vec(actions).expect("a NonEmpty maps to a NonEmpty"),
+            self.flags,
+            self.value_balance,
+            self.anchor,
+            self.authorization,
+            self.bundle_version,
+        ))
+    }
+}
+
+impl<V> BundleBytes<Authorized, V> {
+    /// Same checks as [`Bundle::try_from_parts`], both decidable without a point.
+    ///
+    /// # Errors
+    ///
+    /// [`BundleError::NonCanonicalProofSize`] or [`BundleError::UnrepresentableFlags`].
+    pub fn try_from_parts(
+        actions: NonEmpty<ActionBytes<<Authorized as Authorization>::SpendAuth>>,
+        flags: Flags,
+        value_balance: V,
+        anchor: Anchor,
+        authorization: Authorized,
+        bundle_version: BundleVersion,
+    ) -> Result<Self, BundleError> {
+        if bundle_version.enforces_canonical_proof_size() {
+            validate_proof_size(authorization.proof(), actions.len())?;
+        }
+        validate_flags(&flags, bundle_version)?;
+        Ok(BundleBytes::from_parts_unchecked(
+            actions,
+            flags,
+            value_balance,
+            anchor,
+            authorization,
+            bundle_version,
+        ))
+    }
+}
+
+impl<T: Authorization, V> Bundle<T, V> {
+    /// Drops to the encoded tier.
+    ///
+    /// Infallible: a [`Bundle`] cannot hold a point that fails to encode.
+    pub fn compress(self) -> BundleBytes<T, V> {
+        BundleBytes {
+            actions: self.actions.map(Action::compress),
+            flags: self.flags,
+            value_balance: self.value_balance,
+            anchor: self.anchor,
+            authorization: self.authorization,
+            bundle_version: self.bundle_version,
+        }
+    }
+}
+
+/// Action at bundle-relative index `action` breaks a point rule.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct BundleDecompressionError {
+    /// Index of the offending action.
+    pub action: usize,
+    /// The rule it breaks.
+    pub error: DecompressionError,
+}
+
+impl fmt::Display for BundleDecompressionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "action {}: {}", self.action, self.error)
+    }
+}
+
+impl core::error::Error for BundleDecompressionError {}
+
+#[cfg(all(test, feature = "circuit"))]
+mod tests {
+    use alloc::vec::Vec;
+
+    use nonempty::NonEmpty;
+
+    use super::BundleBytes;
+    use crate::{
+        action::DecompressionError,
+        bundle::{tests::sample_authorized_bundle, Authorized, Bundle, BundleVersion, Flags},
+        ActionBytes, Proof,
+    };
+
+    // Not a canonical encoding of any Pallas point
+    const NON_CANONICAL: [u8; 32] = [0xff; 32];
+
+    /// `ValueSum` is not `Into<i64>`, which `Bundle`'s commitment APIs require.
+    fn sample(n_actions: usize) -> Bundle<Authorized, i64> {
+        sample_authorized_bundle(n_actions)
+            .try_map_value_balance::<i64, (), _>(|_| Ok(0))
+            .expect("the mapping cannot fail")
+    }
+
+    fn with_cv_net_replaced(
+        bytes: &BundleBytes<Authorized, i64>,
+        index: usize,
+        cv_net: [u8; 32],
+    ) -> BundleBytes<Authorized, i64> {
+        let actions = bytes
+            .actions()
+            .iter()
+            .enumerate()
+            .map(|(i, a)| {
+                let mut encoded = a.to_bytes();
+                if i == index {
+                    encoded[0..32].copy_from_slice(&cv_net);
+                }
+                ActionBytes::from_bytes(&encoded)
+                    .expect("only cv_net changed")
+                    .with_authorization(a.authorization().clone())
+            })
+            .collect::<Vec<_>>();
+
+        BundleBytes::try_from_parts(
+            NonEmpty::from_vec(actions).expect("the bundle is non-empty"),
+            *bytes.flags(),
+            0,
+            *bytes.anchor(),
+            bytes.authorization().clone(),
+            bytes.bundle_version(),
+        )
+        .expect("only cv_net changed")
+    }
+
+    #[test]
+    fn decompress_names_the_offending_action() {
+        let bytes = sample(3).compress();
+        let tampered = with_cv_net_replaced(&bytes, 2, NON_CANONICAL);
+
+        let err = tampered.decompress().unwrap_err();
+        assert_eq!(err.action, 2);
+        assert_eq!(err.error, DecompressionError::NonCanonicalValueCommitment);
+    }
+
+    /// `bundle_version` is interpretive context, so no encoding would catch its loss.
+    #[test]
+    fn bundle_round_trips_through_the_parse_tier() {
+        let bundle = sample(3);
+        let bytes = bundle.clone().compress();
+        let encodings: Vec<_> = bytes.actions().iter().map(ActionBytes::to_bytes).collect();
+
+        assert_eq!(bytes.flags(), bundle.flags());
+        assert_eq!(bytes.value_balance(), bundle.value_balance());
+        assert_eq!(bytes.anchor(), bundle.anchor());
+        assert_eq!(bytes.bundle_version(), bundle.bundle_version());
+
+        let recovered = bytes
+            .decompress()
+            .expect("a built bundle is valid")
+            .compress();
+        assert_eq!(
+            recovered
+                .actions()
+                .iter()
+                .map(ActionBytes::to_bytes)
+                .collect::<Vec<_>>(),
+            encodings,
+        );
+    }
+
+    /// The checked constructor must reject exactly what the point tier rejects, notably a
+    /// padded or truncated proof (GHSA-2x4w-pxqw-58v9) — before any curve arithmetic.
+    #[test]
+    fn try_from_parts_matches_the_point_tier() {
+        let bundle = sample(3);
+        let bytes = bundle.clone().compress();
+        let expected = Proof::expected_proof_size(bundle.actions().len());
+        // Enforces canonical proof size and accepts any cross-address flag value
+        let bundle_version = BundleVersion::ironwood_v3();
+
+        let authorization = |proof_len: usize| {
+            Authorized::from_parts(
+                Proof::new(alloc::vec![0u8; proof_len]),
+                bundle.authorization().binding_signature().clone(),
+            )
+        };
+
+        for (proof_len, flags) in [
+            (expected, *bundle.flags()),
+            (expected + 1, *bundle.flags()),
+            (expected - 1, *bundle.flags()),
+            (expected, Flags::CROSS_ADDRESS_DISABLED),
+        ] {
+            let on_bytes = BundleBytes::try_from_parts(
+                bytes.actions().clone(),
+                flags,
+                0i64,
+                *bytes.anchor(),
+                authorization(proof_len),
+                bundle_version,
+            );
+            let on_points = Bundle::try_from_parts(
+                bundle.actions().clone(),
+                flags,
+                0i64,
+                *bundle.anchor(),
+                authorization(proof_len),
+                bundle_version,
+            );
+
+            assert_eq!(on_bytes.err(), on_points.err());
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,12 @@ pub mod zip32;
 #[cfg(test)]
 mod test_vectors;
 
-pub use action::{Action, ActionFromPartsError};
+pub use action::{
+    Action, ActionBytes, ActionFromPartsError, ActionParseError, DecompressionError,
+    ACTION_DESCRIPTION_SIZE,
+};
 pub use address::Address;
-pub use bundle::Bundle;
+pub use bundle::{Bundle, BundleBytes};
 pub use constants::MERKLE_DEPTH_ORCHARD as NOTE_COMMITMENT_TREE_DEPTH;
 pub use constants::{L_ORCHARD_BASE, L_ORCHARD_SCALAR, L_VALUE};
 pub use note::{Note, NoteVersion};

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -12,7 +12,7 @@ use zcash_note_encryption::{
 };
 
 use crate::{
-    action::Action,
+    action::{Action, ActionBytes},
     keys::{
         DiversifiedTransmissionKey, Diversifier, EphemeralPublicKey, EphemeralSecretKey,
         OutgoingViewingKey, PreparedEphemeralPublicKey, PreparedIncomingViewingKey, SharedSecret,
@@ -169,6 +169,11 @@ impl<V: DomainVersion> NoteEncryptionDomain<V> {
 
     /// Constructs a domain that can be used to trial-decrypt this action's output note.
     pub fn for_action<T>(act: &Action<T>) -> Self {
+        Self::from_rho(act.rho())
+    }
+
+    /// Constructs a domain that can be used to trial-decrypt this encoded action's output note.
+    pub fn for_action_bytes<T>(act: &ActionBytes<T>) -> Self {
         Self::from_rho(act.rho())
     }
 
@@ -412,6 +417,22 @@ impl<P: DomainPolicy, T> ShieldedOutput<NoteEncryptionDomain<P>, ENC_CIPHERTEXT_
     }
 }
 
+impl<P: DomainPolicy, T> ShieldedOutput<NoteEncryptionDomain<P>, ENC_CIPHERTEXT_SIZE>
+    for ActionBytes<T>
+{
+    fn ephemeral_key(&self) -> EphemeralKeyBytes {
+        EphemeralKeyBytes(self.encrypted_note().epk_bytes)
+    }
+
+    fn cmstar_bytes(&self) -> [u8; 32] {
+        self.cmx().to_bytes()
+    }
+
+    fn enc_ciphertext(&self) -> &[u8; ENC_CIPHERTEXT_SIZE] {
+        &self.encrypted_note().enc_ciphertext
+    }
+}
+
 impl<P: DomainPolicy> ShieldedOutput<NoteEncryptionDomain<P>, ENC_CIPHERTEXT_SIZE>
     for crate::pczt::Action
 {
@@ -487,6 +508,19 @@ impl<T> From<&Action<T>> for CompactAction {
             enc_ciphertext: action.encrypted_note().enc_ciphertext[..52]
                 .try_into()
                 .unwrap(),
+        }
+    }
+}
+
+impl<T> From<&ActionBytes<T>> for CompactAction {
+    fn from(action: &ActionBytes<T>) -> Self {
+        CompactAction {
+            nullifier: *action.nullifier(),
+            cmx: *action.cmx(),
+            ephemeral_key: EphemeralKeyBytes(action.encrypted_note().epk_bytes),
+            enc_ciphertext: action.encrypted_note().enc_ciphertext[..52]
+                .try_into()
+                .expect("the compact prefix is 52 bytes"),
         }
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -5,3 +5,18 @@
 //     - EphemeralSecretKey
 
 pub mod redpallas;
+
+/// Bytes that are not a canonical encoding of the point they should hold.
+///
+/// Leaf error for the `decompress` methods on the compressed types, which do not know which
+/// field they were read into; a description names the field in its own error.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InvalidPoint;
+
+impl core::fmt::Display for InvalidPoint {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("not a canonical encoding of a Pallas point")
+    }
+}
+
+impl core::error::Error for InvalidPoint {}

--- a/src/primitives/redpallas.rs
+++ b/src/primitives/redpallas.rs
@@ -3,6 +3,8 @@
 use core::cmp::{Ord, Ordering, PartialOrd};
 
 use pasta_curves::pallas;
+
+use super::InvalidPoint;
 use rand::{CryptoRng, RngCore};
 
 #[cfg(feature = "std")]
@@ -59,6 +61,36 @@ impl<T: SigType> SigningKey<T> {
     /// Creates a signature of type `T` on `msg` using this `SigningKey`.
     pub fn sign<R: RngCore + CryptoRng>(&self, rng: R, msg: &[u8]) -> Signature<T> {
         Signature(self.0.sign(rng, msg))
+    }
+}
+
+/// `rk` as [`ActionBytes`](crate::ActionBytes) holds it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct VerificationKeyBytes<T: SigType>(reddsa::VerificationKeyBytes<T>);
+
+impl<T: SigType> From<[u8; 32]> for VerificationKeyBytes<T> {
+    fn from(bytes: [u8; 32]) -> Self {
+        VerificationKeyBytes(reddsa::VerificationKeyBytes::from(bytes))
+    }
+}
+
+impl<T: SigType> From<&VerificationKey<T>> for VerificationKeyBytes<T> {
+    fn from(vk: &VerificationKey<T>) -> Self {
+        VerificationKeyBytes(vk.0.into())
+    }
+}
+
+impl<T: SigType> VerificationKeyBytes<T> {
+    /// Returns the byte encoding of this key.
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.0.into()
+    }
+
+    /// Recovers the key. 1 sqrt.
+    pub fn decompress(&self) -> Result<VerificationKey<T>, InvalidPoint> {
+        reddsa::VerificationKey::try_from(self.0)
+            .map(VerificationKey)
+            .map_err(|_| InvalidPoint)
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -360,7 +360,8 @@ mod tests {
                     .0
                     .to_repr(),
                 *tv_root,
-                "Empty root mismatch at level {level}"
+                "Empty root mismatch at level {}",
+                level
             );
         }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -57,7 +57,10 @@ use crate::{
     constants::fixed_bases::{
         VALUE_COMMITMENT_PERSONALIZATION, VALUE_COMMITMENT_R_BYTES, VALUE_COMMITMENT_V_BYTES,
     },
-    primitives::redpallas::{self, Binding},
+    primitives::{
+        redpallas::{self, Binding},
+        InvalidPoint,
+    },
 };
 
 /// Maximum note value.
@@ -401,6 +404,34 @@ impl ValueCommitment {
         } else {
             *self.0.to_affine().coordinates().unwrap().y()
         }
+    }
+}
+
+/// `cv_net` as [`ActionBytes`](crate::ActionBytes) holds it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ValueCommitmentBytes([u8; 32]);
+
+impl From<[u8; 32]> for ValueCommitmentBytes {
+    fn from(bytes: [u8; 32]) -> Self {
+        ValueCommitmentBytes(bytes)
+    }
+}
+
+impl From<&ValueCommitment> for ValueCommitmentBytes {
+    fn from(cv: &ValueCommitment) -> Self {
+        ValueCommitmentBytes(cv.to_bytes())
+    }
+}
+
+impl ValueCommitmentBytes {
+    /// Returns the byte encoding of this value commitment.
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.0
+    }
+
+    /// Recovers the point. 1 sqrt.
+    pub fn decompress(&self) -> Result<ValueCommitment, InvalidPoint> {
+        Option::from(ValueCommitment::from_bytes(&self.0)).ok_or(InvalidPoint)
     }
 }
 


### PR DESCRIPTION
# A parse tier for Action descriptions

Adds `ActionBytes` / `BundleBytes`, holding an Action description with `cv_net`, `rk` and `epk` left
compressed. A node reading actions from the wire or from disk — and a wallet scanning them — does no
curve arithmetic until it calls `decompress`.

```rust
let bundle: BundleBytes<Authorized, Amount> = read_bundle(&mut reader)?;
let txid_part = bundle.commitment(TxVersion::V5)?;
let notes = bundle.decrypt_outputs_with_keys(&ivks);

let bundle: Bundle<Authorized, Amount> = bundle.decompress()?;  // 3 sqrt/action, once
bundle.verify_proof(&vk)?;
```

`Action` and `Bundle` are untouched and cannot represent an action that breaks a point rule:
`ActionBytes::decompress` recovers `cv_net` and `rk` and then delegates to `Action::from_parts`, so
the identity-`rk` and `epk` rules keep exactly one implementation.